### PR TITLE
Stream response

### DIFF
--- a/src/api/query.rs
+++ b/src/api/query.rs
@@ -3,7 +3,7 @@ use std::sync::Arc;
 
 use async_trait::async_trait;
 use futures::sink::{Sink, SinkExt};
-use futures::stream::{Stream, StreamExt};
+use futures::stream::StreamExt;
 
 use super::portal::Portal;
 use super::results::{into_row_description, Tag};
@@ -11,7 +11,6 @@ use super::stmt::Statement;
 use super::{ClientInfo, DEFAULT_NAME};
 use crate::api::results::{QueryResponse, Response};
 use crate::error::{PgWireError, PgWireResult};
-use crate::messages::data::DataRow;
 use crate::messages::extendedquery::{
     Bind, Close, Describe, Execute, Parse, Sync as PgSync, TARGET_TYPE_BYTE_PORTAL,
     TARGET_TYPE_BYTE_STATEMENT,
@@ -23,8 +22,6 @@ use crate::messages::PgWireBackendMessage;
 /// handler for processing simple query.
 #[async_trait]
 pub trait SimpleQueryHandler: Send + Sync {
-    type DataStream: Stream<Item = DataRow> + Unpin + Send;
-
     /// Executed on `Query` request arrived. This is how postgres respond to
     /// simple query. The default implementation calls `do_query` with the
     /// incoming query string.
@@ -65,25 +62,18 @@ pub trait SimpleQueryHandler: Send + Sync {
             )))
             .await?;
         client.flush().await?;
-
         client.set_state(super::PgWireConnectionState::ReadyForQuery);
         Ok(())
     }
 
     /// Provide your query implementation using the incoming query string.
-    async fn do_query<C>(
-        &self,
-        client: &C,
-        query: &str,
-    ) -> PgWireResult<Vec<Response<Self::DataStream>>>
+    async fn do_query<C>(&self, client: &C, query: &str) -> PgWireResult<Vec<Response>>
     where
         C: ClientInfo + Unpin + Send + Sync;
 }
 
 #[async_trait]
 pub trait ExtendedQueryHandler: Send + Sync {
-    type DataStream: Stream<Item = DataRow> + Unpin + Send;
-
     async fn on_parse<C>(&self, client: &mut C, message: &Parse) -> PgWireResult<()>
     where
         C: ClientInfo + Sink<PgWireBackendMessage> + Unpin + Send + Sync,
@@ -192,25 +182,20 @@ pub trait ExtendedQueryHandler: Send + Sync {
         Ok(())
     }
 
-    async fn do_query<C>(
-        &self,
-        client: &mut C,
-        portal: &Portal,
-    ) -> PgWireResult<Response<Self::DataStream>>
+    async fn do_query<C>(&self, client: &mut C, portal: &Portal) -> PgWireResult<Response>
     where
         C: ClientInfo + Unpin + Send + Sync;
 }
 
