### PR TITLE
fix: support for describing statement

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,17 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased] - ReleaseDate
+
+Fixes compatibility with rust-postgres client's prepared statement
+implementation. It sends Parse-Describe-Sync on `Client::prepare_typed`.
+
+### Fixed
+
+- `Parse` and `Bind` completion response is now fixed
+- Responding statement describe request with parameter description, and ready
+  for query
+
 ## [0.9.0] - 2023-02-01
 
 ### Changed

--- a/src/messages/mod.rs
+++ b/src/messages/mod.rs
@@ -155,6 +155,7 @@ pub enum PgWireBackendMessage {
     NoticeResponse(response::NoticeResponse),
 
     // data
+    ParameterDescription(data::ParameterDescription),
     RowDescription(data::RowDescription),
     DataRow(data::DataRow),
 }
@@ -177,6 +178,7 @@ impl PgWireBackendMessage {
             Self::ErrorResponse(msg) => msg.encode(buf),
             Self::NoticeResponse(msg) => msg.encode(buf),
 
+            Self::ParameterDescription(msg) => msg.encode(buf),
             Self::RowDescription(msg) => msg.encode(buf),
             Self::DataRow(msg) => msg.encode(buf),
         }
@@ -227,6 +229,10 @@ impl PgWireBackendMessage {
                     response::NoticeResponse::decode(buf).map(|v| v.map(Self::NoticeResponse))
                 }
 
+                data::MESSAGE_TYPE_BYTE_PARAMETER_DESCRITION => {
+                    data::ParameterDescription::decode(buf)
+                        .map(|v| v.map(Self::ParameterDescription))
+                }
                 data::MESSAGE_TYPE_BYTE_ROW_DESCRITION => {
                     data::RowDescription::decode(buf).map(|v| v.map(Self::RowDescription))
                 }
@@ -438,6 +444,12 @@ mod test {
 
         let saslresp = SASLResponse::new(Bytes::from_static(b"abc"));
         roundtrip!(saslresp, SASLResponse);
+    }
+
+    #[test]
+    fn test_parameter_description() {
+        let param_desc = ParameterDescription::new(vec![100, 200]);
+        roundtrip!(param_desc, ParameterDescription);
     }
 
     #[test]


### PR DESCRIPTION
This patch fixes:

- parse and bind response is now returned
- respond statement describe request with parameter description, and ready for query