### PR TITLE
Feature/result set api

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,7 +22,7 @@ tokio-util = { version = "0.7.3", features = ["codec", "io"], optional = true }
 
 [dev-dependencies]
 tokio = { version = "1.19", features = ["rt-multi-thread", "net", "io-util", "macros"]}
-rusqlite = { version = "0.28.0", features = ["bundled"] }
+rusqlite = { version = "0.28.0", features = ["bundled", "column_decltype"] }
 hex = "0.4"
 
 [features]

--- a/examples/server.rs
+++ b/examples/server.rs
@@ -4,14 +4,14 @@ use std::sync::Arc;
 use async_trait::async_trait;
 use futures::Sink;
 use pgwire::api::portal::Portal;
+use postgres_types::Type;
 use tokio::net::TcpListener;
 
 use pgwire::api::auth::CleartextPasswordAuthStartupHandler;
-use pgwire::api::query::{ExtendedQueryHandler, QueryResponse, SimpleQueryHandler};
+use pgwire::api::query::{ExtendedQueryHandler, SimpleQueryHandler};
+use pgwire::api::results::{FieldInfo, QueryResponseBuilder, Response, Tag};
 use pgwire::api::ClientInfo;
 use pgwire::error::{PgWireError, PgWireResult};
-use pgwire::messages::data::{DataRow, FieldDescription, RowDescription, FORMAT_CODE_TEXT};
-use pgwire::messages::response::CommandComplete;
 use pgwire::messages::PgWireBackendMessage;
 use pgwire::tokio::process_socket;
 
