### PR TITLE
API support for text response

### DIFF
--- a/examples/server.rs
+++ b/examples/server.rs
@@ -6,7 +6,7 @@ use tokio::net::TcpListener;
 use pgwire::api::auth::noop::NoopStartupHandler;
 use pgwire::api::portal::Portal;
 use pgwire::api::query::{ExtendedQueryHandler, SimpleQueryHandler};
-use pgwire::api::results::{FieldInfo, QueryResponseBuilder, Response, Tag};
+use pgwire::api::results::{FieldInfo, Response, Tag, TextQueryResponseBuilder};
 use pgwire::api::{ClientInfo, Type};
 use pgwire::error::PgWireResult;
 use pgwire::tokio::process_socket;
@@ -25,11 +25,10 @@ impl SimpleQueryHandler for DummyProcessor {
             let f1 = FieldInfo::new("id".into(), None, None, Type::INT4);
             let f2 = FieldInfo::new("name".into(), None, None, Type::VARCHAR);
 
-            let mut result_builder = QueryResponseBuilder::new(vec![f1, f2]);
-            result_builder.text_format();
+            let mut result_builder = TextQueryResponseBuilder::new(vec![f1, f2]);
             for _ in 0..3 {
-                result_builder.append_field_text(Some(1i32))?;
-                result_builder.append_field_text(Some("Tom"))?;
+                result_builder.append_field(Some(1i32))?;
+                result_builder.append_field(Some("Tom"))?;
                 result_builder.finish_row();
             }
             Ok(Response::Query(result_builder.build()))

--- a/examples/server.rs
+++ b/examples/server.rs
@@ -26,9 +26,10 @@ impl SimpleQueryHandler for DummyProcessor {
             let f2 = FieldInfo::new("name".into(), None, None, Type::VARCHAR);
 
             let mut result_builder = QueryResponseBuilder::new(vec![f1, f2]);
+            result_builder.text_format();
             for _ in 0..3 {
-                result_builder.append_field(1i32)?;
-                result_builder.append_field("Tom")?;
+                result_builder.append_field_text(Some(1i32))?;
+                result_builder.append_field_text(Some("Tom"))?;
                 result_builder.finish_row();
             }
             Ok(Response::Query(result_builder.build()))

--- a/examples/sqlite.rs
+++ b/examples/sqlite.rs
@@ -10,7 +10,9 @@ use pgwire::api::auth::cleartext::{CleartextPasswordAuthStartupHandler, Password
 use pgwire::api::auth::ServerParameterProvider;
 use pgwire::api::portal::Portal;
 use pgwire::api::query::{ExtendedQueryHandler, SimpleQueryHandler};
-use pgwire::api::results::{FieldInfo, QueryResponseBuilder, Response, Tag};
+use pgwire::api::results::{
+    BinaryQueryResponseBuilder, FieldInfo, Response, Tag, TextQueryResponseBuilder,
+};
 use pgwire::api::{ClientInfo, Type};
 use pgwire::error::PgWireResult;
 use pgwire::tokio::process_socket;
@@ -73,8 +75,7 @@ impl SimpleQueryHandler for SqliteBackend {
             let header = row_desc_from_stmt(&stmt);
             let rows = stmt.query(()).unwrap();
 
-            let mut builder = QueryResponseBuilder::new(header);
-            builder.text_format();
+            let mut builder = TextQueryResponseBuilder::new(header);
             encode_text_row_data(rows, columns, &mut builder);
 
             Ok(Response::Query(builder.build()))
@@ -112,25 +113,25 @@ fn row_desc_from_stmt(stmt: &Statement) -> Vec<FieldInfo> {
         .collect()
 }
 
-fn encode_text_row_data(mut rows: Rows, columns: usize, builder: &mut QueryResponseBuilder) {
+fn encode_text_row_data(mut rows: Rows, columns: usize, builder: &mut TextQueryResponseBuilder) {
     while let Ok(Some(row)) = rows.next() {
         for idx in 0..columns {
             let data = row.get_ref_unwrap::<usize>(idx);
             match data {
-                ValueRef::Null => builder.append_field_text(None::<i8>).unwrap(),
+                ValueRef::Null => builder.append_field(None::<i8>).unwrap(),
                 ValueRef::Integer(i) => {
-                    builder.append_field_text(Some(i)).unwrap();
+                    builder.append_field(Some(i)).unwrap();
                 }
                 ValueRef::Real(f) => {
-                    builder.append_field_text(Some(f)).unwrap();
+                    builder.append_field(Some(f)).unwrap();
                 }
                 ValueRef::Text(t) => {
                     builder
-                        .append_field_text(Some(String::from_utf8_lossy(t)))
+                        .append_field(Some(String::from_utf8_lossy(t)))
                         .unwrap();
                 }
                 ValueRef::Blob(b) => {
-                    builder.append_field_text(Some(hex::encode(b))).unwrap();
+                    builder.append_field(Some(hex::encode(b))).unwrap();
                 }
             }
         }
@@ -139,23 +140,27 @@ fn encode_text_row_data(mut rows: Rows, columns: usize, builder: &mut QueryRespo
     }
 }
 
-fn encode_binary_row_data(mut rows: Rows, columns: usize, builder: &mut QueryResponseBuilder) {
+fn encode_binary_row_data(
+    mut rows: Rows,
+    columns: usize,
+    builder: &mut BinaryQueryResponseBuilder,
+) {
     while let Ok(Some(row)) = rows.next() {
         for idx in 0..columns {
             let data = row.get_ref_unwrap::<usize>(idx);
             match data {
-                ValueRef::Null => builder.append_field_binary(None::<i8>).unwrap(),
+                ValueRef::Null => builder.append_field(None::<i8>).unwrap(),
                 ValueRef::Integer(i) => {
-                    builder.append_field_binary(i).unwrap();
+                    builder.append_field(i).unwrap();
                 }
                 ValueRef::Real(f) => {
-                    builder.append_field_binary(f).unwrap();
+                    builder.append_field(f).unwrap();
                 }
                 ValueRef::Text(t) => {
-                    builder.append_field_binary(t).unwrap();
+                    builder.append_field(t).unwrap();
                 }
                 ValueRef::Blob(b) => {
-                    builder.append_field_binary(b).unwrap();
+                    builder.append_field(b).unwrap();
                 }
             }
         }
@@ -223,8 +228,7 @@ impl ExtendedQueryHandler for SqliteBackend {
                 .query::<&[&dyn rusqlite::ToSql]>(params_ref.as_ref())
                 .unwrap();
 
-            let mut builder = QueryResponseBuilder::new(header);
-            builder.binary_format();
+            let mut builder = BinaryQueryResponseBuilder::new(header);
             encode_binary_row_data(rows, columns, &mut builder);
 
             Ok(Response::Query(builder.build()))


### PR DESCRIPTION
Fixes #10 

This patch brings in API support for text format response, which is required for simple_query mode in postgresql.

