### PR TITLE
feat: allow multiple queries in simple query

### DIFF
--- a/examples/server.rs
+++ b/examples/server.rs
@@ -15,7 +15,7 @@ pub struct DummyProcessor;
 
 #[async_trait]
 impl SimpleQueryHandler for DummyProcessor {
-    async fn do_query<C>(&self, _client: &C, query: &str) -> PgWireResult<Response>
+    async fn do_query<C>(&self, _client: &C, query: &str) -> PgWireResult<Vec<Response>>
     where
         C: ClientInfo + Unpin + Send + Sync,
     {
@@ -31,9 +31,12 @@ impl SimpleQueryHandler for DummyProcessor {
                 result_builder.append_field(Some("Tom"))?;
                 result_builder.finish_row();
             }
-            Ok(Response::Query(result_builder.build()))
+            Ok(vec![Response::Query(result_builder.build())])
         } else {
-            Ok(Response::Execution(Tag::new_for_execution("OK", Some(1))))
+            Ok(vec![Response::Execution(Tag::new_for_execution(
+                "OK",
+                Some(1),
+            ))])
         }
     }
 }

--- a/src/api/query.rs
+++ b/src/api/query.rs
@@ -33,32 +33,34 @@ pub trait SimpleQueryHandler: Send + Sync {
     {
         client.set_state(super::PgWireConnectionState::QueryInProgress);
         let resp = self.do_query(client, query.query()).await?;
-        match resp {
-            Response::Query(results) => {
-                send_query_response(client, results, true).await?;
-            }
-            Response::Execution(tag) => {
-                send_execution_response(client, tag).await?;
-            }
-            Response::Error(e) => {
-                client
-                    .feed(PgWireBackendMessage::ErrorResponse((*e).into()))
-                    .await?;
-                client
-                    .feed(PgWireBackendMessage::ReadyForQuery(ReadyForQuery::new(
-                        READY_STATUS_IDLE,
-                    )))
-                    .await?;
-                client.flush().await?;
+        for r in resp {
+            match r {
+                Response::Query(results) => {
+                    send_query_response(client, results, true).await?;
+                }
+                Response::Execution(tag) => {
+                    send_execution_response(client, tag).await?;
+                }
+                Response::Error(e) => {
+                    client
+                        .feed(PgWireBackendMessage::ErrorResponse((*e).into()))
+                        .await?;
+                }
             }
         }
+        client
+            .feed(PgWireBackendMessage::ReadyForQuery(ReadyForQuery::new(
+                READY_STATUS_IDLE,
+            )))
+            .await?;
+        client.flush().await?;
 
         client.set_state(super::PgWireConnectionState::ReadyForQuery);
         Ok(())
     }
 
     /// Provide your query implementation using the incoming query string.
-    async fn do_query<C>(&self, client: &C, query: &str) -> PgWireResult<Response>
+    async fn do_query<C>(&self, client: &C, query: &str) -> PgWireResult<Vec<Response>>
     where
         C: ClientInfo + Unpin + Send + Sync;
 }
@@ -114,6 +116,11 @@ pub trait ExtendedQueryHandler: Send + Sync {
                         .await?;
                 }
             }
+            client
+                .send(PgWireBackendMessage::ReadyForQuery(ReadyForQuery::new(
+                    READY_STATUS_IDLE,
+                )))
+                .await?;
 
             Ok(())
         } else {
@@ -209,11 +216,6 @@ where
     client
         .send(PgWireBackendMessage::CommandComplete(tag.into()))
         .await?;
-    client
-        .send(PgWireBackendMessage::ReadyForQuery(ReadyForQuery::new(
-            READY_STATUS_IDLE,
-        )))
-        .await?;
 
     Ok(())
 }
@@ -225,13 +227,8 @@ where
     PgWireError: From<<C as Sink<PgWireBackendMessage>>::Error>,
 {
     client
-        .feed(PgWireBackendMessage::CommandComplete(tag.into()))
+        .send(PgWireBackendMessage::CommandComplete(tag.into()))
         .await?;
-    client
-        .feed(PgWireBackendMessage::ReadyForQuery(ReadyForQuery::new(
-            READY_STATUS_IDLE,
-        )))
-        .await?;
-    client.flush().await?;
+
     Ok(())
 }

--- a/src/messages/mod.rs
+++ b/src/messages/mod.rs
@@ -151,6 +151,7 @@ pub enum PgWireBackendMessage {
 
     // command response
     CommandComplete(response::CommandComplete),
+    EmptyQueryResponse(response::EmptyQueryResponse),
     ReadyForQuery(response::ReadyForQuery),
     ErrorResponse(response::ErrorResponse),
     NoticeResponse(response::NoticeResponse),
@@ -173,6 +174,7 @@ impl PgWireBackendMessage {
             Self::PortalSuspended(msg) => msg.encode(buf),
 
             Self::CommandComplete(msg) => msg.encode(buf),
+            Self::EmptyQueryResponse(msg) => msg.encode(buf),
             Self::ReadyForQuery(msg) => msg.encode(buf),
             Self::ErrorResponse(msg) => msg.encode(buf),
             Self::NoticeResponse(msg) => msg.encode(buf),
@@ -217,6 +219,10 @@ impl PgWireBackendMessage {
 
                 response::MESSAGE_TYPE_BYTE_COMMAND_COMPLETE => {
                     response::CommandComplete::decode(buf).map(|v| v.map(Self::CommandComplete))
+                }
+                response::MESSAGE_TYPE_BYTE_EMPTY_QUERY_RESPONSE => {
+                    response::EmptyQueryResponse::decode(buf)
+                        .map(|v| v.map(Self::EmptyQueryResponse))
                 }
                 response::MESSAGE_TYPE_BYTE_READY_FOR_QUERY => {
                     response::ReadyForQuery::decode(buf).map(|v| v.map(Self::ReadyForQuery))

--- a/src/messages/response.rs
+++ b/src/messages/response.rs
@@ -37,6 +37,30 @@ impl Message for CommandComplete {
 
 #[derive(Getters, Setters, MutGetters, PartialEq, Eq, Debug, new)]
 #[getset(get = "pub", set = "pub", get_mut = "pub")]
+pub struct EmptyQueryResponse;
+
+pub const MESSAGE_TYPE_BYTE_EMPTY_QUERY_RESPONSE: u8 = b'I';
+
+impl Message for EmptyQueryResponse {
+    fn message_type() -> Option<u8> {
+        Some(MESSAGE_TYPE_BYTE_EMPTY_QUERY_RESPONSE)
+    }
+
+    fn message_length(&self) -> usize {
+        4
+    }
+
+    fn encode_body(&self, _buf: &mut BytesMut) -> PgWireResult<()> {
+        Ok(())
+    }
+
+    fn decode_body(_buf: &mut BytesMut, _full_len: usize) -> PgWireResult<Self> {
+        Ok(EmptyQueryResponse)
+    }
+}
+
+#[derive(Getters, Setters, MutGetters, PartialEq, Eq, Debug, new)]
+#[getset(get = "pub", set = "pub", get_mut = "pub")]
 pub struct ReadyForQuery {
     status: u8,
 }


### PR DESCRIPTION
Fixes #9 

As defined in https://www.postgresql.org/docs/8.2/protocol-flow.html#AEN67013, a simple query string can contains multiple queries so here we use `Vec<Response>` to represent the result for a simple query. 