### PR TITLE
Refactor DataRowEncoder apis

### DIFF
--- a/examples/server.rs
+++ b/examples/server.rs
@@ -7,7 +7,7 @@ use tokio::net::TcpListener;
 use pgwire::api::auth::noop::NoopStartupHandler;
 
 use pgwire::api::query::{PlaceholderExtendedQueryHandler, SimpleQueryHandler};
-use pgwire::api::results::{text_query_response, FieldInfo, Response, Tag, TextDataRowEncoder};
+use pgwire::api::results::{query_response, DataRowEncoder, FieldFormat, FieldInfo, Response, Tag};
 use pgwire::api::{ClientInfo, StatelessMakeHandler, Type};
 use pgwire::error::PgWireResult;
 use pgwire::tokio::process_socket;
@@ -22,8 +22,8 @@ impl SimpleQueryHandler for DummyProcessor {
     {
         println!("{:?}", query);
         if query.starts_with("SELECT") {
-            let f1 = FieldInfo::new("id".into(), None, None, Type::INT4);
-            let f2 = FieldInfo::new("name".into(), None, None, Type::VARCHAR);
+            let f1 = FieldInfo::new("id".into(), None, None, Type::INT4, FieldFormat::Text);
+            let f2 = FieldInfo::new("name".into(), None, None, Type::VARCHAR, FieldFormat::Text);
 
             let data = vec![
                 (Some(0), Some("Tom")),
@@ -31,15 +31,15 @@ impl SimpleQueryHandler for DummyProcessor {
                 (Some(2), None),
             ];
             let data_row_stream = stream::iter(data.into_iter()).map(|r| {
-                let mut encoder = TextDataRowEncoder::new(2);
-                encoder.append_field(r.0.as_ref())?;
-                encoder.append_field(r.1.as_ref())?;
+                let mut encoder = DataRowEncoder::new(2);
+                encoder.encode_text_format_field(r.0.as_ref())?;
+                encoder.encode_text_format_field(r.1.as_ref())?;
 
                 encoder.finish()
             });
 
-            Ok(vec![Response::Query(text_query_response(
-                vec![f1, f2],
+            Ok(vec![Response::Query(query_response(
+                Some(vec![f1, f2]),
                 data_row_stream,
             ))])
         } else {

--- a/src/api/results.rs
+++ b/src/api/results.rs
@@ -130,7 +130,7 @@ impl DataRowEncoder {
     where
         T: ToSql + Sized,
     {
-        if let IsNull::No = value.to_sql(&data_type, &mut self.field_buffer)? {
+        if let IsNull::No = value.to_sql(data_type, &mut self.field_buffer)? {
             let buf = self.field_buffer.split().freeze();
             self.buffer.fields_mut().push(Some(buf));
         } else {

--- a/src/api/results.rs
+++ b/src/api/results.rs
@@ -1,4 +1,4 @@
-use std::{fmt::Debug, sync::Arc};
+use std::fmt::Debug;
 
 use bytes::{Bytes, BytesMut};
 use futures::{
@@ -10,7 +10,7 @@ use postgres_types::{IsNull, ToSql, Type};
 use crate::{
     error::{ErrorInfo, PgWireResult},
     messages::{
-        data::{DataRow, FieldDescription, RowDescription, FORMAT_CODE_BINARY, FORMAT_CODE_TEXT},
+        data::{DataRow, FieldDescription, RowDescription},
         response::CommandComplete,
     },
 };
@@ -54,7 +54,6 @@ pub struct FieldInfo {
     table_id: Option<i32>,
     column_id: Option<i16>,
     datatype: Type,
-    #[new(value = "FORMAT_CODE_BINARY")]
     format: i16,
 }
 
@@ -84,53 +83,20 @@ pub struct QueryResponse {
     pub(crate) data_rows: BoxStream<'static, PgWireResult<DataRow>>,
 }
 
-pub struct BinaryDataRowEncoder {
-    row_schema: Arc<Vec<FieldInfo>>,
-    col_index: usize,
+pub struct DataRowEncoder {
     buffer: DataRow,
+    field_buffer: BytesMut,
 }
 
-impl BinaryDataRowEncoder {
-    pub fn new(row_schema: Arc<Vec<FieldInfo>>) -> BinaryDataRowEncoder {
-        BinaryDataRowEncoder {
-            buffer: DataRow::new(Vec::with_capacity(row_schema.len())),
-            col_index: 0,
-            row_schema,
+impl DataRowEncoder {
+    pub fn new(ncols: usize) -> DataRowEncoder {
+        Self {
+            buffer: DataRow::new(Vec::with_capacity(ncols)),
+            field_buffer: BytesMut::with_capacity(8),
         }
     }
 
-    pub fn append_field<T>(&mut self, value: &T) -> PgWireResult<()>
-    where
-        T: ToSql + Sized,
-    {
-        let mut buffer = BytesMut::with_capacity(8);
-        if let IsNull::No = value.to_sql(&self.row_schema[self.col_index].datatype, &mut buffer)? {
-            let buf = buffer.split().freeze();
-            self.buffer.fields_mut().push(Some(buf));
-        } else {
-            self.buffer.fields_mut().push(None);
-        };
-        self.col_index += 1;
-        Ok(())
-    }
-
-    pub fn finish(self) -> PgWireResult<DataRow> {
-        Ok(self.buffer)
-    }
-}
-
-pub struct TextDataRowEncoder {
-    buffer: DataRow,
-}
-
-impl TextDataRowEncoder {
-    pub fn new(nfields: usize) -> TextDataRowEncoder {
-        TextDataRowEncoder {
-            buffer: DataRow::new(Vec::with_capacity(nfields)),
-        }
-    }
-
-    pub fn append_field<T>(&mut self, value: Option<&T>) -> PgWireResult<()>
+    pub fn encode_text_format_field<T>(&mut self, value: Option<&T>) -> PgWireResult<()>
     where
         T: ToString,
     {
@@ -144,31 +110,32 @@ impl TextDataRowEncoder {
         Ok(())
     }
 
-    pub fn finish(self) -> PgWireResult<DataRow> {
+    pub fn encode_binary_format_field<T>(&mut self, value: &T, data_type: &Type) -> PgWireResult<()>
+    where
+        T: ToSql + Sized,
+    {
+        if let IsNull::No = value.to_sql(&data_type, &mut self.field_buffer)? {
+            let buf = self.field_buffer.split().freeze();
+            self.buffer.fields_mut().push(Some(buf));
+        } else {
+            self.buffer.fields_mut().push(None);
+        };
+
+        self.field_buffer.clear();
+        Ok(())
+    }
+
+    pub fn finish_row(self) -> PgWireResult<DataRow> {
         Ok(self.buffer)
     }
 }
 
-pub fn text_query_response<S>(mut field_defs: Vec<FieldInfo>, row_stream: S) -> QueryResponse
-where
-    S: Stream<Item = PgWireResult<DataRow>> + Send + Unpin + 'static,
-{
-    field_defs
-        .iter_mut()
-        .for_each(|f| f.format = FORMAT_CODE_TEXT);
-
-    QueryResponse {
-        row_schema: Some(field_defs),
-        data_rows: row_stream.boxed(),
-    }
-}
-
-pub fn binary_query_response<S>(row_stream: S) -> QueryResponse
+pub fn query_response<S>(field_defs: Option<Vec<FieldInfo>>, row_stream: S) -> QueryResponse
 where
     S: Stream<Item = PgWireResult<DataRow>> + Send + Unpin + 'static,
 {
     QueryResponse {
-        row_schema: None,
+        row_schema: field_defs,
         data_rows: row_stream.boxed(),
     }
 }


### PR DESCRIPTION
This patch merges APIs of  our `TextDataRowEncoder` and `BinaryDataRowEncoder` into `DataRowEncoder`, and allows a row of data to be encoded in different format, as postgres allows.

Developers are required to set field format in `FieldInfo` now.