### PR TITLE
Refactor startup and auth modules

### DIFF
--- a/examples/server.rs
+++ b/examples/server.rs
@@ -7,7 +7,7 @@ use pgwire::api::portal::Portal;
 use postgres_types::Type;
 use tokio::net::TcpListener;
 
-use pgwire::api::auth::CleartextPasswordAuthStartupHandler;
+use pgwire::api::auth::cleartext::CleartextPasswordAuthStartupHandler;
 use pgwire::api::query::{ExtendedQueryHandler, SimpleQueryHandler};
 use pgwire::api::results::{FieldInfo, QueryResponseBuilder, Response, Tag};
 use pgwire::api::ClientInfo;

--- a/examples/server.rs
+++ b/examples/server.rs
@@ -1,17 +1,14 @@
 use std::sync::Arc;
 
 use async_trait::async_trait;
-use futures::Sink;
-use pgwire::api::portal::Portal;
-use postgres_types::Type;
 use tokio::net::TcpListener;
 
 use pgwire::api::auth::noop::NoopStartupHandler;
+use pgwire::api::portal::Portal;
 use pgwire::api::query::{ExtendedQueryHandler, SimpleQueryHandler};
 use pgwire::api::results::{FieldInfo, QueryResponseBuilder, Response, Tag};
-use pgwire::api::ClientInfo;
-use pgwire::error::{PgWireError, PgWireResult};
-use pgwire::messages::PgWireBackendMessage;
+use pgwire::api::{ClientInfo, Type};
+use pgwire::error::PgWireResult;
 use pgwire::tokio::process_socket;
 
 pub struct DummyProcessor;
