### PR TITLE
Server side ssl support

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,7 +24,7 @@ rand = "0.8"
 thiserror = "1"
 postgres-types = "0.2"
 
-tokio = { version = "1.19", features = ["net", "rt"], optional = true}
+tokio = { version = "1.19", features = ["net", "rt", "io-util"], optional = true}
 tokio-util = { version = "0.7.3", features = ["codec", "io"], optional = true }
 tokio-rustls = { version = "0.23", optional = true }
 ## for loading custom cert files
@@ -33,7 +33,7 @@ rustls-pemfile = { version = "1.0", optional = true }
 ## rustls-native-certs loads roots from current system
 
 [dev-dependencies]
-tokio = { version = "1.19", features = ["rt-multi-thread", "net", "io-util", "macros"]}
+tokio = { version = "1.19", features = ["rt-multi-thread", "net", "macros"]}
 rusqlite = { version = "0.28.0", features = ["bundled", "column_decltype"] }
 hex = "0.4"
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,6 +26,11 @@ postgres-types = "0.2"
 
 tokio = { version = "1.19", features = ["net", "rt"], optional = true}
 tokio-util = { version = "0.7.3", features = ["codec", "io"], optional = true }
+tokio-rustls = { version = "0.23", optional = true }
+## for loading custom cert files
+rustls-pemfile = { version = "1.0", optional = true }
+## webpki-roots has mozilla's set of roots
+## rustls-native-certs loads roots from current system
 
 [dev-dependencies]
 tokio = { version = "1.19", features = ["rt-multi-thread", "net", "io-util", "macros"]}
@@ -34,7 +39,7 @@ hex = "0.4"
 
 [features]
 default = ["tokio_support"]
-tokio_support = ["tokio", "tokio-util"]
+tokio_support = ["tokio", "tokio-util", "tokio-rustls", "rustls-pemfile"]
 
 [[example]]
 name = "server"

--- a/examples/server.rs
+++ b/examples/server.rs
@@ -66,6 +66,7 @@ pub async fn main() {
         tokio::spawn(async move {
             process_socket(
                 incoming_socket.0,
+                None,
                 authenticator_ref.clone(),
                 processor_ref.clone(),
                 processor_ref.clone(),

--- a/examples/sqlite.rs
+++ b/examples/sqlite.rs
@@ -268,6 +268,7 @@ pub async fn main() {
         tokio::spawn(async move {
             process_socket(
                 incoming_socket.0,
+                None,
                 authenticator_ref.clone(),
                 processor_ref.clone(),
                 processor_ref.clone(),

--- a/src/api/mod.rs
+++ b/src/api/mod.rs
@@ -13,7 +13,7 @@ pub mod store;
 
 pub const DEFAULT_NAME: &str = "POSTGRESQL_DEFAULT_NAME";
 
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub enum PgWireConnectionState {
     AwaitingSslRequest,
     AwaitingSslHandshake,

--- a/src/api/mod.rs
+++ b/src/api/mod.rs
@@ -15,8 +15,6 @@ pub const DEFAULT_NAME: &str = "POSTGRESQL_DEFAULT_NAME";
 
 #[derive(Debug, Clone)]
 pub enum PgWireConnectionState {
-    AwaitingSslRequest,
-    AwaitingSslHandshake,
     AwaitingStartup,
     AuthenticationInProgress,
     ReadyForQuery,
@@ -25,7 +23,7 @@ pub enum PgWireConnectionState {
 
 impl Default for PgWireConnectionState {
     fn default() -> PgWireConnectionState {
-        PgWireConnectionState::AwaitingSslRequest
+        PgWireConnectionState::AwaitingStartup
     }
 }
 

--- a/src/api/mod.rs
+++ b/src/api/mod.rs
@@ -16,6 +16,7 @@ pub const DEFAULT_NAME: &str = "POSTGRESQL_DEFAULT_NAME";
 #[derive(Debug)]
 pub enum PgWireConnectionState {
     AwaitingSslRequest,
+    AwaitingSslHandshake,
     AwaitingStartup,
     AuthenticationInProgress,
     ReadyForQuery,
@@ -31,6 +32,8 @@ impl Default for PgWireConnectionState {
 /// Describe a client infomation holder
 pub trait ClientInfo {
     fn socket_addr(&self) -> &SocketAddr;
+
+    fn is_secure(&self) -> bool;
 
     fn state(&self) -> &PgWireConnectionState;
 
@@ -53,6 +56,7 @@ pub trait ClientInfo {
 #[getset(get = "pub", set = "pub", get_mut = "pub")]
 pub struct ClientInfoHolder {
     socket_addr: SocketAddr,
+    is_secure: bool,
     #[new(default)]
     state: PgWireConnectionState,
     #[new(default)]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2,8 +2,6 @@
 extern crate getset;
 #[macro_use]
 extern crate derive_new;
-#[macro_use]
-extern crate log;
 
 pub mod api;
 pub mod error;

--- a/src/messages/startup.rs
+++ b/src/messages/startup.rs
@@ -256,7 +256,8 @@ impl Message for BackendKeyData {
 pub struct SslRequest {}
 
 impl SslRequest {
-    const BODY_MAGIC_NUMBER: i32 = 80877103;
+    pub const BODY_MAGIC_NUMBER: i32 = 80877103;
+    pub const BODY_SIZE: usize = 8;
 }
 
 impl Message for SslRequest {
@@ -267,7 +268,7 @@ impl Message for SslRequest {
 
     #[inline]
     fn message_length(&self) -> usize {
-        8
+        Self::BODY_SIZE
     }
 
     fn encode_body(&self, buf: &mut BytesMut) -> PgWireResult<()> {


### PR DESCRIPTION
Fixes #14 

This patch adds:

- `TlsAcceptor` to `process_socket` function so that user can configure a ssl session
- Manually decode `SslRequest` and initiate ssl handshake if configured and requested