### PR TITLE
Refining Tokio API

### DIFF
--- a/examples/sqlite.rs
+++ b/examples/sqlite.rs
@@ -224,11 +224,16 @@ pub async fn main() {
     println!("Listening to {}", server_addr);
     loop {
         let incoming_socket = listener.accept().await.unwrap();
-        process_socket(
-            incoming_socket,
-            authenticator.clone(),
-            processor.clone(),
-            processor.clone(),
-        );
+        let authenticator_ref = authenticator.clone();
+        let processor_ref = processor.clone();
+        tokio::spawn(async move {
+            process_socket(
+                incoming_socket.0,
+                authenticator_ref.clone(),
+                processor_ref.clone(),
+                processor_ref.clone(),
+            )
+            .await;
+        });
     }
 }


### PR DESCRIPTION
Fixes #8 

This patch moves `tokio::spawn` out of `process_socket` so that users could use their own runtime to spawn.

It also dropped `socket_addr` as input because the information is carried by `TcpStream` already.