@@ -45,9 +42,7 @@ impl SimpleQueryHandler for DummyProcessor {
 impl ExtendedQueryHandler for DummyProcessor {
     async fn do_query<C>(&self, _client: &mut C, _portal: &Portal) -> PgWireResult<Response>
     where
-        C: ClientInfo + Sink<PgWireBackendMessage> + Unpin + Send + Sync,
-        C::Error: std::fmt::Debug,
-        PgWireError: From<<C as Sink<PgWireBackendMessage>>::Error>,
+        C: ClientInfo + Unpin + Send + Sync,
     {
         todo!()
     }

--- a/examples/sqlite.rs
+++ b/examples/sqlite.rs
@@ -8,7 +8,7 @@ use rusqlite::Rows;
 use rusqlite::{types::ValueRef, Connection, Statement, ToSql};
 use tokio::net::TcpListener;
 
-use pgwire::api::auth::CleartextPasswordAuthStartupHandler;
+use pgwire::api::auth::cleartext::CleartextPasswordAuthStartupHandler;
 use pgwire::api::portal::Portal;
 use pgwire::api::query::{ExtendedQueryHandler, SimpleQueryHandler};
 use pgwire::api::results::{FieldInfo, QueryResponseBuilder, Response, Tag};

--- a/examples/sqlite.rs
+++ b/examples/sqlite.rs
@@ -2,8 +2,6 @@ use std::collections::HashMap;
 use std::sync::{Arc, Mutex};
 
 use async_trait::async_trait;
-use futures::Sink;
-use postgres_types::Type;
 use rusqlite::Rows;
 use rusqlite::{types::ValueRef, Connection, Statement, ToSql};
 use tokio::net::TcpListener;
@@ -13,9 +11,8 @@ use pgwire::api::auth::ServerParameterProvider;
 use pgwire::api::portal::Portal;
 use pgwire::api::query::{ExtendedQueryHandler, SimpleQueryHandler};
 use pgwire::api::results::{FieldInfo, QueryResponseBuilder, Response, Tag};
-use pgwire::api::ClientInfo;
-use pgwire::error::{PgWireError, PgWireResult};
-use pgwire::messages::PgWireBackendMessage;
+use pgwire::api::{ClientInfo, Type};
+use pgwire::error::PgWireResult;
 use pgwire::tokio::process_socket;
 
 pub struct SqliteBackend {
@@ -180,9 +177,7 @@ fn get_params(portal: &Portal) -> Vec<Box<dyn ToSql>> {
 impl ExtendedQueryHandler for SqliteBackend {
     async fn do_query<C>(&self, _client: &mut C, portal: &Portal) -> PgWireResult<Response>
     where
-        C: ClientInfo + Sink<PgWireBackendMessage> + Unpin + Send + Sync,
-        C::Error: std::fmt::Debug,
-        PgWireError: From<<C as Sink<PgWireBackendMessage>>::Error>,
+        C: ClientInfo + Unpin + Send + Sync,
     {
         let conn = self.conn.lock().unwrap();
         let query = portal.statement();

--- a/src/api/auth/cleartext.rs
+++ b/src/api/auth/cleartext.rs
@@ -14,6 +14,7 @@ pub trait PasswordVerifier: Send + Sync {
     async fn verify_password(&self, password: &str) -> PgWireResult<bool>;
 }
 
+#[derive(new)]
 pub struct CleartextPasswordAuthStartupHandler<V: PasswordVerifier> {
     verifier: V,
 }

--- a/src/api/auth/cleartext.rs
+++ b/src/api/auth/cleartext.rs
@@ -1,0 +1,78 @@
+use std::collections::HashMap;
+use std::fmt::Debug;
+
+use async_trait::async_trait;
+use futures::sink::{Sink, SinkExt};
+
+use super::{ClientInfo, PgWireConnectionState, StartupHandler};
+use crate::error::{PgWireError, PgWireResult};
+use crate::messages::response::ErrorResponse;
+use crate::messages::startup::Authentication;
+use crate::messages::{PgWireBackendMessage, PgWireFrontendMessage};
+
+#[async_trait]
+pub trait CleartextPasswordAuthStartupHandler: StartupHandler {
+    async fn verify_password(&self, password: &str) -> PgWireResult<bool>;
+
+    fn server_parameters<C>(&self, _client: &C) -> HashMap<String, String>
+    where
+        C: ClientInfo;
+}
+
+#[async_trait]
+impl<T> StartupHandler for T
+where
+    T: CleartextPasswordAuthStartupHandler,
+{
+    async fn on_startup<C>(
+        &self,
+        client: &mut C,
+        message: &PgWireFrontendMessage,
+    ) -> PgWireResult<()>
+    where
+        C: ClientInfo + Sink<PgWireBackendMessage> + Unpin + Send,
+        C::Error: Debug,
+        PgWireError: From<<C as Sink<PgWireBackendMessage>>::Error>,
+    {
+        match message {
+            PgWireFrontendMessage::Startup(ref startup) => {
+                self.handle_startup_parameters(client, startup);
+                client.set_state(PgWireConnectionState::AuthenticationInProgress);
+                client
+                    .send(PgWireBackendMessage::Authentication(
+                        Authentication::CleartextPassword,
+                    ))
+                    .await?;
+            }
+            PgWireFrontendMessage::Password(ref pwd) => {
+                if let Ok(true) = self.verify_password(pwd.password()).await {
+                    self.finish_authentication(client).await
+                } else {
+                    // TODO: error api
+                    let info = vec![
+                        (b'L', "FATAL".to_owned()),
+                        (b'T', "FATAL".to_owned()),
+                        (b'C', "28P01".to_owned()),
+                        (b'M', "Password authentication failed".to_owned()),
+                        (b'R', "auth_failed".to_owned()),
+                    ];
+                    let error = ErrorResponse::new(info);
+
+                    client
+                        .feed(PgWireBackendMessage::ErrorResponse(error))
+                        .await?;
+                    client.close().await?;
+                }
+            }
+            _ => {}
+        }
+        Ok(())
+    }
+
+    fn server_parameters<C>(&self, _client: &C) -> HashMap<String, String>
+    where
+        C: ClientInfo,
+    {
+        CleartextPasswordAuthStartupHandler::server_parameters(self, _client)
+    }
+}

--- a/src/api/auth/mod.rs
+++ b/src/api/auth/mod.rs
@@ -27,51 +27,65 @@ pub trait StartupHandler: Send + Sync {
         C: ClientInfo + Sink<PgWireBackendMessage> + Unpin + Send,
         C::Error: Debug,
         PgWireError: From<<C as Sink<PgWireBackendMessage>>::Error>;
+}
 
-    fn handle_startup_parameters<C>(&self, client: &mut C, startup_message: &Startup)
+pub trait ServerParameterProvider: Send + Sync {
+    fn server_parameters<C>(&self, _client: &C) -> Option<HashMap<String, String>>
     where
-        C: ClientInfo + Sink<PgWireBackendMessage> + Unpin + Send,
-        C::Error: Debug,
+        C: ClientInfo;
+}
+
+struct NoopServerParameterProvider;
+
+impl ServerParameterProvider for NoopServerParameterProvider {
+    fn server_parameters<C>(self: &Self, _client: &C) -> Option<HashMap<String, String>>
+    where
+        C: ClientInfo,
     {
-        client.metadata_mut().extend(
-            startup_message
-                .parameters()
-                .iter()
-                .map(|(k, v)| (k.to_owned(), v.to_owned())),
-        );
+        None
     }
+}
 
-    async fn finish_authentication<C>(&self, client: &mut C)
-    where
-        C: ClientInfo + Sink<PgWireBackendMessage> + Unpin + Send,
-        C::Error: Debug,
-    {
-        client.set_state(PgWireConnectionState::ReadyForQuery);
-        let mut messages = vec![PgWireBackendMessage::Authentication(Authentication::Ok)];
-        for (k, v) in self.server_parameters(client) {
+pub fn save_startup_parameters_to_metadata<C>(client: &mut C, startup_message: &Startup)
+where
+    C: ClientInfo + Sink<PgWireBackendMessage> + Unpin + Send,
+    C::Error: Debug,
+{
+    client.metadata_mut().extend(
+        startup_message
+            .parameters()
+            .iter()
+            .map(|(k, v)| (k.to_owned(), v.to_owned())),
+    );
+}
+
+pub async fn finish_authentication<C, P>(client: &mut C, server_parameter_provider: &P)
+where
+    C: ClientInfo + Sink<PgWireBackendMessage> + Unpin + Send,
+    C::Error: Debug,
+    P: ServerParameterProvider,
+{
+    client.set_state(PgWireConnectionState::ReadyForQuery);
+    let mut messages = vec![PgWireBackendMessage::Authentication(Authentication::Ok)];
+
+    if let Some(parameters) = server_parameter_provider.server_parameters(client) {
+        for (k, v) in parameters {
             messages.push(PgWireBackendMessage::ParameterStatus(ParameterStatus::new(
                 k, v,
             )));
         }
-
-        // TODO: store this backend key
-        messages.push(PgWireBackendMessage::BackendKeyData(BackendKeyData::new(
-            std::process::id() as i32,
-            rand::random::<i32>(),
-        )));
-        messages.push(PgWireBackendMessage::ReadyForQuery(ReadyForQuery::new(
-            READY_STATUS_IDLE,
-        )));
-        let mut message_stream = stream::iter(messages.into_iter().map(Ok));
-        client.send_all(&mut message_stream).await.unwrap();
     }
 
-    fn server_parameters<C>(&self, _client: &C) -> HashMap<String, String>
-    where
-        C: ClientInfo,
-    {
-        HashMap::default()
-    }
+    // TODO: store this backend key
+    messages.push(PgWireBackendMessage::BackendKeyData(BackendKeyData::new(
+        std::process::id() as i32,
+        rand::random::<i32>(),
+    )));
+    messages.push(PgWireBackendMessage::ReadyForQuery(ReadyForQuery::new(
+        READY_STATUS_IDLE,
+    )));
+    let mut message_stream = stream::iter(messages.into_iter().map(Ok));
+    client.send_all(&mut message_stream).await.unwrap();
 }
 
 pub mod cleartext;

--- a/src/api/auth/mod.rs
+++ b/src/api/auth/mod.rs
@@ -8,7 +8,7 @@ use rand;
 
 use super::{ClientInfo, PgWireConnectionState};
 use crate::error::{PgWireError, PgWireResult};
-use crate::messages::response::{ErrorResponse, ReadyForQuery, READY_STATUS_IDLE};
+use crate::messages::response::{ReadyForQuery, READY_STATUS_IDLE};
 use crate::messages::startup::{Authentication, BackendKeyData, ParameterStatus, Startup};
 use crate::messages::{PgWireBackendMessage, PgWireFrontendMessage};
 
@@ -17,6 +17,7 @@ use crate::messages::{PgWireBackendMessage, PgWireFrontendMessage};
 // support for other auth type like sasl.
 #[async_trait]
 pub trait StartupHandler: Send + Sync {
+    /// A generic frontend message callback during startup phase.
     async fn on_startup<C>(
         &self,
         client: &mut C,
@@ -70,70 +71,6 @@ pub trait StartupHandler: Send + Sync {
         C: ClientInfo;
 }
 
-#[async_trait]
-pub trait CleartextPasswordAuthStartupHandler: StartupHandler {
-    async fn verify_password(&self, password: &str) -> PgWireResult<bool>;
-
-    fn server_parameters<C>(&self, _client: &C) -> HashMap<String, String>
-    where
-        C: ClientInfo;
-}
-
-#[async_trait]
-impl<T> StartupHandler for T
-where
-    T: CleartextPasswordAuthStartupHandler,
-{
-    async fn on_startup<C>(
-        &self,
-        client: &mut C,
-        message: &PgWireFrontendMessage,
-    ) -> PgWireResult<()>
-    where
-        C: ClientInfo + Sink<PgWireBackendMessage> + Unpin + Send,
-        C::Error: Debug,
-        PgWireError: From<<C as Sink<PgWireBackendMessage>>::Error>,
-    {
-        match message {
-            PgWireFrontendMessage::Startup(ref startup) => {
-                self.handle_startup_parameters(client, startup);
-                client.set_state(PgWireConnectionState::AuthenticationInProgress);
-                client
-                    .send(PgWireBackendMessage::Authentication(
-                        Authentication::CleartextPassword,
-                    ))
-                    .await?;
-            }
-            PgWireFrontendMessage::Password(ref pwd) => {
-                if let Ok(true) = self.verify_password(pwd.password()).await {
-                    self.finish_authentication(client).await
-                } else {
-                    let info = vec![
-                        (b'L', "FATAL".to_owned()),
-                        (b'T', "FATAL".to_owned()),
-                        (b'C', "28P01".to_owned()),
-                        (b'M', "Password authentication failed".to_owned()),
-                        (b'R', "auth_failed".to_owned()),
-                    ];
-                    let error = ErrorResponse::new(info);
-
-                    client
-                        .feed(PgWireBackendMessage::ErrorResponse(error))
-                        .await?;
-                    client.close().await?;
-                }
-            }
-            _ => {}
-        }
-        Ok(())
-    }
-
-    fn server_parameters<C>(&self, _client: &C) -> HashMap<String, String>
-    where
-        C: ClientInfo,
-    {
-        CleartextPasswordAuthStartupHandler::server_parameters(self, _client)
-    }
-}
+pub mod cleartext;
 
 // TODO: md5, scram-sha-256(sasl)

--- a/src/api/auth/mod.rs
+++ b/src/api/auth/mod.rs
@@ -68,9 +68,13 @@ pub trait StartupHandler: Send + Sync {
 
     fn server_parameters<C>(&self, _client: &C) -> HashMap<String, String>
     where
-        C: ClientInfo;
+        C: ClientInfo,
+    {
+        HashMap::default()
+    }
 }
 
 pub mod cleartext;
+pub mod noop;
 
 // TODO: md5, scram-sha-256(sasl)

--- a/src/api/auth/mod.rs
+++ b/src/api/auth/mod.rs
@@ -38,7 +38,7 @@ pub trait ServerParameterProvider: Send + Sync {
 struct NoopServerParameterProvider;
 
 impl ServerParameterProvider for NoopServerParameterProvider {
-    fn server_parameters<C>(self: &Self, _client: &C) -> Option<HashMap<String, String>>
+    fn server_parameters<C>(&self, _client: &C) -> Option<HashMap<String, String>>
     where
         C: ClientInfo,
     {

--- a/src/api/auth/noop.rs
+++ b/src/api/auth/noop.rs
@@ -21,12 +21,9 @@ impl StartupHandler for NoopStartupHandler {
         C::Error: Debug,
         PgWireError: From<<C as Sink<PgWireBackendMessage>>::Error>,
     {
-        match message {
-            PgWireFrontendMessage::Startup(ref startup) => {
-                self.handle_startup_parameters(client, startup);
-                self.finish_authentication(client).await;
-            }
-            _ => {}
+        if let PgWireFrontendMessage::Startup(ref startup) = message {
+            self.handle_startup_parameters(client, startup);
+            self.finish_authentication(client).await;
         }
         Ok(())
     }

--- a/src/api/auth/noop.rs
+++ b/src/api/auth/noop.rs
@@ -1,0 +1,33 @@
+use std::fmt::Debug;
+
+use async_trait::async_trait;
+use futures::sink::Sink;
+
+use super::{ClientInfo, StartupHandler};
+use crate::error::{PgWireError, PgWireResult};
+use crate::messages::{PgWireBackendMessage, PgWireFrontendMessage};
+
+pub struct NoopStartupHandler;
+
+#[async_trait]
+impl StartupHandler for NoopStartupHandler {
+    async fn on_startup<C>(
+        &self,
+        client: &mut C,
+        message: &PgWireFrontendMessage,
+    ) -> PgWireResult<()>
+    where
+        C: ClientInfo + Sink<PgWireBackendMessage> + Unpin + Send,
+        C::Error: Debug,
+        PgWireError: From<<C as Sink<PgWireBackendMessage>>::Error>,
+    {
+        match message {
+            PgWireFrontendMessage::Startup(ref startup) => {
+                self.handle_startup_parameters(client, startup);
+                self.finish_authentication(client).await;
+            }
+            _ => {}
+        }
+        Ok(())
+    }
+}

--- a/src/api/auth/noop.rs
+++ b/src/api/auth/noop.rs
@@ -3,7 +3,7 @@ use std::fmt::Debug;
 use async_trait::async_trait;
 use futures::sink::Sink;
 
-use super::{ClientInfo, StartupHandler};
+use super::{ClientInfo, NoopServerParameterProvider, StartupHandler};
 use crate::error::{PgWireError, PgWireResult};
 use crate::messages::{PgWireBackendMessage, PgWireFrontendMessage};
 
@@ -22,8 +22,8 @@ impl StartupHandler for NoopStartupHandler {
         PgWireError: From<<C as Sink<PgWireBackendMessage>>::Error>,
     {
         if let PgWireFrontendMessage::Startup(ref startup) = message {
-            self.handle_startup_parameters(client, startup);
-            self.finish_authentication(client).await;
+            super::save_startup_parameters_to_metadata(client, startup);
+            super::finish_authentication(client, &NoopServerParameterProvider).await;
         }
         Ok(())
     }

--- a/src/api/mod.rs
+++ b/src/api/mod.rs
@@ -2,6 +2,8 @@ use std::collections::HashMap;
 use std::net::SocketAddr;
 use std::sync::Arc;
 
+pub use postgres_types::Type;
+
 pub mod auth;
 pub mod portal;
 pub mod query;

--- a/src/api/query.rs
+++ b/src/api/query.rs
@@ -170,9 +170,7 @@ pub trait ExtendedQueryHandler: Send + Sync {
 
     async fn do_query<C>(&self, client: &mut C, portal: &Portal) -> PgWireResult<Response>
     where
-        C: ClientInfo + Sink<PgWireBackendMessage> + Unpin + Send + Sync,
-        C::Error: Debug,
-        PgWireError: From<<C as Sink<PgWireBackendMessage>>::Error>;
+        C: ClientInfo + Unpin + Send + Sync;
 }
 
 async fn send_query_response<C>(

--- a/src/tokio.rs
+++ b/src/tokio.rs
@@ -177,7 +177,7 @@ pub fn process_socket<A, Q, EQ>(
         loop {
             match socket.next().await {
                 Some(Ok(msg)) => {
-                    if let Err(e) = process_message(
+                    if let Err(_e) = process_message(
                         msg,
                         &mut socket,
                         authenticator.clone(),
@@ -187,13 +187,13 @@ pub fn process_socket<A, Q, EQ>(
                     .await
                     {
                         // TODO: error processing
-                        println!("{:?}", e);
+                        // println!("{:?}", e);
                         break;
                     }
                 }
-                Some(Err(e)) => {
+                Some(Err(_e)) => {
                     // TODO: logging
-                    println!("{:?}", e);
+                    // println!("{:?}", e);
                     break;
                 }
                 None => break,


### PR DESCRIPTION
Addresses #5 

The previous implementation of auth framework is limited by rust's type system. So we have to change the design by providing a concrete type `CleartextPasswordAuthStartupHandler` and use a smaller `PasswordVerifier` as an extending point.

We still need to figure out a way to deal with how to customize `server_parameters`