### PR TITLE
SCRAM-SHA256-PLUS with tls-server-end-point channel binding

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,6 +28,7 @@ md5 = "0.7"
 base64 = "0.21"
 ring = "0.16"
 stringprep = "0.1.2"
+x509-certificate = "0.17"
 
 tokio = { version = "1.19", features = ["net", "rt", "io-util"], optional = true}
 tokio-util = { version = "0.7.3", features = ["codec", "io"], optional = true }

--- a/src/api/auth/scram.rs
+++ b/src/api/auth/scram.rs
@@ -92,14 +92,14 @@ impl<A, P> SASLScramAuthStartupHandler<A, P> {
         if client_channel_binding.starts_with("p=tls-server-end-point") {
             format!(
                 "{}{}",
-                base64::encode(client_channel_binding),
+                STANDARD.encode(client_channel_binding),
                 self.server_cert_sig
                     .as_deref()
                     .map(|v| &v[..])
                     .unwrap_or("")
             )
         } else {
-            base64::encode(client_channel_binding.as_bytes())
+            STANDARD.encode(client_channel_binding.as_bytes())
         }
     }
 }
@@ -274,7 +274,7 @@ impl<A, P> MakeSASLScramAuthStartupHandler<A, P> {
     /// certificate as server certificate.
     pub fn configure_certificate(&mut self, certs_pem: &[u8]) -> PgWireResult<()> {
         let sig = compute_cert_signature(certs_pem)?;
-        self.server_cert_sig = Some(Arc::new(base64::encode(sig)));
+        self.server_cert_sig = Some(Arc::new(STANDARD.encode(sig)));
         Ok(())
     }
 }

--- a/src/api/auth/scram.rs
+++ b/src/api/auth/scram.rs
@@ -368,9 +368,9 @@ impl ClientFinal {
             Ok(())
         } else {
             Err(PgWireError::InvalidScramMessage(format!(
-                "Channel binding mismatch, expect: {}, decoded: {}",
-                channel_binding,
-                String::from_utf8_lossy(decoded_channel_binding.as_slice())
+                "Channel binding mismatch, expect: {:?}, decoded: {:?}",
+                channel_binding.as_bytes(),
+                decoded_channel_binding.as_slice()
             )))
         }
     }

--- a/src/api/auth/scram.rs
+++ b/src/api/auth/scram.rs
@@ -93,7 +93,10 @@ impl<A, P> SASLScramAuthStartupHandler<A, P> {
             format!(
                 "{}{}",
                 base64::encode(client_channel_binding),
-                self.server_cert_sig.as_ref().unwrap()
+                self.server_cert_sig
+                    .as_deref()
+                    .map(|v| &v[..])
+                    .unwrap_or("")
             )
         } else {
             base64::encode(client_channel_binding.as_bytes())

--- a/src/error.rs
+++ b/src/error.rs
@@ -29,6 +29,8 @@ pub enum PgWireError {
     FailedToParseParameter(Box<dyn std::error::Error + Send + Sync>),
     #[error("Failed to parse scram message: {0}")]
     InvalidScramMessage(String),
+    #[error("Certificate algorithm is not supported")]
+    UnsupportedCertificateSignatureAlgorithm,
     #[error("Username is required")]
     UserNameRequired,
 


### PR DESCRIPTION
This patch implements `SCRAM-SHA256-PLUS` with `tls-server-end-point` channel binding. It uses server certificate for channel binding. TLS is required when using `SCRAM-SHA256-PLUS` 