### PR TITLE
Add do_describe to ExtendedQueryHandler

### DIFF
--- a/examples/gluesql.rs
+++ b/examples/gluesql.rs
@@ -2,14 +2,11 @@ use std::sync::{Arc, Mutex};
 
 use async_trait::async_trait;
 use futures::stream;
-use pgwire::api::stmt::NoopQueryParser;
-use pgwire::api::store::MemPortalStore;
 use tokio::net::TcpListener;
 
 use gluesql::prelude::*;
 use pgwire::api::auth::noop::NoopStartupHandler;
-use pgwire::api::portal::Portal;
-use pgwire::api::query::{ExtendedQueryHandler, SimpleQueryHandler};
+use pgwire::api::query::{PlaceholderExtendedQueryHandler, SimpleQueryHandler};
 use pgwire::api::results::{text_query_response, FieldInfo, Response, Tag, TextDataRowEncoder};
 use pgwire::api::{ClientInfo, StatelessMakeHandler, Type};
 use pgwire::error::{PgWireError, PgWireResult};
@@ -113,33 +110,6 @@ impl SimpleQueryHandler for GluesqlProcessor {
     }
 }
 
-#[async_trait]
-impl ExtendedQueryHandler for GluesqlProcessor {
-    type Statement = String;
-    type PortalStore = MemPortalStore<Self::Statement>;
-    type QueryParser = NoopQueryParser;
-
-    fn portal_store(&self) -> Arc<Self::PortalStore> {
-        todo!()
-    }
-
-    fn query_parser(&self) -> Arc<Self::QueryParser> {
-        todo!()
-    }
-
-    async fn do_query<C>(
-        &self,
-        _client: &mut C,
-        _portal: &Portal<Self::Statement>,
-        _max_rows: usize,
-    ) -> PgWireResult<Response>
-    where
-        C: ClientInfo + Unpin + Send + Sync,
-    {
-        todo!()
-    }
-}
-
 #[tokio::main]
 pub async fn main() {
     let gluesql = GluesqlProcessor {
@@ -147,6 +117,10 @@ pub async fn main() {
     };
 
     let processor = Arc::new(StatelessMakeHandler::new(Arc::new(gluesql)));
+    // We have not implemented extended query in this server, use placeholder instead
+    let placeholder = Arc::new(StatelessMakeHandler::new(Arc::new(
+        PlaceholderExtendedQueryHandler,
+    )));
     let authenticator = Arc::new(StatelessMakeHandler::new(Arc::new(NoopStartupHandler)));
 
     let server_addr = "127.0.0.1:5432";
@@ -156,13 +130,14 @@ pub async fn main() {
         let incoming_socket = listener.accept().await.unwrap();
         let authenticator_ref = authenticator.clone();
         let processor_ref = processor.clone();
+        let placeholder_ref = placeholder.clone();
         tokio::spawn(async move {
             process_socket(
                 incoming_socket.0,
                 None,
                 authenticator_ref,
-                processor_ref.clone(),
                 processor_ref,
+                placeholder_ref,
             )
             .await
         });

--- a/src/api/portal.rs
+++ b/src/api/portal.rs
@@ -22,9 +22,6 @@ pub struct Portal<S> {
     parameter_format: Format,
     parameters: Vec<Option<Bytes>>,
     result_column_format_codes: Vec<i16>,
-    #[getset(skip)]
-    #[getset(get_copy = "pub", set = "pub")]
-    row_description_requested: bool,
 }
 
 #[derive(Debug, Clone, Default)]
@@ -86,7 +83,6 @@ impl<S: Clone> Portal<S> {
             parameter_format: format,
             parameters: bind.parameters().clone(),
             result_column_format_codes: bind.result_column_format_codes().clone(),
-            row_description_requested: false,
         })
     }
 

--- a/src/api/query.rs
+++ b/src/api/query.rs
@@ -7,8 +7,8 @@ use futures::stream::StreamExt;
 
 use super::portal::Portal;
 use super::results::{into_row_description, FieldInfo, Tag};
-use super::stmt::{QueryParser, StoredStatement};
-use super::store::PortalStore;
+use super::stmt::{NoopQueryParser, QueryParser, StoredStatement};
+use super::store::{MemPortalStore, PortalStore};
 use super::{ClientInfo, DEFAULT_NAME};
 use crate::api::results::{QueryResponse, Response};
 use crate::error::{PgWireError, PgWireResult};
@@ -283,4 +283,48 @@ where
         .await?;
 
     Ok(())
+}
+
+/// A placeholder extended query handler. It panics when extended query messages
+/// received. This handler is for demo only, never use it in serious
+/// application.
+#[derive(Debug, Clone)]
+pub struct PlaceholderExtendedQueryHandler;
+
+#[async_trait]
+impl ExtendedQueryHandler for PlaceholderExtendedQueryHandler {
+    type Statement = String;
+    type PortalStore = MemPortalStore<Self::Statement>;
+    type QueryParser = NoopQueryParser;
+
+    fn portal_store(&self) -> Arc<Self::PortalStore> {
+        unimplemented!("Extended Query is not implemented on this server.")
+    }
+
+    fn query_parser(&self) -> Arc<Self::QueryParser> {
+        unimplemented!("Extended Query is not implemented on this server.")
+    }
+
+    async fn do_query<C>(
+        &self,
+        _client: &mut C,
+        _portal: &Portal<Self::Statement>,
+        _max_rows: usize,
+    ) -> PgWireResult<Response>
+    where
+        C: ClientInfo + Unpin + Send + Sync,
+    {
+        unimplemented!("Extended Query is not implemented on this server.")
+    }
+
+    async fn do_describe<C>(
+        &self,
+        _client: &mut C,
+        _statement: &Self::Statement,
+    ) -> PgWireResult<Vec<FieldInfo>>
+    where
+        C: ClientInfo + Unpin + Send + Sync,
+    {
+        unimplemented!("Extended Query is not implemented on this server.")
+    }
 }

