### PR TITLE
Md5 password support, and new PasswordVerifier API

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,6 +23,7 @@ async-trait = "0.1"
 rand = "0.8"
 thiserror = "1"
 postgres-types = "0.2"
+hex = "0.4"
 
 tokio = { version = "1.19", features = ["net", "rt", "io-util"], optional = true}
 tokio-util = { version = "0.7.3", features = ["codec", "io"], optional = true }
@@ -31,7 +32,6 @@ tokio-rustls = { version = "0.23", optional = true }
 [dev-dependencies]
 tokio = { version = "1.19", features = ["rt-multi-thread", "net", "macros"]}
 rusqlite = { version = "0.28.0", features = ["bundled", "column_decltype"] }
-hex = "0.4"
 ## for loading custom cert files
 rustls-pemfile = { version = "1.0" }
 ## webpki-roots has mozilla's set of roots

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,6 +24,7 @@ rand = "0.8"
 thiserror = "1"
 postgres-types = "0.2"
 hex = "0.4"
+md5 = "0.7"
 
 tokio = { version = "1.19", features = ["net", "rt", "io-util"], optional = true}
 tokio-util = { version = "0.7.3", features = ["codec", "io"], optional = true }

--- a/src/api/auth/md5pass.rs
+++ b/src/api/auth/md5pass.rs
@@ -21,8 +21,8 @@ pub struct Md5PasswordAuthStartupHandler<V, P> {
 
 fn random_salt() -> [u8; 4] {
     let mut arr = [0u8; 4];
-    for i in 0..3 {
-        arr[i] = rand::random::<u8>();
+    for v in arr.iter_mut() {
+        *v = rand::random::<u8>();
     }
 
     arr

--- a/src/api/auth/md5pass.rs
+++ b/src/api/auth/md5pass.rs
@@ -98,7 +98,7 @@ impl<V: PasswordVerifier, P: ServerParameterProvider> StartupHandler
 pub fn hash_md5_password(md5hashed_username_password: &String, salt: &[u8]) -> String {
     let hashed_bytes = md5hashed_username_password.as_bytes();
     let mut bytes = Vec::with_capacity(hashed_bytes.len() + 4);
-    bytes.extend_from_slice(&hashed_bytes);
+    bytes.extend_from_slice(hashed_bytes);
     bytes.extend_from_slice(salt);
 
     format!("md5{:x}", md5::compute(bytes))

--- a/src/api/mod.rs
+++ b/src/api/mod.rs
@@ -50,6 +50,9 @@ pub trait ClientInfo {
     fn portal_store_mut(&mut self) -> &mut dyn store::SessionStore<Arc<portal::Portal>>;
 }
 
+pub const METADATA_USER: &str = "user";
+pub const METADATA_DATABASE: &str = "database";
+
 #[derive(Debug, new, Getters, Setters, MutGetters)]
 #[getset(get = "pub", set = "pub", get_mut = "pub")]
 pub struct ClientInfoHolder {


### PR DESCRIPTION
This patch introduces support for postgresql's md5 hash password authentication method.

It also refined our password verifier to provide more context for authentication, including:

- username
- database
- host