### PR TITLE
Using bytes for Bind parameters and DataRow data

### DIFF
--- a/src/api/portal.rs
+++ b/src/api/portal.rs
@@ -1,3 +1,4 @@
+use bytes::Bytes;
 use postgres_types::{FromSqlOwned, Type};
 
 use crate::{
@@ -19,7 +20,7 @@ pub struct Portal {
     statement: String,
     parameter_types: Vec<Type>,
     parameter_format: Format,
-    parameters: Vec<Option<Vec<u8>>>,
+    parameters: Vec<Option<Bytes>>,
     result_column_format_codes: Vec<i16>,
     #[getset(skip)]
     #[getset(get_copy = "pub", set = "pub")]

--- a/src/messages/extendedquery.rs
+++ b/src/messages/extendedquery.rs
@@ -1,4 +1,4 @@
-use bytes::{Buf, BufMut};
+use bytes::{Buf, BufMut, Bytes};
 use postgres_types::Oid;
 
 use super::{codec, Message};
@@ -163,7 +163,7 @@ pub struct Bind {
     parameter_format_codes: Vec<i16>,
     // None for Null data, TODO: consider wrapping this together with DataRow in
     // data.rs
-    parameters: Vec<Option<Vec<u8>>>,
+    parameters: Vec<Option<Bytes>>,
 
     result_column_format_codes: Vec<i16>,
 }
@@ -230,7 +230,7 @@ impl Message for Bind {
             let data_len = buf.get_i32();
 
             if data_len >= 0 {
-                parameters.push(Some(buf.split_to(data_len as usize).to_vec()));
+                parameters.push(Some(buf.split_to(data_len as usize).freeze()));
             } else {
                 parameters.push(None);
             }

--- a/src/messages/mod.rs
+++ b/src/messages/mod.rs
@@ -246,7 +246,7 @@ mod test {
     use super::startup::*;
     use super::terminate::*;
     use super::Message;
-    use bytes::{Buf, BufMut, BytesMut};
+    use bytes::{Buf, Bytes, BytesMut};
 
     macro_rules! roundtrip {
         ($ins:ident, $st:ty) => {
@@ -354,10 +354,10 @@ mod test {
 
     #[test]
     fn test_data_row() {
-        let mut row0 = DataRow::new(2, BytesMut::with_capacity(10));
-        row0.buf_mut().put_i16(1);
-        row0.buf_mut().put_u8(b'1');
-        row0.buf_mut().put_i16(-1);
+        let mut row0 = DataRow::default();
+        row0.fields_mut().push(Some(Bytes::from_static(b"1")));
+        row0.fields_mut().push(Some(Bytes::from_static(b"abc")));
+        row0.fields_mut().push(None);
 
         roundtrip!(row0, DataRow);
     }
@@ -399,7 +399,7 @@ mod test {
             Some("find-user-by-id-0".to_owned()),
             Some("find-user-by-id".to_owned()),
             vec![0],
-            vec![Some("1233".as_bytes().to_vec())],
+            vec![Some(Bytes::from_static(b"1234"))],
             vec![0],
         );
         roundtrip!(bind, Bind);


### PR DESCRIPTION
This patch replaces `Vec<u8>` with `Bytes` for less allocation and data copy.