--- a/src/api/query.rs
+++ b/src/api/query.rs
@@ -6,7 +6,7 @@ use futures::sink::{Sink, SinkExt};
 use futures::stream::StreamExt;
 
 use super::portal::Portal;
-use super::results::{into_row_description, Tag};
+use super::results::{into_row_description, FieldInfo, Tag};
 use super::stmt::{QueryParser, StoredStatement};
 use super::store::PortalStore;
 use super::{ClientInfo, DEFAULT_NAME};
@@ -43,7 +43,7 @@ pub trait SimpleQueryHandler: Send + Sync {
             for r in resp {
                 match r {
                     Response::Query(results) => {
-                        send_query_response(client, results, true).await?;
+                        send_query_response(client, results).await?;
                     }
                     Response::Execution(tag) => {
                         send_execution_response(client, tag).await?;
@@ -127,8 +127,7 @@ pub trait ExtendedQueryHandler: Send + Sync {
                 .await?
             {
                 Response::Query(results) => {
-                    send_query_response(client, results, portal.row_description_requested())
-                        .await?;
+                    send_query_response(client, results).await?;
                 }
                 Response::Execution(tag) => {
                     send_execution_response(client, tag).await?;
@@ -152,26 +151,36 @@ pub trait ExtendedQueryHandler: Send + Sync {
         // TODO: clear/remove portal?
     }
 
-    async fn on_describe<C>(&self, _client: &mut C, message: Describe) -> PgWireResult<()>
+    async fn on_describe<C>(&self, client: &mut C, message: Describe) -> PgWireResult<()>
     where
         C: ClientInfo + Sink<PgWireBackendMessage> + Unpin + Send + Sync,
         C::Error: Debug,
         PgWireError: From<<C as Sink<PgWireBackendMessage>>::Error>,
     {
         let name = message.name().as_deref().unwrap_or(DEFAULT_NAME);
-        match message.target_type() {
-            TARGET_TYPE_BYTE_STATEMENT => Ok(()),
-            TARGET_TYPE_BYTE_PORTAL => {
-                if let Some(mut portal) = self.portal_store().get_portal(name) {
-                    Arc::make_mut(&mut portal).set_row_description_requested(true);
-                    self.portal_store().put_portal(portal);
-                    Ok(())
+        let row_schema = match message.target_type() {
+            TARGET_TYPE_BYTE_STATEMENT => {
+                if let Some(stmt) = self.portal_store().get_statement(name) {
+                    self.do_describe(client, stmt.statement()).await
                 } else {
-                    Err(PgWireError::PortalNotFound(name.to_owned()))
+                    return Err(PgWireError::StatementNotFound(name.to_owned()));
                 }
             }
-            _ => Ok(()),
-        }
+            TARGET_TYPE_BYTE_PORTAL => {
+                if let Some(portal) = self.portal_store().get_portal(name) {
+                    self.do_describe(client, portal.statement()).await
+                } else {
+                    return Err(PgWireError::PortalNotFound(name.to_owned()));
+                }
+            }
+            _ => return Err(PgWireError::InvalidTargetType(message.target_type())),
+        }?;
+
+        let row_desc = into_row_description(row_schema);
+        client
+            .send(PgWireBackendMessage::RowDescription(row_desc))
+            .await?;
+        Ok(())
     }
 
     async fn on_sync<C>(&self, client: &mut C, _message: PgSync) -> PgWireResult<()>
@@ -203,6 +212,15 @@ pub trait ExtendedQueryHandler: Send + Sync {
         Ok(())
     }
 
+    /// Return resultset metadata without actually execute statement or portal
+    async fn do_describe<C>(
+        &self,
+        client: &mut C,
+        statement: &Self::Statement,
+    ) -> PgWireResult<Vec<FieldInfo>>
+    where
+        C: ClientInfo + Unpin + Send + Sync;
+
     /// This is the main implementation for query execution. Context has
     /// been provided:
     ///
@@ -219,11 +237,7 @@ pub trait ExtendedQueryHandler: Send + Sync {
         C: ClientInfo + Unpin + Send + Sync;
 }
 
-async fn send_query_response<C>(
-    client: &mut C,
-    results: QueryResponse,
-    row_desc_required: bool,
-) -> PgWireResult<()>
+async fn send_query_response<C>(client: &mut C, results: QueryResponse) -> PgWireResult<()>
 where
     C: ClientInfo + Sink<PgWireBackendMessage> + Unpin + Send + Sync,
     C::Error: Debug,
@@ -234,7 +248,9 @@ where
         mut data_rows,
     } = results;
 
-    if row_desc_required {
+    // Simple query has row_schema in query response. For extended query,
+    // row_schema is returned as response of `Describe`.
+    if let Some(row_schema) = row_schema {
         let row_desc = into_row_description(row_schema);
         client
             .send(PgWireBackendMessage::RowDescription(row_desc))

--- a/src/error.rs
+++ b/src/error.rs
@@ -11,6 +11,8 @@ pub enum PgWireError {
     InvalidProtocolVersion(i32),
     #[error("Invalid message recevied, received {0}")]
     InvalidMessageType(u8),
+    #[error("Invalid target type, received {0}")]
+    InvalidTargetType(u8),
     #[error(transparent)]
     IoError(#[from] std::io::Error),
     #[error("Portal not found for name: {0:?}")]


### PR DESCRIPTION
This patch updates query apis to deal with `Describe` and `Execute` separately. Now it's possible to return `RowDescription` without actually executing the query. `Describe` on prepared statement is also supported.

Fixes #40 
Fixes #29 

As our `ExtendedQueryHandler` is getting bigger, we provide a placeholder implementation for those doesn't implement it in their application.