@@ -38,52 +38,32 @@ impl CleartextPasswordAuthStartupHandler for DummyProcessor {
 
 #[async_trait]
 impl SimpleQueryHandler for DummyProcessor {
-    async fn do_query<C>(&self, _client: &C, query: &str) -> PgWireResult<QueryResponse>
+    async fn do_query<C>(&self, _client: &C, query: &str) -> PgWireResult<Response>
     where
         C: ClientInfo + Unpin + Send + Sync,
     {
         println!("{:?}", query);
         if query.starts_with("SELECT") {
-            let mut rd = RowDescription::default();
             // column 0
-            rd.fields_mut().push(FieldDescription::new(
-                "id".into(),
-                123,
-                123,
-                123,
-                132,
-                -1,
-                FORMAT_CODE_TEXT,
-            ));
-            // column 1
-            rd.fields_mut().push(FieldDescription::new(
-                "name".into(),
-                123,
-                123,
-                123,
-                132,
-                -1,
-                FORMAT_CODE_TEXT,
-            ));
+            let f1 = FieldInfo::new("id".into(), None, None, Type::INT4);
+            let f2 = FieldInfo::new("name".into(), None, None, Type::VARCHAR);
 
-            let mut data_row = DataRow::default();
-            *data_row.fields_mut() = vec![Some("0".as_bytes().to_vec()), None];
-
-            let rows = vec![data_row.clone(), data_row.clone(), data_row.clone()];
-
-            let status = CommandComplete::new("SELECT 3".to_owned());
-            Ok(QueryResponse::Data(rd, rows, status))
+            let mut result_builder = QueryResponseBuilder::new(vec![f1, f2]);
+            for _ in 0..3 {
+                result_builder.append_field(1i32)?;
+                result_builder.append_field("Tom")?;
+                result_builder.finish_row();
+            }
+            Ok(Response::Query(result_builder.build()))
         } else {
-            Ok(QueryResponse::Empty(CommandComplete::new(
-                "OK 1".to_owned(),
-            )))
+            Ok(Response::Execution(Tag::new_for_execution("OK", Some(1))))
         }
     }
 }
 
 #[async_trait]
 impl ExtendedQueryHandler for DummyProcessor {
-    async fn do_query<C>(&self, _client: &mut C, _portal: &Portal) -> PgWireResult<QueryResponse>
+    async fn do_query<C>(&self, _client: &mut C, _portal: &Portal) -> PgWireResult<Response>
     where
         C: ClientInfo + Sink<PgWireBackendMessage> + Unpin + Send + Sync,
         C::Error: std::fmt::Debug,

--- a/examples/sqlite.rs
+++ b/examples/sqlite.rs
@@ -75,7 +75,7 @@ impl SimpleQueryHandler for SqliteBackend {
 fn name_to_type(name: &str) -> Type {
     dbg!(name);
     match name.to_uppercase().as_ref() {
-        "INT" => Type::INT4,
+        "INT" => Type::INT8,
         "VARCHAR" => Type::VARCHAR,
         "BINARY" => Type::BYTEA,
         "FLOAT" => Type::FLOAT8,
@@ -126,18 +126,30 @@ fn get_params(portal: &Portal) -> Vec<Box<dyn ToSql>> {
     let mut results = Vec::with_capacity(portal.parameter_len());
     for i in 0..portal.parameter_len() {
         let param_type = portal.parameter_types().get(i).unwrap();
-        // we now support only a little amount of types
+        // we only support a small amount of types for demo
         match param_type {
             &Type::BOOL => {
                 let param = portal.parameter::<bool>(i).unwrap();
                 results.push(Box::new(param) as Box<dyn ToSql>);
             }
-            &Type::INT4 | &Type::INT8 => {
+            &Type::INT4 => {
                 let param = portal.parameter::<i32>(i).unwrap();
+                results.push(Box::new(param) as Box<dyn ToSql>);
+            }
+            &Type::INT8 => {
+                let param = portal.parameter::<i64>(i).unwrap();
                 results.push(Box::new(param) as Box<dyn ToSql>);
             }
             &Type::TEXT | &Type::VARCHAR => {
                 let param = portal.parameter::<String>(i).unwrap();
+                results.push(Box::new(param) as Box<dyn ToSql>);
+            }
+            &Type::FLOAT4 => {
+                let param = portal.parameter::<f32>(i).unwrap();
+                results.push(Box::new(param) as Box<dyn ToSql>);
+            }
+            &Type::FLOAT8 => {
+                let param = portal.parameter::<f64>(i).unwrap();
                 results.push(Box::new(param) as Box<dyn ToSql>);
             }
             _ => {}

--- a/examples/sqlite.rs
+++ b/examples/sqlite.rs
@@ -4,16 +4,16 @@ use std::sync::{Arc, Mutex};
 use async_trait::async_trait;
 use futures::Sink;
 use postgres_types::Type;
-use rusqlite::{types::ValueRef, Connection, Row, Statement, ToSql};
+use rusqlite::Rows;
+use rusqlite::{types::ValueRef, Connection, Statement, ToSql};
 use tokio::net::TcpListener;
 
 use pgwire::api::auth::CleartextPasswordAuthStartupHandler;
 use pgwire::api::portal::Portal;
-use pgwire::api::query::{ExtendedQueryHandler, QueryResponse, SimpleQueryHandler};
+use pgwire::api::query::{ExtendedQueryHandler, SimpleQueryHandler};
+use pgwire::api::results::{FieldInfo, QueryResponseBuilder, Response, Tag};
 use pgwire::api::ClientInfo;
 use pgwire::error::{PgWireError, PgWireResult};
-use pgwire::messages::data::{DataRow, FieldDescription, RowDescription, FORMAT_CODE_TEXT};
-use pgwire::messages::response::CommandComplete;
 use pgwire::messages::PgWireBackendMessage;
 use pgwire::tokio::process_socket;
 
@@ -48,7 +48,7 @@ impl CleartextPasswordAuthStartupHandler for SqliteBackend {
 
 #[async_trait]
 impl SimpleQueryHandler for SqliteBackend {
-    async fn do_query<C>(&self, _client: &C, query: &str) -> PgWireResult<QueryResponse>
+    async fn do_query<C>(&self, _client: &C, query: &str) -> PgWireResult<Response>
     where
         C: ClientInfo + Unpin + Send + Sync,
     {
@@ -57,58 +57,69 @@ impl SimpleQueryHandler for SqliteBackend {
             let mut stmt = conn.prepare(query).unwrap();
             let columns = stmt.column_count();
             let header = row_desc_from_stmt(&stmt);
-
             let rows = stmt.query(()).unwrap();
-            let body = rows
-                .mapped(|r| Ok(row_data_from_sqlite_row(r, columns)))
-                .map(|r| r.unwrap())
-                .collect::<Vec<DataRow>>();
 
-            let tail = CommandComplete::new(format!("SELECT {:?}", body.len()));
-            Ok(QueryResponse::Data(header, body, tail))
+            let mut builder = QueryResponseBuilder::new(header);
+            encode_row_data(rows, columns, &mut builder);
+
+            Ok(Response::Query(builder.build()))
         } else {
-            let affect_rows = conn.execute(query, ()).unwrap();
-            Ok(QueryResponse::Empty(CommandComplete::new(format!(
-                "OK {:?}",
-                affect_rows
-            ))))
+            let affected_rows = conn.execute(query, ()).unwrap();
+            Ok(Response::Execution(
+                Tag::new_for_execution("OK", Some(affected_rows)).into(),
+            ))
         }
     }
 }
 
-fn row_desc_from_stmt(stmt: &Statement) -> RowDescription {
-    // TODO: real field descriptions
-    let fields = stmt
-        .column_names()
-        .into_iter()
-        .map(|n| FieldDescription::new(n.to_owned(), 123, 123, 123, 12, 0, FORMAT_CODE_TEXT))
-        .collect();
-    RowDescription::new(fields)
+fn name_to_type(name: &str) -> Type {
+    dbg!(name);
+    match name.to_uppercase().as_ref() {
+        "INT" => Type::INT4,
+        "VARCHAR" => Type::VARCHAR,
+        "BINARY" => Type::BYTEA,
+        "FLOAT" => Type::FLOAT8,
+        _ => unimplemented!("unknown type"),
+    }
 }
 
-fn row_data_from_sqlite_row(row: &Row, columns: usize) -> DataRow {
-    let mut fields = Vec::with_capacity(columns);
+fn row_desc_from_stmt(stmt: &Statement) -> Vec<FieldInfo> {
+    stmt.columns()
+        .iter()
+        .map(|col| {
+            FieldInfo::new(
+                col.name().to_owned(),
+                None,
+                None,
+                name_to_type(col.decl_type().unwrap()),
+            )
+        })
+        .collect()
+}
 
-    for idx in 0..columns {
-        let data = row.get_ref_unwrap::<usize>(idx);
-        match data {
-            ValueRef::Null => fields.push(None),
-            ValueRef::Integer(i) => {
-                fields.push(Some(i.to_string().as_bytes().to_vec()));
-            }
-            ValueRef::Real(f) => {
-                fields.push(Some(f.to_string().as_bytes().to_vec()));
-            }
-            ValueRef::Text(t) => {
-                fields.push(Some(t.to_vec()));
-            }
-            ValueRef::Blob(b) => {
-                fields.push(Some(hex::encode(b).as_bytes().to_vec()));
+fn encode_row_data(mut rows: Rows, columns: usize, builder: &mut QueryResponseBuilder) {
+    while let Ok(Some(row)) = rows.next() {
+        for idx in 0..columns {
+            let data = row.get_ref_unwrap::<usize>(idx);
+            match data {
+                ValueRef::Null => builder.append_field(None::<i8>).unwrap(),
+                ValueRef::Integer(i) => {
+                    builder.append_field(i).unwrap();
+                }
+                ValueRef::Real(f) => {
+                    builder.append_field(f).unwrap();
+                }
+                ValueRef::Text(t) => {
+                    builder.append_field(t).unwrap();
+                }
+                ValueRef::Blob(b) => {
+                    builder.append_field(b).unwrap();
+                }
             }
         }
-    }
 
-    DataRow::new(fields)
+        builder.finish_row();
+    }
 }
 
 fn get_params(portal: &Portal) -> Vec<Box<dyn ToSql>> {
@@ -138,7 +149,7 @@ fn get_params(portal: &Portal) -> Vec<Box<dyn ToSql>> {
 
 #[async_trait]
 impl ExtendedQueryHandler for SqliteBackend {
-    async fn do_query<C>(&self, _client: &mut C, portal: &Portal) -> PgWireResult<QueryResponse>
+    async fn do_query<C>(&self, _client: &mut C, portal: &Portal) -> PgWireResult<Response>
     where
         C: ClientInfo + Sink<PgWireBackendMessage> + Unpin + Send + Sync,
         C::Error: std::fmt::Debug,
@@ -156,23 +167,22 @@ impl ExtendedQueryHandler for SqliteBackend {
         if query.to_uppercase().starts_with("SELECT") {
             let columns = stmt.column_count();
             let header = row_desc_from_stmt(&stmt);
-
             let rows = stmt
                 .query::<&[&dyn rusqlite::ToSql]>(params_ref.as_ref())
                 .unwrap();
-            let body = rows
-                .mapped(|r| Ok(row_data_from_sqlite_row(r, columns)))
-                .map(|r| r.unwrap())
-                .collect::<Vec<DataRow>>();
 
-            let tail = CommandComplete::new(format!("SELECT {:?}", body.len()));
-            Ok(QueryResponse::Data(header, body, tail))
+            let mut builder = QueryResponseBuilder::new(header);
+            encode_row_data(rows, columns, &mut builder);
+
+            Ok(Response::Query(builder.build()))
         } else {
-            let affect_rows = stmt.execute::<&[&dyn rusqlite::ToSql]>(params_ref.as_ref());
-            Ok(QueryResponse::Empty(CommandComplete::new(format!(
-                "OK {:?}",
-                affect_rows
-            ))))
+            let affected_rows = stmt
+                .execute::<&[&dyn rusqlite::ToSql]>(params_ref.as_ref())
+                .unwrap();
+            Ok(Response::Execution(Tag::new_for_execution(
+                "OK",
+                Some(affected_rows),
+            )))
         }
     }
 }

--- a/src/api/mod.rs
+++ b/src/api/mod.rs
@@ -5,6 +5,7 @@ use std::sync::Arc;
 pub mod auth;
 pub mod portal;
 pub mod query;
+pub mod results;
 pub mod stmt;
 pub mod store;
 

--- a/src/api/query.rs
+++ b/src/api/query.rs
@@ -22,7 +22,9 @@ use crate::messages::PgWireBackendMessage;
 /// handler for processing simple query.
 #[async_trait]
 pub trait SimpleQueryHandler: Send + Sync {
-    ///
+    /// Executed on `Query` request arrived. This is how postgres respond to
+    /// simple query. The default implementation calls `do_query` with the
+    /// incoming query string.
     async fn on_query<C>(&self, client: &mut C, query: &Query) -> PgWireResult<()>
     where
         C: ClientInfo + Sink<PgWireBackendMessage> + Unpin + Send + Sync,
@@ -53,7 +55,7 @@ pub trait SimpleQueryHandler: Send + Sync {
         Ok(())
     }
 
-    ///
+    /// Provide your query implementation using the incoming query string.
     async fn do_query<C>(&self, client: &C, query: &str) -> PgWireResult<Response>
     where
         C: ClientInfo + Unpin + Send + Sync;

--- a/src/api/results.rs
+++ b/src/api/results.rs
@@ -38,7 +38,7 @@ impl From<Tag> for CommandComplete {
         let tag_string = if let Some(rows) = tag.rows {
             format!("{:?} {:?}", tag.command, rows)
         } else {
-            tag.command.clone()
+            tag.command
         };
         CommandComplete::new(tag_string)
     }

--- a/src/api/results.rs
+++ b/src/api/results.rs
@@ -1,0 +1,122 @@
+use std::fmt::Debug;
+
+use bytes::BytesMut;
+use postgres_types::{ToSql, Type};
+
+use crate::{
+    error::PgWireResult,
+    messages::{
+        data::{DataRow, FieldDescription, FORMAT_CODE_BINARY},
+        response::{CommandComplete, ErrorResponse},
+    },
+};
+
+#[derive(Debug)]
+pub struct Tag {
+    command: String,
+    rows: Option<usize>,
+}
+
+impl Tag {
+    pub fn new_for_query(rows: usize) -> Tag {
+        Tag {
+            command: "SELECT".to_owned(),
+            rows: Some(rows),
+        }
+    }
+
+    pub fn new_for_execution(command: &str, rows: Option<usize>) -> Tag {
+        Tag {
+            command: command.to_owned(),
+            rows,
+        }
+    }
+}
+
+impl From<Tag> for CommandComplete {
+    fn from(tag: Tag) -> CommandComplete {
+        let tag_string = if let Some(rows) = tag.rows {
+            format!("{:?} {:?}", tag.command, rows)
+        } else {
+            tag.command.clone()
+        };
+        CommandComplete::new(tag_string)
+    }
+}
+
+#[derive(Debug, new)]
+pub struct FieldInfo {
+    name: String,
+    table_id: i32,
+    column_id: i16,
+    datatype: Type,
+}
+
+impl From<FieldInfo> for FieldDescription {
+    fn from(fi: FieldInfo) -> Self {
+        FieldDescription::new(
+            fi.name,           // name
+            fi.table_id,       // table_id
+            fi.column_id,      // column_id
+            fi.datatype.oid(), // type_id
+            // TODO: type size and modifier
+            0,
+            0,
+            FORMAT_CODE_BINARY,
+        )
+    }
+}
+
+// TODO: do not hold the reference to Sized or ToSql type,
+// use a write method instead to write down them into bytebuf
+#[derive(new)]
+pub struct QueryResponse<I, T>
+where
+    I: Iterator<Item = Vec<Box<dyn ?Sized + ToSql>>>,
+{
+    row_schema: Vec<FieldInfo>,
+    data_rows: I,
+    tag: Tag,
+}
+
+impl<I> Debug for QueryResponse<I>
+where
+    I: Iterator<Item = Vec<Box<dyn ToSql>>>,
+{
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("QueryResponse")
+            .field("row_schema", &self.row_schema)
+            .field("tag", &self.tag)
+            .finish()
+    }
+}
+
+impl<I> QueryResponse<I>
+where
+    I: Iterator<Item = Vec<Box<dyn ToSql>>>,
+{
+    fn into_rows_iter(&mut self) -> impl Iterator<Item = PgWireResult<DataRow>> {
+        let columns = self.row_schema.len();
+        self.data_rows.map(|raw_vec: Vec<Box<dyn ToSql>>| {
+            let mut result = Vec::with_capacity(columns);
+            for idx in 0..columns {
+                // default buffer size 64
+                let mut bytes = BytesMut::with_capacity(64);
+                raw_vec[idx].to_sql(&self.row_schema[idx].datatype, &mut bytes)?;
+
+                result.push(bytes);
+            }
+            Ok(DataRow::new(result))
+        })
+    }
+}
+
+#[derive(Debug)]
+pub enum Response<I>
+where
+    I: Iterator<Item = Vec<Box<dyn ToSql>>>,
+{
+    Query(QueryResponse<I>),
+    Execution(Tag),
+    Error(ErrorResponse),
+}

--- a/src/api/results.rs
+++ b/src/api/results.rs
@@ -47,18 +47,18 @@ impl From<Tag> for CommandComplete {
 #[derive(Debug, new)]
 pub struct FieldInfo {
     name: String,
-    table_id: i32,
-    column_id: i16,
+    table_id: Option<i32>,
+    column_id: Option<i16>,
     datatype: Type,
 }
 
 impl From<FieldInfo> for FieldDescription {
     fn from(fi: FieldInfo) -> Self {
         FieldDescription::new(
-            fi.name,           // name
-            fi.table_id,       // table_id
-            fi.column_id,      // column_id
-            fi.datatype.oid(), // type_id
+            fi.name,                   // name
+            fi.table_id.unwrap_or(0),  // table_id
+            fi.column_id.unwrap_or(0), // column_id
+            fi.datatype.oid(),         // type_id
             // TODO: type size and modifier
             0,
             0,

--- a/src/messages/data.rs
+++ b/src/messages/data.rs
@@ -94,36 +94,11 @@ impl Message for RowDescription {
 #[derive(Getters, Setters, MutGetters, PartialEq, Eq, Debug, Default, new, Clone)]
 #[getset(get = "pub", set = "pub", get_mut = "pub")]
 pub struct DataRow {
-    // None for Null data
-    fields: Vec<Option<Vec<u8>>>,
+    // TODO: concat these bytes
+    fields: Vec<BytesMut>,
 }
 
-impl DataRow {
-    /// resolve data row content as text, return None if the field not exists or
-    /// the value is Null.
-    ///
-    /// FIXME: unwrap for utf8
-    pub fn as_text(&self, index: usize) -> Option<String> {
-        self.fields
-            .get(index)
-            .and_then(|f| f.as_ref().map(|bs| String::from_utf8(bs.clone()).unwrap()))
-    }
-
-    /// resolve data row content as binary, return None if the field not exists
-    /// or the value is Null
-    pub fn as_binary(&self, index: usize) -> Option<&Vec<u8>> {
-        self.fields.get(index).and_then(|f| f.as_ref())
-    }
-
-    /// count of fields
-    pub fn len(&self) -> usize {
-        self.fields.len()
-    }
-
-    pub fn is_empty(&self) -> bool {
-        self.len() == 0
-    }
-}
+impl DataRow {}
 
 pub const MESSAGE_TYPE_BYTE_DATA_ROW: u8 = b'D';
 

--- a/src/messages/extendedquery.rs
+++ b/src/messages/extendedquery.rs
@@ -39,7 +39,7 @@ impl Message for Parse {
         Ok(())
     }
 
-    fn decode_body(buf: &mut bytes::BytesMut) -> PgWireResult<Self> {
+    fn decode_body(buf: &mut bytes::BytesMut, _: usize) -> PgWireResult<Self> {
         let name = codec::get_cstring(buf);
         let query = codec::get_cstring(buf).unwrap_or_else(|| "".to_owned());
         let type_oid_count = buf.get_i16();
@@ -81,7 +81,7 @@ impl Message for ParseComplete {
     }
 
     #[inline]
-    fn decode_body(_buf: &mut bytes::BytesMut) -> PgWireResult<Self> {
+    fn decode_body(_buf: &mut bytes::BytesMut, _: usize) -> PgWireResult<Self> {
         Ok(ParseComplete)
     }
 }
@@ -117,7 +117,7 @@ impl Message for Close {
         Ok(())
     }
 
-    fn decode_body(buf: &mut bytes::BytesMut) -> PgWireResult<Self> {
+    fn decode_body(buf: &mut bytes::BytesMut, _: usize) -> PgWireResult<Self> {
         let target_type = buf.get_u8();
         let name = codec::get_cstring(buf);
 
@@ -149,7 +149,7 @@ impl Message for CloseComplete {
     }
 
     #[inline]
-    fn decode_body(_buf: &mut bytes::BytesMut) -> PgWireResult<Self> {
+    fn decode_body(_buf: &mut bytes::BytesMut, _: usize) -> PgWireResult<Self> {
         Ok(CloseComplete)
     }
 }
@@ -213,7 +213,7 @@ impl Message for Bind {
         Ok(())
     }
 
-    fn decode_body(buf: &mut bytes::BytesMut) -> PgWireResult<Self> {
+    fn decode_body(buf: &mut bytes::BytesMut, _: usize) -> PgWireResult<Self> {
         let portal_name = codec::get_cstring(buf);
         let statement_name = codec::get_cstring(buf);
 
@@ -279,7 +279,7 @@ impl Message for BindComplete {
     }
 
     #[inline]
-    fn decode_body(_buf: &mut bytes::BytesMut) -> PgWireResult<Self> {
+    fn decode_body(_buf: &mut bytes::BytesMut, _: usize) -> PgWireResult<Self> {
         Ok(BindComplete)
     }
 }
@@ -311,7 +311,7 @@ impl Message for Describe {
         Ok(())
     }
 
-    fn decode_body(buf: &mut bytes::BytesMut) -> PgWireResult<Self> {
+    fn decode_body(buf: &mut bytes::BytesMut, _: usize) -> PgWireResult<Self> {
         let target_type = buf.get_u8();
         let name = codec::get_cstring(buf);
 
@@ -345,7 +345,7 @@ impl Message for Execute {
         Ok(())
     }
 
-    fn decode_body(buf: &mut bytes::BytesMut) -> PgWireResult<Self> {
+    fn decode_body(buf: &mut bytes::BytesMut, _: usize) -> PgWireResult<Self> {
         let name = codec::get_cstring(buf);
         let max_rows = buf.get_i32();
 
@@ -375,7 +375,7 @@ impl Message for Sync {
         Ok(())
     }
 
-    fn decode_body(_buf: &mut bytes::BytesMut) -> PgWireResult<Self> {
+    fn decode_body(_buf: &mut bytes::BytesMut, _: usize) -> PgWireResult<Self> {
         Ok(Sync)
     }
 }
@@ -401,7 +401,7 @@ impl Message for PortalSuspended {
         Ok(())
     }
 
-    fn decode_body(_buf: &mut bytes::BytesMut) -> PgWireResult<Self> {
+    fn decode_body(_buf: &mut bytes::BytesMut, _: usize) -> PgWireResult<Self> {
         Ok(PortalSuspended)
     }
 }

--- a/src/messages/mod.rs
+++ b/src/messages/mod.rs
@@ -15,7 +15,7 @@ pub trait Message: Sized {
 
     fn encode_body(&self, buf: &mut BytesMut) -> PgWireResult<()>;
 
-    fn decode_body(buf: &mut BytesMut) -> PgWireResult<Self>;
+    fn decode_body(buf: &mut BytesMut, full_len: usize) -> PgWireResult<Self>;
 
     fn encode(&self, buf: &mut BytesMut) -> PgWireResult<()> {
         if let Some(mt) = Self::message_type() {
@@ -31,7 +31,7 @@ pub trait Message: Sized {
             codec::get_and_ensure_message_type(buf, mt)?;
         }
 
-        codec::decode_packet(buf, |buf, _| Self::decode_body(buf))
+        codec::decode_packet(buf, |buf, full_len| Self::decode_body(buf, full_len))
     }
 }
 

--- a/src/messages/response.rs
+++ b/src/messages/response.rs
@@ -28,7 +28,7 @@ impl Message for CommandComplete {
         Ok(())
     }
 
-    fn decode_body(buf: &mut BytesMut) -> PgWireResult<Self> {
+    fn decode_body(buf: &mut BytesMut, _: usize) -> PgWireResult<Self> {
         let tag = codec::get_cstring(buf).unwrap_or_else(|| "".to_owned());
 
         Ok(CommandComplete::new(tag))
@@ -64,7 +64,7 @@ impl Message for ReadyForQuery {
         Ok(())
     }
 
-    fn decode_body(buf: &mut BytesMut) -> PgWireResult<Self> {
+    fn decode_body(buf: &mut BytesMut, _: usize) -> PgWireResult<Self> {
         let status = buf.get_u8();
         Ok(ReadyForQuery::new(status))
     }
@@ -104,7 +104,7 @@ impl Message for ErrorResponse {
         Ok(())
     }
 
-    fn decode_body(buf: &mut BytesMut) -> PgWireResult<Self> {
+    fn decode_body(buf: &mut BytesMut, _: usize) -> PgWireResult<Self> {
         let mut fields = Vec::new();
         loop {
             let code = buf.get_u8();

--- a/src/messages/simplequery.rs
+++ b/src/messages/simplequery.rs
@@ -29,7 +29,7 @@ impl Message for Query {
         Ok(())
     }
 
-    fn decode_body(buf: &mut BytesMut) -> PgWireResult<Self> {
+    fn decode_body(buf: &mut BytesMut, _: usize) -> PgWireResult<Self> {
         let query = codec::get_cstring(buf).unwrap_or_else(|| "".to_owned());
 
         Ok(Query::new(query))

--- a/src/messages/startup.rs
+++ b/src/messages/startup.rs
@@ -55,7 +55,7 @@ impl Message for Startup {
         Ok(())
     }
 
-    fn decode_body(buf: &mut BytesMut) -> PgWireResult<Self> {
+    fn decode_body(buf: &mut BytesMut, _: usize) -> PgWireResult<Self> {
         let mut msg = Startup::default();
         // parse
         msg.set_protocol_number_major(buf.get_u16());
@@ -121,7 +121,7 @@ impl Message for Authentication {
         Ok(())
     }
 
-    fn decode_body(buf: &mut BytesMut) -> PgWireResult<Self> {
+    fn decode_body(buf: &mut BytesMut, _: usize) -> PgWireResult<Self> {
         let code = buf.get_i32();
         let msg = match code {
             0 => Authentication::Ok,
@@ -165,7 +165,7 @@ impl Message for Password {
         Ok(())
     }
 
-    fn decode_body(buf: &mut BytesMut) -> PgWireResult<Self> {
+    fn decode_body(buf: &mut BytesMut, _: usize) -> PgWireResult<Self> {
         let pass = codec::get_cstring(buf).unwrap_or_else(|| "".to_owned());
 
         Ok(Password::new(pass))
@@ -199,7 +199,7 @@ impl Message for ParameterStatus {
         Ok(())
     }
 
-    fn decode_body(buf: &mut BytesMut) -> PgWireResult<Self> {
+    fn decode_body(buf: &mut BytesMut, _: usize) -> PgWireResult<Self> {
         let name = codec::get_cstring(buf).unwrap_or_else(|| "".to_owned());
         let value = codec::get_cstring(buf).unwrap_or_else(|| "".to_owned());
 
@@ -236,7 +236,7 @@ impl Message for BackendKeyData {
         Ok(())
     }
 
-    fn decode_body(buf: &mut BytesMut) -> PgWireResult<Self> {
+    fn decode_body(buf: &mut BytesMut, _: usize) -> PgWireResult<Self> {
         let pid = buf.get_i32();
         let secret_key = buf.get_i32();
 
@@ -270,7 +270,7 @@ impl Message for SslRequest {
         Ok(())
     }
 
-    fn decode_body(buf: &mut BytesMut) -> PgWireResult<Self> {
+    fn decode_body(buf: &mut BytesMut, _: usize) -> PgWireResult<Self> {
         buf.advance(4);
         Ok(SslRequest::new())
     }

--- a/src/messages/terminate.rs
+++ b/src/messages/terminate.rs
@@ -21,7 +21,7 @@ impl Message for Terminate {
         Ok(())
     }
 
-    fn decode_body(_: &mut bytes::BytesMut) -> PgWireResult<Self> {
+    fn decode_body(_: &mut bytes::BytesMut, _: usize) -> PgWireResult<Self> {
         Ok(Terminate)
     }
 }


### PR DESCRIPTION
This patch implements our first version of results set APIs, that works with query handler trait. It hides message types from developer to provide a pure rust development experience for query handler apis.

Internally the design tries to reduce copy but `ToSql` does not work well with postgres `DataRow` protocol. The later requires a byte length field to be written ahead of body which `ToSql` failed to meet. Currently we still use a buffer to hold the serialized data and copy it into `DataRow` (which copies again into underlying network connection)