### PR TITLE
Stateful extended query apis

### DIFF
--- a/examples/gluesql.rs
+++ b/examples/gluesql.rs
@@ -2,6 +2,8 @@ use std::sync::{Arc, Mutex};
 
 use async_trait::async_trait;
 use futures::stream;
+use pgwire::api::stmt::NoopQueryParser;
+use pgwire::api::store::MemPortalStore;
 use tokio::net::TcpListener;
 
 use gluesql::prelude::*;
@@ -14,7 +16,6 @@ use pgwire::error::{PgWireError, PgWireResult};
 use pgwire::tokio::process_socket;
 
 pub struct GluesqlProcessor {
-    // TODO: mutex
     glue: Arc<Mutex<Glue<MemoryStorage>>>,
 }
 
@@ -114,10 +115,22 @@ impl SimpleQueryHandler for GluesqlProcessor {
 
 #[async_trait]
 impl ExtendedQueryHandler for GluesqlProcessor {
+    type Statement = String;
+    type PortalStore = MemPortalStore<Self::Statement>;
+    type QueryParser = NoopQueryParser;
+
+    fn portal_store(&self) -> Arc<Self::PortalStore> {
+        todo!()
+    }
+
+    fn query_parser(&self) -> Arc<Self::QueryParser> {
+        todo!()
+    }
+
     async fn do_query<C>(
         &self,
         _client: &mut C,
-        _portal: &Portal,
+        _portal: &Portal<Self::Statement>,
         _max_rows: usize,
     ) -> PgWireResult<Response>
     where

--- a/examples/scram.rs
+++ b/examples/scram.rs
@@ -4,6 +4,7 @@ use std::sync::Arc;
 
 use async_trait::async_trait;
 
+use pgwire::api::stmt::NoopQueryParser;
 use rustls_pemfile::{certs, pkcs8_private_keys};
 use tokio::net::TcpListener;
 use tokio_rustls::rustls::{Certificate, PrivateKey, ServerConfig};
@@ -14,6 +15,7 @@ use pgwire::api::auth::DefaultServerParameterProvider;
 use pgwire::api::portal::Portal;
 use pgwire::api::query::{ExtendedQueryHandler, SimpleQueryHandler};
 use pgwire::api::results::{Response, Tag};
+use pgwire::api::store::MemPortalStore;
 use pgwire::api::{ClientInfo, StatelessMakeHandler};
 use pgwire::error::PgWireResult;
 use pgwire::tokio::process_socket;
@@ -35,16 +37,28 @@ impl SimpleQueryHandler for DummyProcessor {
 
 #[async_trait]
 impl ExtendedQueryHandler for DummyProcessor {
+    type Statement = String;
+    type PortalStore = MemPortalStore<Self::Statement>;
+    type QueryParser = NoopQueryParser;
+
+    fn portal_store(&self) -> Arc<Self::PortalStore> {
+        todo!()
+    }
+
+    fn query_parser(&self) -> Arc<Self::QueryParser> {
+        todo!()
+    }
+
     async fn do_query<C>(
         &self,
         _client: &mut C,
-        _portal: &Portal,
+        _portal: &Portal<Self::Statement>,
         _max_rows: usize,
     ) -> PgWireResult<Response>
     where
         C: ClientInfo + Unpin + Send + Sync,
     {
-        Ok(Response::Execution(Tag::new_for_execution("OK", Some(1))))
+        todo!()
     }
 }
 

--- a/examples/secure_server.rs
+++ b/examples/secure_server.rs
@@ -4,6 +4,8 @@ use std::sync::Arc;
 
 use async_trait::async_trait;
 use futures::stream;
+use pgwire::api::stmt::NoopQueryParser;
+use pgwire::api::store::MemPortalStore;
 use rustls_pemfile::{certs, pkcs8_private_keys};
 use tokio::net::TcpListener;
 use tokio_rustls::rustls::{Certificate, PrivateKey, ServerConfig};
@@ -58,11 +60,23 @@ impl SimpleQueryHandler for DummyProcessor {
 
 #[async_trait]
 impl ExtendedQueryHandler for DummyProcessor {
+    type Statement = String;
+    type PortalStore = MemPortalStore<Self::Statement>;
+    type QueryParser = NoopQueryParser;
+
+    fn portal_store(&self) -> Arc<Self::PortalStore> {
+        todo!()
+    }
+
+    fn query_parser(&self) -> Arc<Self::QueryParser> {
+        todo!()
+    }
+
     async fn do_query<C>(
         &self,
         _client: &mut C,
-        _portal: &Portal,
-        _max_row: usize,
+        _portal: &Portal<Self::Statement>,
+        _max_rows: usize,
     ) -> PgWireResult<Response>
     where
         C: ClientInfo + Unpin + Send + Sync,

--- a/examples/server.rs
+++ b/examples/server.rs
@@ -2,6 +2,8 @@ use std::sync::Arc;
 
 use async_trait::async_trait;
 use futures::{stream, StreamExt};
+use pgwire::api::stmt::NoopQueryParser;
+use pgwire::api::store::MemPortalStore;
 use tokio::net::TcpListener;
 
 use pgwire::api::auth::noop::NoopStartupHandler;
@@ -53,10 +55,22 @@ impl SimpleQueryHandler for DummyProcessor {
 
 #[async_trait]
 impl ExtendedQueryHandler for DummyProcessor {
+    type Statement = String;
+    type PortalStore = MemPortalStore<Self::Statement>;
+    type QueryParser = NoopQueryParser;
+
+    fn portal_store(&self) -> Arc<Self::PortalStore> {
+        todo!()
+    }
+
+    fn query_parser(&self) -> Arc<Self::QueryParser> {
+        todo!()
+    }
+
     async fn do_query<C>(
         &self,
         _client: &mut C,
-        _portal: &Portal,
+        _portal: &Portal<Self::Statement>,
         _max_rows: usize,
     ) -> PgWireResult<Response>
     where

--- a/src/api/mod.rs
+++ b/src/api/mod.rs
@@ -35,14 +35,6 @@ pub trait ClientInfo {
     fn metadata(&self) -> &HashMap<String, String>;
 
     fn metadata_mut(&mut self) -> &mut HashMap<String, String>;
-
-    fn stmt_store(&self) -> &dyn store::SessionStore<Arc<stmt::Statement>>;
-
-    fn stmt_store_mut(&mut self) -> &mut dyn store::SessionStore<Arc<stmt::Statement>>;
-
-    fn portal_store(&self) -> &dyn store::SessionStore<Arc<portal::Portal>>;
-
-    fn portal_store_mut(&mut self) -> &mut dyn store::SessionStore<Arc<portal::Portal>>;
 }
 
 pub const METADATA_USER: &str = "user";

--- a/src/api/mod.rs
+++ b/src/api/mod.rs
@@ -49,10 +49,6 @@ pub struct ClientInfoHolder {
     state: PgWireConnectionState,
     #[new(default)]
     metadata: HashMap<String, String>,
-    #[new(default)]
-    portal_store: store::MemSessionStore<portal::Portal>,
-    #[new(default)]
-    stmt_store: store::MemSessionStore<stmt::Statement>,
 }
 
 pub trait MakeHandler {

--- a/src/api/portal.rs
+++ b/src/api/portal.rs
@@ -9,7 +9,7 @@ use crate::{
     },
 };
 
-use super::{stmt::StoredStatement, ClientInfo, DEFAULT_NAME};
+use super::{stmt::StoredStatement, DEFAULT_NAME};
 
 /// Represent a prepared sql statement and its parameters bound by a `Bind`
 /// request.
@@ -57,16 +57,9 @@ impl Format {
 
 impl<S: Clone> Portal<S> {
     /// Try to create portal from bind command and current client state
-    pub fn try_new<C>(bind: &Bind, statement: &StoredStatement<S>) -> PgWireResult<Self>
-    where
-        C: ClientInfo,
-    {
+    pub fn try_new(bind: &Bind, statement: &StoredStatement<S>) -> PgWireResult<Self> {
         let portal_name = bind
             .portal_name()
-            .clone()
-            .unwrap_or_else(|| DEFAULT_NAME.to_owned());
-        let statement_name = bind
-            .statement_name()
             .clone()
             .unwrap_or_else(|| DEFAULT_NAME.to_owned());
 

--- a/src/api/portal.rs
+++ b/src/api/portal.rs
@@ -9,7 +9,7 @@ use crate::{
     },
 };
 
-use super::{ClientInfo, DEFAULT_NAME};
+use super::{stmt::StoredStatement, ClientInfo, DEFAULT_NAME};
 
 /// Represent a prepared sql statement and its parameters bound by a `Bind`
 /// request.
@@ -55,9 +55,9 @@ impl Format {
     }
 }
 
-impl<S> Portal<S> {
+impl<S: Clone> Portal<S> {
     /// Try to create portal from bind command and current client state
-    pub fn try_new<C>(bind: &Bind, statement: &StoredStatement) -> PgWireResult<Portal>
+    pub fn try_new<C>(bind: &Bind, statement: &StoredStatement<S>) -> PgWireResult<Self>
     where
         C: ClientInfo,
     {
@@ -88,7 +88,7 @@ impl<S> Portal<S> {
 
         Ok(Portal {
             name: portal_name,
-            statement: statement.statement().to_owned(),
+            statement: statement.statement().clone(),
             parameter_types: types,
             parameter_format: format,
             parameters: bind.parameters().clone(),

--- a/src/api/portal.rs
+++ b/src/api/portal.rs
@@ -15,9 +15,9 @@ use super::{ClientInfo, DEFAULT_NAME};
 /// request.
 #[derive(Debug, CopyGetters, Default, Getters, Setters, Clone)]
 #[getset(get = "pub", set = "pub", get_mut = "pub")]
-pub struct Portal {
+pub struct Portal<S> {
     name: String,
-    statement: String,
+    statement: S,
     parameter_types: Vec<Type>,
     parameter_format: Format,
     parameters: Vec<Option<Bytes>>,
@@ -55,9 +55,9 @@ impl Format {
     }
 }
 
-impl Portal {
+impl<S> Portal<S> {
     /// Try to create portal from bind command and current client state
-    pub fn try_new<C>(bind: &Bind, client: &C) -> PgWireResult<Portal>
+    pub fn try_new<C>(bind: &Bind, statement: &StoredStatement) -> PgWireResult<Portal>
     where
         C: ClientInfo,
     {
@@ -69,10 +69,6 @@ impl Portal {
             .statement_name()
             .clone()
             .unwrap_or_else(|| DEFAULT_NAME.to_owned());
-        let statement = client
-            .stmt_store()
-            .get(&statement_name)
-            .ok_or_else(|| PgWireError::StatementNotFound(statement_name.clone()))?;
 
         // types
         let mut types = Vec::new();

--- a/src/api/query.rs
+++ b/src/api/query.rs
@@ -72,6 +72,7 @@ pub trait SimpleQueryHandler: Send + Sync {
         C: ClientInfo + Unpin + Send + Sync;
 }
 
+// FIXME: sqlparser and portal store
 #[async_trait]
 pub trait ExtendedQueryHandler: Send + Sync {
     async fn on_parse<C>(&self, client: &mut C, message: Parse) -> PgWireResult<()>

--- a/src/api/results.rs
+++ b/src/api/results.rs
@@ -106,7 +106,8 @@ impl BinaryDataRowEncoder {
     {
         let mut buffer = BytesMut::with_capacity(8);
         if let IsNull::No = value.to_sql(&self.row_schema[self.col_index].datatype, &mut buffer)? {
-            self.buffer.fields_mut().push(Some(buffer.split().freeze()));
+            let buf = buffer.split().freeze();
+            self.buffer.fields_mut().push(Some(buf));
         } else {
             self.buffer.fields_mut().push(None);
         };

--- a/src/api/stmt.rs
+++ b/src/api/stmt.rs
@@ -32,8 +32,22 @@ impl<S> StoredStatement<S> {
     }
 }
 
+/// Trait for sql parser. The parser transforms string query into its statement
+/// type.
 pub trait QueryParser {
     type Statement;
 
     fn parse_sql(&self, sql: &str) -> PgWireResult<Self::Statement>;
+}
+
+/// A demo parser implementation. Never use it in serious application.
+#[derive(new, Debug)]
+pub struct NoopQueryParser;
+
+impl QueryParser for NoopQueryParser {
+    type Statement = String;
+
+    fn parse_sql(&self, sql: &str) -> PgWireResult<Self::Statement> {
+        Ok(sql.to_owned())
+    }
 }

--- a/src/api/stmt.rs
+++ b/src/api/stmt.rs
@@ -1,5 +1,6 @@
 use postgres_types::Oid;
 
+use crate::error::PgWireResult;
 use crate::messages::extendedquery::Parse;
 
 use super::DEFAULT_NAME;
@@ -15,17 +16,19 @@ pub struct StoredStatement<S> {
     type_oids: Vec<Oid>,
 }
 
-pub(crate) fn parse<S>(
-    parse: &Parse,
-    parser: &QueryParser<Statement = S>,
-) -> PgWireResult<StoredStatement<S>> {
-    StoredStatement {
-        id: parse
-            .name()
-            .clone()
-            .unwrap_or_else(|| DEFAULT_NAME.to_owned()),
-        statement: parser.parse_sql(parse.query())?,
-        type_oids: parse.type_oids().clone(),
+impl<S> StoredStatement<S> {
+    pub(crate) fn parse<Q>(parse: &Parse, parser: &Q) -> PgWireResult<StoredStatement<S>>
+    where
+        Q: QueryParser<Statement = S>,
+    {
+        Ok(StoredStatement {
+            id: parse
+                .name()
+                .clone()
+                .unwrap_or_else(|| DEFAULT_NAME.to_owned()),
+            statement: parser.parse_sql(parse.query())?,
+            type_oids: parse.type_oids().clone(),
+        })
     }
 }
 

--- a/src/api/stmt.rs
+++ b/src/api/stmt.rs
@@ -6,24 +6,31 @@ use super::DEFAULT_NAME;
 
 #[derive(Debug, Default, new, Getters, Setters)]
 #[getset(get = "pub", set = "pub", get_mut = "pub")]
-pub struct Statement {
+pub struct StoredStatement<S> {
     // name of the statement, empty string for unnamed
     id: String,
     // query statement
-    statement: String,
+    statement: S,
     // type ids of query parameters
     type_oids: Vec<Oid>,
 }
 
-impl From<&Parse> for Statement {
-    fn from(parse: &Parse) -> Statement {
-        Statement {
-            id: parse
-                .name()
-                .clone()
-                .unwrap_or_else(|| DEFAULT_NAME.to_owned()),
-            statement: parse.query().clone(),
-            type_oids: parse.type_oids().clone(),
-        }
+pub(crate) fn parse<S>(
+    parse: &Parse,
+    parser: &QueryParser<Statement = S>,
+) -> PgWireResult<StoredStatement<S>> {
+    StoredStatement {
+        id: parse
+            .name()
+            .clone()
+            .unwrap_or_else(|| DEFAULT_NAME.to_owned()),
+        statement: parser.parse_sql(parse.query())?,
+        type_oids: parse.type_oids().clone(),
     }
+}
+
+pub trait QueryParser {
+    type Statement;
+
+    fn parse_sql(&self, sql: &str) -> PgWireResult<Self::Statement>;
 }

--- a/src/api/store.rs
+++ b/src/api/store.rs
@@ -1,20 +1,23 @@
 use std::collections::BTreeMap;
 use std::sync::{Arc, RwLock};
 
+use super::portal::Portal;
+use super::stmt::StoredStatement;
+
 pub trait PortalStore {
     type Statement;
 
-    fn put_statement(&mut self, name: &str, statement: StoredStatement<Self::Statement>);
+    fn put_statement(&self, name: &str, statement: StoredStatement<Self::Statement>);
 
-    fn rm_statement(&mut self, name: &str);
+    fn rm_statement(&self, name: &str);
 
     fn get_statement(&self, name: &str) -> Option<Arc<StoredStatement<Self::Statement>>>;
 
-    fn put_portal(&mut self, name: &str, portal: Portal<Self::Statement>);
+    fn put_portal(&self, name: &str, portal: Portal<Self::Statement>);
 
-    fn rm_portal(&mut self, name: &str);
+    fn rm_portal(&self, name: &str);
 
-    fn get_portal(&self, name: &str) -> Option<Arc<Self::Portal<Self::Statement>>>;
+    fn get_portal(&self, name: &str) -> Option<Arc<Portal<Self::Statement>>>;
 }
 
 #[derive(Debug, Default)]
@@ -23,35 +26,35 @@ pub struct MemPortalStore<S> {
     portals: RwLock<BTreeMap<String, Arc<Portal<S>>>>,
 }
 
-impl<S> PortalStore for MemPortalStore<S> {
+impl<S: Clone> PortalStore for MemPortalStore<S> {
     type Statement = S;
 
-    fn put_statement(&mut self, name: &str, statement: StoredStatement<Self::Statement>) {
+    fn put_statement(&self, name: &str, statement: StoredStatement<Self::Statement>) {
         let mut guard = self.statements.write().unwrap();
         guard.insert(name.to_owned(), Arc::new(statement));
     }
 
-    fn rm_statement(&mut self, name: &str) {
+    fn rm_statement(&self, name: &str) {
         let mut guard = self.statements.write().unwrap();
         guard.remove(name);
     }
 
-    fn get_statement(&self, name: &str) -> Arc<StoredStatement<Self::Statement>> {
+    fn get_statement(&self, name: &str) -> Option<Arc<StoredStatement<Self::Statement>>> {
         let guard = self.statements.read().unwrap();
         guard.get(name).cloned()
     }
 
-    fn put_portal(&mut self, name: &str, portal: Portal<Self::Statement>) {
+    fn put_portal(&self, name: &str, portal: Portal<Self::Statement>) {
         let mut guard = self.portals.write().unwrap();
-        guard.insert(name.to_owned(), Arc::new(statement));
+        guard.insert(name.to_owned(), Arc::new(portal));
     }
 
-    fn rm_portal(&mut self, name: &str) {
+    fn rm_portal(&self, name: &str) {
         let mut guard = self.portals.write().unwrap();
         guard.remove(name);
     }
 
-    fn get_portal(&self, name: &str) -> Arc<Self::Portal<Self::Statement>> {
+    fn get_portal(&self, name: &str) -> Option<Arc<Portal<Self::Statement>>> {
         let mut guard = self.portals.read().unwrap();
         guard.get(name).cloned()
     }

--- a/src/api/store.rs
+++ b/src/api/store.rs
@@ -20,9 +20,11 @@ pub trait PortalStore: Send + Sync {
     fn get_portal(&self, name: &str) -> Option<Arc<Portal<Self::Statement>>>;
 }
 
-#[derive(Debug, Default)]
+#[derive(Debug, Default, new)]
 pub struct MemPortalStore<S> {
+    #[new(default)]
     statements: RwLock<BTreeMap<String, Arc<StoredStatement<S>>>>,
+    #[new(default)]
     portals: RwLock<BTreeMap<String, Arc<Portal<S>>>>,
 }
 

--- a/src/messages/extendedquery.rs
+++ b/src/messages/extendedquery.rs
@@ -286,9 +286,11 @@ impl Message for BindComplete {
 
 /// Describe command fron frontend to backend. For getting information of
 /// particular portal or statement
-#[derive(Getters, Setters, MutGetters, PartialEq, Eq, Debug, new)]
+#[derive(Getters, Setters, CopyGetters, MutGetters, PartialEq, Eq, Debug, new)]
 #[getset(get = "pub", set = "pub", get_mut = "pub")]
 pub struct Describe {
+    #[getset(skip)]
+    #[getset(get_copy = "pub", set = "pub")]
     target_type: u8,
     name: Option<String>,
 }

--- a/src/tokio.rs
+++ b/src/tokio.rs
@@ -13,8 +13,6 @@ use crate::api::auth::StartupHandler;
 use crate::api::portal::Portal;
 use crate::api::query::ExtendedQueryHandler;
 use crate::api::query::SimpleQueryHandler;
-use crate::api::stmt::Statement;
-use crate::api::store::SessionStore;
 use crate::api::{ClientInfo, ClientInfoHolder, MakeHandler, PgWireConnectionState};
 use crate::error::{ErrorInfo, PgWireError, PgWireResult};
 use crate::messages::response::ReadyForQuery;
@@ -81,22 +79,6 @@ impl<T> ClientInfo for Framed<T, PgWireMessageServerCodec> {
 
     fn metadata_mut(&mut self) -> &mut std::collections::HashMap<String, String> {
         self.codec_mut().client_info_mut().metadata_mut()
-    }
-
-    fn stmt_store(&self) -> &dyn SessionStore<Arc<Statement>> {
-        self.codec().client_info().stmt_store()
-    }
-
-    fn stmt_store_mut(&mut self) -> &mut dyn SessionStore<Arc<Statement>> {
-        self.codec_mut().client_info_mut().stmt_store_mut()
-    }
-
-    fn portal_store(&self) -> &dyn SessionStore<Arc<Portal>> {
-        self.codec().client_info().portal_store()
-    }
-
-    fn portal_store_mut(&mut self) -> &mut dyn SessionStore<Arc<Portal>> {
-        self.codec_mut().client_info_mut().portal_store_mut()
     }
 }
 

--- a/src/tokio.rs
+++ b/src/tokio.rs
@@ -10,7 +10,6 @@ use tokio_rustls::TlsAcceptor;
 use tokio_util::codec::{Decoder, Encoder, Framed};
 
 use crate::api::auth::StartupHandler;
-use crate::api::portal::Portal;
 use crate::api::query::ExtendedQueryHandler;
 use crate::api::query::SimpleQueryHandler;
 use crate::api::{ClientInfo, ClientInfoHolder, MakeHandler, PgWireConnectionState};


### PR DESCRIPTION
This patch resigned our `ExtendedQueryHandler` with following updates:

- Assume all `ExtendedQueryHandler`s are stateful (a handler for each connection)
- Move cached statements and portals to `PortalStore`, and `PortalStore` is associated with `ExtendedQueryHandler` instead of `ClientInfo`.
- Abstract `QueryParser` trait for `parse` step. `Portal` and `StoredStatement` now stores parsed statement instead of raw query string

See `sqlite` example for its usage.