### PR TITLE
feat: improve describe and parser API

### DIFF
--- a/src/api/portal.rs
+++ b/src/api/portal.rs
@@ -72,7 +72,7 @@ impl<S: Clone> Portal<S> {
 
         Ok(Portal {
             name: portal_name,
-            statement: statement.clone(),
+            statement,
             parameter_format: format,
             parameters: bind.parameters().clone(),
             result_column_format_codes: bind.result_column_format_codes().clone(),

--- a/src/api/query.rs
+++ b/src/api/query.rs
@@ -106,7 +106,7 @@ pub trait ExtendedQueryHandler: Send + Sync {
         let statement_name = message.statement_name().as_deref().unwrap_or(DEFAULT_NAME);
 
         if let Some(statement) = self.portal_store().get_statement(statement_name) {
-            let portal = Portal::try_new(&message, statement.clone())?;
+            let portal = Portal::try_new(&message, statement)?;
             self.portal_store().put_portal(Arc::new(portal));
             Ok(())
         } else {


### PR DESCRIPTION
As in integration we realize some query engines require parameter types to be able to describe a statement. This patch:

- opens parameter types to `QueryParser`
- reduce data cloned from `StoredStatement` to `Portal`

As always, this is a break change.