### PR TITLE
feat: do not accept MakeHandler in process_socket

### DIFF
--- a/examples/gluesql.rs
+++ b/examples/gluesql.rs
@@ -8,7 +8,7 @@ use gluesql::prelude::*;
 use pgwire::api::auth::noop::NoopStartupHandler;
 use pgwire::api::query::{PlaceholderExtendedQueryHandler, SimpleQueryHandler};
 use pgwire::api::results::{query_response, DataRowEncoder, FieldFormat, FieldInfo, Response, Tag};
-use pgwire::api::{ClientInfo, StatelessMakeHandler, Type};
+use pgwire::api::{ClientInfo, MakeHandler, StatelessMakeHandler, Type};
 use pgwire::error::{PgWireError, PgWireResult};
 use pgwire::tokio::process_socket;
 
@@ -157,9 +157,9 @@ pub async fn main() {
     println!("Listening to {}", server_addr);
     loop {
         let incoming_socket = listener.accept().await.unwrap();
-        let authenticator_ref = authenticator.clone();
-        let processor_ref = processor.clone();
-        let placeholder_ref = placeholder.clone();
+        let authenticator_ref = authenticator.make();
+        let processor_ref = processor.make();
+        let placeholder_ref = placeholder.make();
         tokio::spawn(async move {
             process_socket(
                 incoming_socket.0,

--- a/examples/scram.rs
+++ b/examples/scram.rs
@@ -14,7 +14,7 @@ use pgwire::api::auth::{AuthSource, DefaultServerParameterProvider, LoginInfo, P
 use pgwire::api::query::{PlaceholderExtendedQueryHandler, SimpleQueryHandler};
 use pgwire::api::results::{Response, Tag};
 
-use pgwire::api::{ClientInfo, StatelessMakeHandler};
+use pgwire::api::{ClientInfo, MakeHandler, StatelessMakeHandler};
 use pgwire::error::PgWireResult;
 use pgwire::tokio::process_socket;
 
@@ -98,9 +98,9 @@ pub async fn main() {
     loop {
         let incoming_socket = listener.accept().await.unwrap();
         let tls_acceptor_ref = tls_acceptor.clone();
-        let authenticator_ref = authenticator.clone();
-        let processor_ref = processor.clone();
-        let placeholder_ref = placeholder.clone();
+        let authenticator_ref = authenticator.make();
+        let processor_ref = processor.make();
+        let placeholder_ref = placeholder.make();
         tokio::spawn(async move {
             process_socket(
                 incoming_socket.0,

--- a/examples/secure_server.rs
+++ b/examples/secure_server.rs
@@ -12,7 +12,7 @@ use tokio_rustls::TlsAcceptor;
 use pgwire::api::auth::noop::NoopStartupHandler;
 use pgwire::api::query::{PlaceholderExtendedQueryHandler, SimpleQueryHandler};
 use pgwire::api::results::{query_response, DataRowEncoder, FieldFormat, FieldInfo, Response, Tag};
-use pgwire::api::{ClientInfo, StatelessMakeHandler, Type};
+use pgwire::api::{ClientInfo, MakeHandler, StatelessMakeHandler, Type};
 use pgwire::error::PgWireResult;
 use pgwire::tokio::process_socket;
 
@@ -89,9 +89,9 @@ pub async fn main() {
     loop {
         let incoming_socket = listener.accept().await.unwrap();
         let tls_acceptor_ref = tls_acceptor.clone();
-        let authenticator_ref = authenticator.clone();
-        let processor_ref = processor.clone();
-        let placeholder_ref = placeholder.clone();
+        let authenticator_ref = authenticator.make();
+        let processor_ref = processor.make();
+        let placeholder_ref = placeholder.make();
         tokio::spawn(async move {
             process_socket(
                 incoming_socket.0,

--- a/examples/server.rs
+++ b/examples/server.rs
@@ -8,7 +8,7 @@ use pgwire::api::auth::noop::NoopStartupHandler;
 
 use pgwire::api::query::{PlaceholderExtendedQueryHandler, SimpleQueryHandler};
 use pgwire::api::results::{query_response, DataRowEncoder, FieldFormat, FieldInfo, Response, Tag};
-use pgwire::api::{ClientInfo, StatelessMakeHandler, Type};
+use pgwire::api::{ClientInfo, MakeHandler, StatelessMakeHandler, Type};
 use pgwire::error::PgWireResult;
 use pgwire::tokio::process_socket;
 
@@ -65,9 +65,9 @@ pub async fn main() {
     println!("Listening to {}", server_addr);
     loop {
         let incoming_socket = listener.accept().await.unwrap();
-        let authenticator_ref = authenticator.clone();
-        let processor_ref = processor.clone();
-        let placeholder_ref = placeholder.clone();
+        let authenticator_ref = authenticator.make();
+        let processor_ref = processor.make();
+        let placeholder_ref = placeholder.make();
         tokio::spawn(async move {
             process_socket(
                 incoming_socket.0,

--- a/examples/sqlite.rs
+++ b/examples/sqlite.rs
@@ -350,8 +350,8 @@ pub async fn main() {
     println!("Listening to {}", server_addr);
     loop {
         let incoming_socket = listener.accept().await.unwrap();
-        let authenticator_ref = authenticator.clone();
-        let processor_ref = processor.clone();
+        let authenticator_ref = authenticator.make();
+        let processor_ref = processor.make();
         tokio::spawn(async move {
             process_socket(
                 incoming_socket.0,


### PR DESCRIPTION
Accepting `MakeHandler` in `process_socket` stops us from reusing data between auth and query handlers.