-async fn send_query_response<C, S>(
+async fn send_query_response<C>(
     client: &mut C,
-    results: QueryResponse<S>,
+    results: QueryResponse,
     row_desc_required: bool,
 ) -> PgWireResult<()>
 where
     C: ClientInfo + Sink<PgWireBackendMessage> + Unpin + Send + Sync,
     C::Error: Debug,
     PgWireError: From<<C as Sink<PgWireBackendMessage>>::Error>,
-    S: Stream<Item = DataRow> + Unpin + Send,
 {
     let QueryResponse {
         row_schema,

--- a/src/api/results.rs
+++ b/src/api/results.rs
@@ -1,7 +1,7 @@
 use std::fmt::Debug;
 
 use bytes::{Bytes, BytesMut};
-use futures::stream::{self, Stream};
+use futures::stream::{self, BoxStream, StreamExt};
 use postgres_types::{IsNull, ToSql, Type};
 
 use crate::{
@@ -78,7 +78,7 @@ pub(crate) fn into_row_description(fields: Vec<FieldInfo>) -> RowDescription {
 #[getset(get = "pub")]
 pub struct QueryResponse {
     pub(crate) row_schema: Vec<FieldInfo>,
-    pub(crate) data_rows: Box<dyn Stream<Item = DataRow> + Send + Unpin>,
+    pub(crate) data_rows: BoxStream<'static, DataRow>,
     pub(crate) tag: Tag,
 }
 
@@ -135,7 +135,7 @@ impl QueryResponseBuilder {
 
         QueryResponse {
             row_schema: self.row_schema,
-            data_rows: Box::new(stream::iter(self.rows.into_iter())),
+            data_rows: stream::iter(self.rows.into_iter()).boxed(),
             tag: Tag::new_for_query(row_count),
         }
     }

--- a/src/api/results.rs
+++ b/src/api/results.rs
@@ -125,7 +125,7 @@ impl QueryResponseBuilder {
         self.col_index = 0;
     }
 
-    fn build<S: Stream<Item = DataRow>>(mut self) -> QueryResponse<S> {
+    fn build(mut self) -> QueryResponse<stream::Iter<std::vec::IntoIter<DataRow>>> {
         let row_count = self.rows.len();
 
         // set column format
@@ -135,7 +135,7 @@ impl QueryResponseBuilder {
 
         QueryResponse {
             row_schema: self.row_schema,
-            data_rows: stream::iter(self.rows.iter()),
+            data_rows: stream::iter(self.rows.into_iter()),
             tag: Tag::new_for_query(row_count),
         }
     }
@@ -177,7 +177,7 @@ impl BinaryQueryResponseBuilder {
         self.inner.finish_row();
     }
 
-    pub fn build<S: Stream<Item = DataRow>>(self) -> QueryResponse<S> {
+    pub fn build(self) -> QueryResponse<stream::Iter<std::vec::IntoIter<DataRow>>> {
         self.inner.build()
     }
 }
@@ -214,7 +214,7 @@ impl TextQueryResponseBuilder {
         self.inner.finish_row();
     }
 
-    pub fn build<S: Stream<Item = DataRow>>(self) -> QueryResponse<S> {
+    pub fn build(self) -> QueryResponse<stream::Iter<std::vec::IntoIter<DataRow>>> {
         self.inner.build()
     }
 }

--- a/src/api/results.rs
+++ b/src/api/results.rs
@@ -76,9 +76,9 @@ pub(crate) fn into_row_description(fields: Vec<FieldInfo>) -> RowDescription {
 
 #[derive(Getters)]
 #[getset(get = "pub")]
-pub struct QueryResponse<S: Stream<Item = DataRow>> {
+pub struct QueryResponse {
     pub(crate) row_schema: Vec<FieldInfo>,
-    pub(crate) data_rows: S,
+    pub(crate) data_rows: Box<dyn Stream<Item = DataRow> + Send + Unpin>,
     pub(crate) tag: Tag,
 }
 
@@ -125,7 +125,7 @@ impl QueryResponseBuilder {
         self.col_index = 0;
     }
 
-    fn build(mut self) -> QueryResponse<stream::Iter<std::vec::IntoIter<DataRow>>> {
+    fn build(mut self) -> QueryResponse {
         let row_count = self.rows.len();
 
         // set column format
@@ -135,7 +135,7 @@ impl QueryResponseBuilder {
 
         QueryResponse {
             row_schema: self.row_schema,
-            data_rows: stream::iter(self.rows.into_iter()),
+            data_rows: Box::new(stream::iter(self.rows.into_iter())),
             tag: Tag::new_for_query(row_count),
         }
     }
@@ -177,7 +177,7 @@ impl BinaryQueryResponseBuilder {
         self.inner.finish_row();
     }
 
-    pub fn build(self) -> QueryResponse<stream::Iter<std::vec::IntoIter<DataRow>>> {
+    pub fn build(self) -> QueryResponse {
         self.inner.build()
     }
 }
@@ -214,7 +214,7 @@ impl TextQueryResponseBuilder {
         self.inner.finish_row();
     }
 
-    pub fn build(self) -> QueryResponse<stream::Iter<std::vec::IntoIter<DataRow>>> {
+    pub fn build(self) -> QueryResponse {
         self.inner.build()
     }
 }
@@ -224,8 +224,8 @@ impl TextQueryResponseBuilder {
 /// * Query: the response contains data rows
 /// * Execution: response for ddl/dml execution
 /// * Error: error response
-pub enum Response<S: Stream<Item = DataRow>> {
-    Query(QueryResponse<S>),
+pub enum Response {
+    Query(QueryResponse),
     Execution(Tag),
     Error(Box<ErrorInfo>),
 }

--- a/src/tokio.rs
+++ b/src/tokio.rs
@@ -2,8 +2,7 @@ use std::io::Error as IOError;
 use std::sync::Arc;
 
 use bytes::Buf;
-use futures::SinkExt;
-use futures::StreamExt;
+use futures::{SinkExt, StreamExt};
 use tokio::io::{AsyncRead, AsyncReadExt, AsyncWrite, AsyncWriteExt};
 use tokio::net::TcpStream;
 use tokio_rustls::TlsAcceptor;


### PR DESCRIPTION
This is the first part of #17 implementation.

This patch refactors `QueryResponse` to use async stream instead of original implementation, which buffers all `DataRow`s in memory. 