### PR TITLE
Add Flush front-end message

### DIFF
--- a/src/messages/extendedquery.rs
+++ b/src/messages/extendedquery.rs
@@ -353,6 +353,32 @@ impl Message for Execute {
     }
 }
 
+#[derive(Getters, Setters, MutGetters, PartialEq, Eq, Debug, new)]
+#[getset(get = "pub", set = "pub", get_mut = "pub")]
+pub struct Flush;
+
+pub const MESSAGE_TYPE_BYTE_FLUSH: u8 = b'H';
+
+impl Message for Flush {
+    #[inline]
+    fn message_type() -> Option<u8> {
+        Some(MESSAGE_TYPE_BYTE_FLUSH)
+    }
+
+    #[inline]
+    fn message_length(&self) -> usize {
+        4
+    }
+
+    fn encode_body(&self, _buf: &mut bytes::BytesMut) -> PgWireResult<()> {
+        Ok(())
+    }
+
+    fn decode_body(_buf: &mut bytes::BytesMut, _: usize) -> PgWireResult<Self> {
+        Ok(Flush)
+    }
+}
+
 /// Execute portal by its name
 #[derive(Getters, Setters, MutGetters, PartialEq, Eq, Debug, new)]
 #[getset(get = "pub", set = "pub", get_mut = "pub")]

--- a/src/messages/mod.rs
+++ b/src/messages/mod.rs
@@ -59,6 +59,7 @@ pub enum PgWireFrontendMessage {
     Bind(extendedquery::Bind),
     Describe(extendedquery::Describe),
     Execute(extendedquery::Execute),
+    Flush(extendedquery::Flush),
     Sync(extendedquery::Sync),
 
     Terminate(terminate::Terminate),
@@ -80,6 +81,7 @@ impl PgWireFrontendMessage {
             Self::Close(msg) => msg.encode(buf),
             Self::Describe(msg) => msg.encode(buf),
             Self::Execute(msg) => msg.encode(buf),
+            Self::Flush(msg) => msg.encode(buf),
             Self::Sync(msg) => msg.encode(buf),
 
             Self::Terminate(msg) => msg.encode(buf),


### PR DESCRIPTION
The PostgreSQL wire protocol has a Flush front-end message to force the server to send out responses before the final Sync. Add the message definition so library users can use it.