### PR TITLE
refactor: update resultset stream lifetime to allow usage of portal data

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,8 @@ describe correctly.
 - Update `do_describe` of `ExtendedQueryHandler`. Add new bool argument
   `inference_parameters` to check if parameter types from statement is required
   to return.
+- Updated resultset `Response::QueryResponse` lifetime from `'static` to portal
+  or query string, this allows reference of portal in stream.
 
 ### Fixed
 

--- a/examples/gluesql.rs
+++ b/examples/gluesql.rs
@@ -18,7 +18,7 @@ pub struct GluesqlProcessor {
 
 #[async_trait]
 impl SimpleQueryHandler for GluesqlProcessor {
-    async fn do_query<C>(&self, _client: &C, query: &str) -> PgWireResult<Vec<Response>>
+    async fn do_query<'a, C>(&self, _client: &C, query: &'a str) -> PgWireResult<Vec<Response<'a>>>
     where
         C: ClientInfo + Unpin + Send + Sync,
     {

--- a/examples/scram.rs
+++ b/examples/scram.rs
@@ -22,7 +22,7 @@ pub struct DummyProcessor;
 
 #[async_trait]
 impl SimpleQueryHandler for DummyProcessor {
-    async fn do_query<C>(&self, _client: &C, _query: &str) -> PgWireResult<Vec<Response>>
+    async fn do_query<'a, C>(&self, _client: &C, _query: &'a str) -> PgWireResult<Vec<Response<'a>>>
     where
         C: ClientInfo + Unpin + Send + Sync,
     {

--- a/examples/secure_server.rs
+++ b/examples/secure_server.rs
@@ -20,7 +20,7 @@ pub struct DummyProcessor;
 
 #[async_trait]
 impl SimpleQueryHandler for DummyProcessor {
-    async fn do_query<C>(&self, _client: &C, query: &str) -> PgWireResult<Vec<Response>>
+    async fn do_query<'a, C>(&self, _client: &C, query: &'a str) -> PgWireResult<Vec<Response<'a>>>
     where
         C: ClientInfo + Unpin + Send + Sync,
     {

--- a/examples/server.rs
+++ b/examples/server.rs
@@ -16,7 +16,7 @@ pub struct DummyProcessor;
 
 #[async_trait]
 impl SimpleQueryHandler for DummyProcessor {
-    async fn do_query<C>(&self, _client: &C, query: &str) -> PgWireResult<Vec<Response>>
+    async fn do_query<'a, C>(&self, _client: &C, query: &'a str) -> PgWireResult<Vec<Response<'a>>>
     where
         C: ClientInfo + Unpin + Send + Sync,
     {

--- a/examples/sqlite.rs
+++ b/examples/sqlite.rs
@@ -75,7 +75,7 @@ impl ServerParameterProvider for SqliteParameters {
 
 #[async_trait]
 impl SimpleQueryHandler for SqliteBackend {
-    async fn do_query<C>(&self, _client: &C, query: &str) -> PgWireResult<Vec<Response>>
+    async fn do_query<'a, C>(&self, _client: &C, query: &'a str) -> PgWireResult<Vec<Response<'a>>>
     where
         C: ClientInfo + Unpin + Send + Sync,
     {
@@ -258,12 +258,12 @@ impl ExtendedQueryHandler for SqliteBackend {
         self.query_parser.clone()
     }
 
-    async fn do_query<C>(
+    async fn do_query<'a, C>(
         &self,
         _client: &mut C,
-        portal: &Portal<Self::Statement>,
+        portal: &'a Portal<Self::Statement>,
         _max_rows: usize,
-    ) -> PgWireResult<Response>
+    ) -> PgWireResult<Response<'a>>
     where
         C: ClientInfo + Unpin + Send + Sync,
     {

--- a/src/api/query.rs
+++ b/src/api/query.rs
@@ -69,7 +69,7 @@ pub trait SimpleQueryHandler: Send + Sync {
     }
 
     /// Provide your query implementation using the incoming query string.
-    async fn do_query<C>(&self, client: &C, query: &str) -> PgWireResult<Vec<Response>>
+    async fn do_query<'a, C>(&self, client: &C, query: &'a str) -> PgWireResult<Vec<Response<'a>>>
     where
         C: ClientInfo + Unpin + Send + Sync;
 }
@@ -155,7 +155,6 @@ pub trait ExtendedQueryHandler: Send + Sync {
         } else {
             Err(PgWireError::PortalNotFound(portal_name.to_owned()))
         }
-        // TODO: clear/remove portal?
     }
 
     async fn on_describe<C>(&self, client: &mut C, message: Describe) -> PgWireResult<()>
@@ -264,17 +263,17 @@ pub trait ExtendedQueryHandler: Send + Sync {
     /// - `client`: Information of the client sending the query
     /// - `portal`: Statement and parameters for the query
     /// - `max_rows`: Max requested rows of the query
-    async fn do_query<C>(
+    async fn do_query<'a, C>(
         &self,
         client: &mut C,
-        portal: &Portal<Self::Statement>,
+        portal: &'a Portal<Self::Statement>,
         max_rows: usize,
-    ) -> PgWireResult<Response>
+    ) -> PgWireResult<Response<'a>>
     where
         C: ClientInfo + Unpin + Send + Sync;
 }
 
-async fn send_query_response<C>(client: &mut C, results: QueryResponse) -> PgWireResult<()>
+async fn send_query_response<'a, C>(client: &mut C, results: QueryResponse<'a>) -> PgWireResult<()>
 where
     C: ClientInfo + Sink<PgWireBackendMessage> + Unpin + Send + Sync,
     C::Error: Debug,
@@ -342,12 +341,12 @@ impl ExtendedQueryHandler for PlaceholderExtendedQueryHandler {
         unimplemented!("Extended Query is not implemented on this server.")
     }
 
-    async fn do_query<C>(
+    async fn do_query<'a, C>(
         &self,
         _client: &mut C,
-        _portal: &Portal<Self::Statement>,
+        _portal: &'a Portal<Self::Statement>,
         _max_rows: usize,
-    ) -> PgWireResult<Response>
+    ) -> PgWireResult<Response<'a>>
     where
         C: ClientInfo + Unpin + Send + Sync,
     {

--- a/src/api/results.rs
+++ b/src/api/results.rs
@@ -94,9 +94,9 @@ pub(crate) fn into_row_description(fields: Vec<FieldInfo>) -> RowDescription {
 
 #[derive(Getters)]
 #[getset(get = "pub")]
-pub struct QueryResponse {
+pub struct QueryResponse<'a> {
     pub(crate) row_schema: Option<Vec<FieldInfo>>,
-    pub(crate) data_rows: BoxStream<'static, PgWireResult<DataRow>>,
+    pub(crate) data_rows: BoxStream<'a, PgWireResult<DataRow>>,
 }
 
 pub struct DataRowEncoder {
@@ -146,9 +146,9 @@ impl DataRowEncoder {
     }
 }
 
-pub fn query_response<S>(field_defs: Option<Vec<FieldInfo>>, row_stream: S) -> QueryResponse
+pub fn query_response<'a, S>(field_defs: Option<Vec<FieldInfo>>, row_stream: S) -> QueryResponse<'a>
 where
-    S: Stream<Item = PgWireResult<DataRow>> + Send + Unpin + 'static,
+    S: Stream<Item = PgWireResult<DataRow>> + Send + Unpin + 'a,
 {
     QueryResponse {
         row_schema: field_defs,
@@ -180,8 +180,8 @@ impl DescribeResponse {
 /// * Query: the response contains data rows
 /// * Execution: response for ddl/dml execution
 /// * Error: error response
-pub enum Response {
-    Query(QueryResponse),
+pub enum Response<'a> {
+    Query(QueryResponse<'a>),
     Execution(Tag),
     Error(Box<ErrorInfo>),
 }


### PR DESCRIPTION
This patch includes changes:

- updated resultset `Response::QueryResponse` lifetime from `'static` to portal or query string, this allows reference of `portal` in streasm
- updated resultset column format access for `portal`