### PR TITLE
Unifying AuthSource APIs for various authentication mechanism

### DIFF
--- a/src/api/auth/md5pass.rs
+++ b/src/api/auth/md5pass.rs
@@ -3,11 +3,11 @@ use std::sync::Arc;
 
 use async_trait::async_trait;
 use futures::sink::{Sink, SinkExt};
-use rand;
+use tokio::sync::Mutex;
 
 use super::{
-    ClientInfo, HashedPassword, LoginInfo, Password, PasswordVerifier, PgWireConnectionState,
-    ServerParameterProvider, StartupHandler,
+    AuthSource, ClientInfo, LoginInfo, PgWireConnectionState, ServerParameterProvider,
+    StartupHandler,
 };
 use crate::api::MakeHandler;
 use crate::error::{ErrorInfo, PgWireError, PgWireResult};
@@ -15,24 +15,15 @@ use crate::messages::response::ErrorResponse;
 use crate::messages::startup::Authentication;
 use crate::messages::{PgWireBackendMessage, PgWireFrontendMessage};
 
-pub struct Md5PasswordAuthStartupHandler<V, P> {
-    verifier: Arc<V>,
+pub struct Md5PasswordAuthStartupHandler<A, P> {
+    auth_source: Arc<A>,
     parameter_provider: Arc<P>,
-    salt: [u8; 4],
-}
-
-fn random_salt() -> [u8; 4] {
-    let mut arr = [0u8; 4];
-    for v in arr.iter_mut() {
-        *v = rand::random::<u8>();
-    }
-
-    arr
+    cached_password: Mutex<Vec<u8>>,
 }
 
 #[async_trait]
-impl<V: PasswordVerifier, P: ServerParameterProvider> StartupHandler
-    for Md5PasswordAuthStartupHandler<V, P>
+impl<A: AuthSource, P: ServerParameterProvider> StartupHandler
+    for Md5PasswordAuthStartupHandler<A, P>
 {
     async fn on_startup<C>(
         &self,
@@ -48,18 +39,28 @@ impl<V: PasswordVerifier, P: ServerParameterProvider> StartupHandler
             PgWireFrontendMessage::Startup(ref startup) => {
                 super::save_startup_parameters_to_metadata(client, startup);
                 client.set_state(PgWireConnectionState::AuthenticationInProgress);
+
+                let login_info = LoginInfo::from_client_info(client);
+                let salt_and_pass = self.auth_source.get_password(&login_info).await?;
+
+                let salt = salt_and_pass
+                    .salt()
+                    .as_ref()
+                    .expect("Salt is required for Md5Password authentication");
+
+                *self.cached_password.lock().await = salt_and_pass.password().clone();
+
                 client
                     .send(PgWireBackendMessage::Authentication(
-                        Authentication::MD5Password(self.salt),
+                        Authentication::MD5Password(salt.clone()),
                     ))
                     .await?;
             }
             PgWireFrontendMessage::PasswordMessageFamily(pwd) => {
                 let pwd = pwd.into_password()?;
-                let login_info = LoginInfo::from_client_info(client);
+                let cached_pass = self.cached_password.lock().await;
 
-                let passwd = Password::Hashed(HashedPassword::new(&self.salt, pwd.password()));
-                if let Ok(true) = self.verifier.verify_password(login_info, passwd).await {
+                if pwd.password().as_bytes() == *cached_pass {
                     super::finish_authentication(client, self.parameter_provider.as_ref()).await
                 } else {
                     let error_info = ErrorInfo::new(
@@ -81,25 +82,25 @@ impl<V: PasswordVerifier, P: ServerParameterProvider> StartupHandler
     }
 }
 
-/// this function is to compute postgres standard md5 hashed password
+/// This function is to compute postgres standard md5 hashed password
 ///
 /// concat('md5', md5(concat(md5(concat(password, username)), random-salt)))
 ///
 /// the input parameter `md5hashed_username_password` represents
 /// `md5(concat(password, username))` so that your can store hashed password in
 /// storage.
-pub fn hash_md5_password(md5hashed_username_password: &String, salt: &[u8]) -> String {
-    let hashed_bytes = md5hashed_username_password.as_bytes();
+pub fn hash_md5_password(username: &str, password: &str, salt: &[u8]) -> String {
+    let hashed_bytes = format!("{:x}", md5::compute(format!("{password}{username}")));
     let mut bytes = Vec::with_capacity(hashed_bytes.len() + 4);
-    bytes.extend_from_slice(hashed_bytes);
+    bytes.extend_from_slice(hashed_bytes.as_ref());
     bytes.extend_from_slice(salt);
 
     format!("md5{:x}", md5::compute(bytes))
 }
 
 #[derive(Debug, new)]
-pub struct MakeMd5PasswordAuthStartupHandler<V, P> {
-    verifier: Arc<V>,
+pub struct MakeMd5PasswordAuthStartupHandler<A, P> {
+    auth_source: Arc<A>,
     parameter_provider: Arc<P>,
 }
 
@@ -108,9 +109,9 @@ impl<V, P> MakeHandler for MakeMd5PasswordAuthStartupHandler<V, P> {
 
     fn make(&self) -> Self::Handler {
         Arc::new(Md5PasswordAuthStartupHandler {
-            verifier: self.verifier.clone(),
+            auth_source: self.auth_source.clone(),
             parameter_provider: self.parameter_provider.clone(),
-            salt: random_salt(),
+            cached_password: Mutex::new(vec![]),
         })
     }
 }
@@ -124,10 +125,8 @@ mod tests {
         let username = "zmjiang";
         let password = "themanwhochangedchina";
 
-        let passwdhash = format!("{:x}", md5::compute(format!("{}{}", password, username)));
-
         let result = "md521fe459d77d3e3ea9c9fcd5c11030d30";
 
-        assert_eq!(result, super::hash_md5_password(&passwdhash, &salt));
+        assert_eq!(result, super::hash_md5_password(username, password, &salt));
     }
 }

--- a/src/api/auth/mod.rs
+++ b/src/api/auth/mod.rs
@@ -54,7 +54,7 @@ impl ServerParameterProvider for DefaultServerParameterProvider {
     }
 }
 
-#[derive(Debug, new, Getters)]
+#[derive(Debug, new, Getters, Clone)]
 #[getset(get = "pub")]
 pub struct Password {
     salt: Option<Vec<u8>>,

--- a/src/messages/mod.rs
+++ b/src/messages/mod.rs
@@ -286,7 +286,7 @@ mod test {
             roundtrip!(s, Authentication);
         }
 
-        let md5pass = Authentication::MD5Password([b'p', b's', b't', b'g']);
+        let md5pass = Authentication::MD5Password(vec![b'p', b's', b't', b'g']);
         roundtrip!(md5pass, Authentication);
     }
 

--- a/src/messages/startup.rs
+++ b/src/messages/startup.rs
@@ -96,7 +96,7 @@ pub enum Authentication {
     Ok,                   // code 0
     CleartextPassword,    // code 3
     KerberosV5,           // code 2
-    MD5Password([u8; 4]), // code 5, with 4 bytes of md5 salt
+    MD5Password(Vec<u8>), // code 5, with 4 bytes of md5 salt
 
     SASL(Vec<String>),   // code 10, with server supported sasl mechanisms
     SASLContinue(Bytes), // code 11, with authentication data
@@ -168,10 +168,9 @@ impl Message for Authentication {
             2 => Authentication::KerberosV5,
             3 => Authentication::CleartextPassword,
             5 => {
-                let mut salt = buf.split_to(4);
-                let mut salt_array = [0u8; 4];
-                salt.copy_to_slice(&mut salt_array);
-                Authentication::MD5Password(salt_array)
+                let mut salt_vec = vec![0; 4];
+                buf.copy_to_slice(&mut salt_vec);
+                Authentication::MD5Password(salt_vec)
             }
             10 => {
                 let mut methods = Vec::new();


### PR DESCRIPTION
This patch adds a unified `AuthSource` API for developer to implement their user systems. Password (plain or salted) and an optional salt is returned. This design fits both cases that passwords are stored plain or salted (together with salt).

