### PR TITLE
feat: ToSqlText for text encoding

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,7 +23,7 @@ futures = "0.3"
 async-trait = "0.1"
 rand = "0.8"
 thiserror = "1"
-postgres-types = "0.2"
+postgres-types = { version = "0.2", features = ["with-chrono-0_4"]}
 md5 = "0.7"
 hex = "0.4"
 ## scram libraries
@@ -49,9 +49,9 @@ gluesql = "0.13"
 
 [features]
 default = ["tokio", "time-format"]
-tokio = ["dep:tokio", "tokio-util", "tokio-rustls"]
+tokio = ["dep:tokio", "dep:tokio-util", "dep:tokio-rustls"]
 time-format = ["dep:chrono"]
 
 [[example]]
 name = "server"
-required-features = ["tokio_support"]
+required-features = ["tokio"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,6 +25,7 @@ rand = "0.8"
 thiserror = "1"
 postgres-types = "0.2"
 md5 = "0.7"
+hex = "0.4"
 ## scram libraries
 base64 = "0.21"
 ring = "0.16"
@@ -35,8 +36,9 @@ tokio = { version = "1.19", features = ["net", "rt", "io-util"], optional = true
 tokio-util = { version = "0.7.3", features = ["codec", "io"], optional = true }
 tokio-rustls = { version = "0.23", optional = true }
 
+chrono = { version = "0.4", optional = true, features = ["std"] }
+
 [dev-dependencies]
-hex = "0.4"
 tokio = { version = "1.19", features = ["rt-multi-thread", "net", "macros"]}
 rusqlite = { version = "0.28.0", features = ["bundled", "column_decltype"] }
 ## for loading custom cert files
@@ -46,8 +48,9 @@ rustls-pemfile = { version = "1.0" }
 gluesql = "0.13"
 
 [features]
-default = ["tokio_support"]
-tokio_support = ["tokio", "tokio-util", "tokio-rustls"]
+default = ["tokio", "time-format"]
+tokio = ["dep:tokio", "tokio-util", "tokio-rustls"]
+time-format = ["dep:chrono"]
 
 [[example]]
 name = "server"

--- a/examples/gluesql.rs
+++ b/examples/gluesql.rs
@@ -10,6 +10,7 @@ use pgwire::api::query::{PlaceholderExtendedQueryHandler, SimpleQueryHandler};
 use pgwire::api::results::{query_response, DataRowEncoder, FieldFormat, FieldInfo, Response, Tag};
 use pgwire::api::{ClientInfo, MakeHandler, StatelessMakeHandler, Type};
 use pgwire::error::{PgWireError, PgWireResult};
+use pgwire::messages::data::FORMAT_CODE_TEXT;
 use pgwire::tokio::process_socket;
 
 pub struct GluesqlProcessor {
@@ -50,44 +51,66 @@ impl SimpleQueryHandler for GluesqlProcessor {
                                 let mut encoder = DataRowEncoder::new(nfields);
                                 for field in row.iter() {
                                     match field {
-                                        Value::Bool(v) => {
-                                            encoder.encode_text_format_field(Some(v))?
-                                        }
-                                        Value::I8(v) => {
-                                            encoder.encode_text_format_field(Some(v))?
-                                        }
-                                        Value::I16(v) => {
-                                            encoder.encode_text_format_field(Some(v))?
-                                        }
-                                        Value::I32(v) => {
-                                            encoder.encode_text_format_field(Some(v))?
-                                        }
-                                        Value::I64(v) => {
-                                            encoder.encode_text_format_field(Some(v))?
-                                        }
-                                        Value::I128(v) => {
-                                            encoder.encode_text_format_field(Some(v))?
-                                        }
-                                        Value::U8(v) => {
-                                            encoder.encode_text_format_field(Some(v))?
-                                        }
-                                        Value::F64(v) => {
-                                            encoder.encode_text_format_field(Some(v))?
-                                        }
-                                        Value::Str(v) => {
-                                            encoder.encode_text_format_field(Some(v))?
-                                        }
-                                        Value::Bytea(v) => encoder
-                                            .encode_text_format_field(Some(&hex::encode(v)))?,
-                                        Value::Date(v) => {
-                                            encoder.encode_text_format_field(Some(v))?
-                                        }
-                                        Value::Time(v) => {
-                                            encoder.encode_text_format_field(Some(v))?
-                                        }
-                                        Value::Timestamp(v) => {
-                                            encoder.encode_text_format_field(Some(v))?
-                                        }
+                                        Value::Bool(v) => encoder.encode_field(
+                                            v,
+                                            &Type::BOOL,
+                                            FORMAT_CODE_TEXT,
+                                        )?,
+                                        Value::I8(v) => encoder.encode_field(
+                                            v,
+                                            &Type::CHAR,
+                                            FORMAT_CODE_TEXT,
+                                        )?,
+                                        Value::I16(v) => encoder.encode_field(
+                                            v,
+                                            &Type::INT2,
+                                            FORMAT_CODE_TEXT,
+                                        )?,
+                                        Value::I32(v) => encoder.encode_field(
+                                            v,
+                                            &Type::INT4,
+                                            FORMAT_CODE_TEXT,
+                                        )?,
+                                        Value::I64(v) => encoder.encode_field(
+                                            v,
+                                            &Type::INT8,
+                                            FORMAT_CODE_TEXT,
+                                        )?,
+                                        Value::U8(v) => encoder.encode_field(
+                                            &(*v as i8),
+                                            &Type::CHAR,
+                                            FORMAT_CODE_TEXT,
+                                        )?,
+                                        Value::F64(v) => encoder.encode_field(
+                                            v,
+                                            &Type::FLOAT8,
+                                            FORMAT_CODE_TEXT,
+                                        )?,
+                                        Value::Str(v) => encoder.encode_field(
+                                            v,
+                                            &Type::VARCHAR,
+                                            FORMAT_CODE_TEXT,
+                                        )?,
+                                        Value::Bytea(v) => encoder.encode_field(
+                                            v,
+                                            &Type::BYTEA,
+                                            FORMAT_CODE_TEXT,
+                                        )?,
+                                        Value::Date(v) => encoder.encode_field(
+                                            v,
+                                            &Type::DATE,
+                                            FORMAT_CODE_TEXT,
+                                        )?,
+                                        Value::Time(v) => encoder.encode_field(
+                                            v,
+                                            &Type::TIME,
+                                            FORMAT_CODE_TEXT,
+                                        )?,
+                                        Value::Timestamp(v) => encoder.encode_field(
+                                            v,
+                                            &Type::TIMESTAMP,
+                                            FORMAT_CODE_TEXT,
+                                        )?,
                                         _ => unimplemented!(),
                                     }
                                 }

--- a/examples/secure_server.rs
+++ b/examples/secure_server.rs
@@ -14,6 +14,7 @@ use pgwire::api::query::{PlaceholderExtendedQueryHandler, SimpleQueryHandler};
 use pgwire::api::results::{query_response, DataRowEncoder, FieldFormat, FieldInfo, Response, Tag};
 use pgwire::api::{ClientInfo, MakeHandler, StatelessMakeHandler, Type};
 use pgwire::error::PgWireResult;
+use pgwire::messages::data::FORMAT_CODE_TEXT;
 use pgwire::tokio::process_socket;
 
 pub struct DummyProcessor;
@@ -36,8 +37,8 @@ impl SimpleQueryHandler for DummyProcessor {
             ];
             let data_row_stream = stream::iter(data.into_iter()).map(|r| {
                 let mut encoder = DataRowEncoder::new(2);
-                encoder.encode_text_format_field(r.0.as_ref())?;
-                encoder.encode_text_format_field(r.1.as_ref())?;
+                encoder.encode_field(&r.0, &Type::INT4, FORMAT_CODE_TEXT)?;
+                encoder.encode_field(&r.1, &Type::VARCHAR, FORMAT_CODE_TEXT)?;
 
                 encoder.finish()
             });

--- a/examples/server.rs
+++ b/examples/server.rs
@@ -5,11 +5,11 @@ use futures::{stream, StreamExt};
 use tokio::net::TcpListener;
 
 use pgwire::api::auth::noop::NoopStartupHandler;
-
 use pgwire::api::query::{PlaceholderExtendedQueryHandler, SimpleQueryHandler};
 use pgwire::api::results::{query_response, DataRowEncoder, FieldFormat, FieldInfo, Response, Tag};
 use pgwire::api::{ClientInfo, MakeHandler, StatelessMakeHandler, Type};
 use pgwire::error::PgWireResult;
+use pgwire::messages::data::FORMAT_CODE_TEXT;
 use pgwire::tokio::process_socket;
 
 pub struct DummyProcessor;
@@ -32,8 +32,8 @@ impl SimpleQueryHandler for DummyProcessor {
             ];
             let data_row_stream = stream::iter(data.into_iter()).map(|r| {
                 let mut encoder = DataRowEncoder::new(2);
-                encoder.encode_text_format_field(r.0.as_ref())?;
-                encoder.encode_text_format_field(r.1.as_ref())?;
+                encoder.encode_field(&r.0, &Type::INT4, FORMAT_CODE_TEXT)?;
+                encoder.encode_field(&r.1, &Type::VARCHAR, FORMAT_CODE_TEXT)?;
 
                 encoder.finish()
             });

--- a/src/api/portal.rs
+++ b/src/api/portal.rs
@@ -44,6 +44,7 @@ impl From<i16> for Format {
 }
 
 impl Format {
+    /// Get format code for given index
     pub fn format_for(&self, idx: usize) -> i16 {
         match self {
             Format::UnifiedText => FORMAT_CODE_TEXT,

--- a/src/api/results.rs
+++ b/src/api/results.rs
@@ -117,20 +117,17 @@ impl DataRowEncoder {
     where
         T: ToSql + ToSqlText + Sized,
     {
-        if format == FORMAT_CODE_TEXT {
-            if let IsNull::No = value.to_sql_text(data_type, &mut self.field_buffer)? {
-                let buf = self.field_buffer.split().freeze();
-                self.buffer.fields_mut().push(Some(buf));
-            } else {
-                self.buffer.fields_mut().push(None);
-            };
+        let is_null = if format == FORMAT_CODE_TEXT {
+            value.to_sql_text(data_type, &mut self.field_buffer)?
         } else {
-            if let IsNull::No = value.to_sql(data_type, &mut self.field_buffer)? {
-                let buf = self.field_buffer.split().freeze();
-                self.buffer.fields_mut().push(Some(buf));
-            } else {
-                self.buffer.fields_mut().push(None);
-            };
+            value.to_sql(data_type, &mut self.field_buffer)?
+        };
+
+        if let IsNull::No = is_null {
+            let buf = self.field_buffer.split().freeze();
+            self.buffer.fields_mut().push(Some(buf));
+        } else {
+            self.buffer.fields_mut().push(None);
         }
         self.field_buffer.clear();
         Ok(())

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -46,7 +46,7 @@ pub mod error;
 /// the protocol layer.
 pub mod messages;
 /// server entry-point for tokio based application.
-#[cfg(feature = "tokio_support")]
+#[cfg(feature = "tokio")]
 pub mod tokio;
 /// types and encoding related helper
 pub mod types;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -48,3 +48,5 @@ pub mod messages;
 /// server entry-point for tokio based application.
 #[cfg(feature = "tokio_support")]
 pub mod tokio;
+/// types and encoding related helper
+pub mod types;

--- a/src/types/mod.rs
+++ b/src/types/mod.rs
@@ -1,6 +1,9 @@
+use std::time::SystemTime;
 use std::{error::Error, fmt};
 
 use bytes::{BufMut, BytesMut};
+use chrono::offset::Utc;
+use chrono::{DateTime, NaiveDate, NaiveDateTime, NaiveTime};
 use postgres_types::{IsNull, Type};
 
 pub trait ToSqlText: fmt::Debug {
@@ -8,7 +11,11 @@ pub trait ToSqlText: fmt::Debug {
     ///
     /// This trait is modelled after `ToSql` from postgres-types, which is
     /// for binary encoding.
-    fn to_sql(&self, ty: &Type, out: &mut BytesMut) -> Result<IsNull, Box<dyn Error + Sync + Send>>
+    fn to_sql_text(
+        &self,
+        ty: &Type,
+        out: &mut BytesMut,
+    ) -> Result<IsNull, Box<dyn Error + Sync + Send>>
     where
         Self: Sized;
 }
@@ -17,23 +24,23 @@ impl<'a, T> ToSqlText for &'a T
 where
     T: ToSqlText,
 {
-    fn to_sql(
+    fn to_sql_text(
         &self,
         ty: &Type,
         out: &mut BytesMut,
     ) -> Result<IsNull, Box<dyn Error + Sync + Send>> {
-        (*self).to_sql(ty, out)
+        (*self).to_sql_text(ty, out)
     }
 }
 
 impl<T: ToSqlText> ToSqlText for Option<T> {
-    fn to_sql(
+    fn to_sql_text(
         &self,
         ty: &Type,
         out: &mut BytesMut,
     ) -> Result<IsNull, Box<dyn Error + Sync + Send>> {
         match *self {
-            Some(ref val) => val.to_sql(ty, out),
+            Some(ref val) => val.to_sql_text(ty, out),
             None => Ok(IsNull::Yes),
         }
     }
@@ -42,14 +49,141 @@ impl<T: ToSqlText> ToSqlText for Option<T> {
 // TODO: array support
 
 impl ToSqlText for String {
-    fn to_sql(&self, ty: &Type, w: &mut BytesMut) -> Result<IsNull, Box<dyn Error + Sync + Send>> {
-        <&str as ToSqlText>::to_sql(&&**self, ty, w)
+    fn to_sql_text(
+        &self,
+        ty: &Type,
+        w: &mut BytesMut,
+    ) -> Result<IsNull, Box<dyn Error + Sync + Send>> {
+        <&str as ToSqlText>::to_sql_text(&&**self, ty, w)
     }
 }
 
 impl<'a> ToSqlText for &'a str {
-    fn to_sql(&self, _ty: &Type, w: &mut BytesMut) -> Result<IsNull, Box<dyn Error + Sync + Send>> {
+    fn to_sql_text(
+        &self,
+        _ty: &Type,
+        w: &mut BytesMut,
+    ) -> Result<IsNull, Box<dyn Error + Sync + Send>> {
         w.put_slice(self.as_bytes());
+        Ok(IsNull::No)
+    }
+}
+
+macro_rules! impl_to_sql_text {
+    ($t:ty) => {
+        impl ToSqlText for $t {
+            fn to_sql_text(
+                &self,
+                _ty: &Type,
+                w: &mut BytesMut,
+            ) -> Result<IsNull, Box<dyn Error + Sync + Send>> {
+                w.put_slice(self.to_string().as_bytes());
+                Ok(IsNull::No)
+            }
+        }
+    };
+}
+
+impl_to_sql_text!(i8);
+impl_to_sql_text!(i16);
+impl_to_sql_text!(i32);
+impl_to_sql_text!(i64);
+impl_to_sql_text!(i128);
+impl_to_sql_text!(u8);
+impl_to_sql_text!(u16);
+impl_to_sql_text!(u32);
+impl_to_sql_text!(u64);
+impl_to_sql_text!(u128);
+impl_to_sql_text!(f32);
+impl_to_sql_text!(f64);
+impl_to_sql_text!(bool);
+impl_to_sql_text!(char);
+
+impl ToSqlText for Vec<u8> {
+    fn to_sql_text(
+        &self,
+        _ty: &Type,
+        out: &mut BytesMut,
+    ) -> Result<IsNull, Box<dyn Error + Sync + Send>>
+    where
+        Self: Sized,
+    {
+        out.put_slice(hex::encode(self).as_bytes());
+        Ok(IsNull::No)
+    }
+}
+
+impl ToSqlText for &[u8] {
+    fn to_sql_text(
+        &self,
+        _ty: &Type,
+        out: &mut BytesMut,
+    ) -> Result<IsNull, Box<dyn Error + Sync + Send>>
+    where
+        Self: Sized,
+    {
+        out.put_slice(hex::encode(self).as_bytes());
+        Ok(IsNull::No)
+    }
+}
+
+impl ToSqlText for SystemTime {
+    fn to_sql_text(
+        &self,
+        _ty: &Type,
+        out: &mut BytesMut,
+    ) -> Result<IsNull, Box<dyn Error + Sync + Send>>
+    where
+        Self: Sized,
+    {
+        let datetime: DateTime<Utc> = DateTime::<Utc>::from(self.clone());
+        let fmt = datetime.format("%Y-%m-%d %H:%M:%S%.6f").to_string();
+        out.put_slice(fmt.as_bytes());
+        Ok(IsNull::No)
+    }
+}
+
+impl ToSqlText for NaiveDateTime {
+    fn to_sql_text(
+        &self,
+        _ty: &Type,
+        out: &mut BytesMut,
+    ) -> Result<IsNull, Box<dyn Error + Sync + Send>>
+    where
+        Self: Sized,
+    {
+        let fmt = self.format("%Y-%m-%d %H:%M:%S%.6f").to_string();
+        out.put_slice(fmt.as_bytes());
+        Ok(IsNull::No)
+    }
+}
+
+impl ToSqlText for NaiveDate {
+    fn to_sql_text(
+        &self,
+        _ty: &Type,
+        out: &mut BytesMut,
+    ) -> Result<IsNull, Box<dyn Error + Sync + Send>>
+    where
+        Self: Sized,
+    {
+        let fmt = self.format("%Y-%m-%d").to_string();
+        out.put_slice(fmt.as_bytes());
+        Ok(IsNull::No)
+    }
+}
+
+impl ToSqlText for NaiveTime {
+    fn to_sql_text(
+        &self,
+        _ty: &Type,
+        out: &mut BytesMut,
+    ) -> Result<IsNull, Box<dyn Error + Sync + Send>>
+    where
+        Self: Sized,
+    {
+        let fmt = self.format("%H:%M:%S%.6f").to_string();
+        out.put_slice(fmt.as_bytes());
         Ok(IsNull::No)
     }
 }

--- a/src/types/mod.rs
+++ b/src/types/mod.rs
@@ -136,7 +136,7 @@ impl ToSqlText for SystemTime {
     where
         Self: Sized,
     {
-        let datetime: DateTime<Utc> = DateTime::<Utc>::from(self.clone());
+        let datetime: DateTime<Utc> = DateTime::<Utc>::from(*self);
         let fmt = datetime.format("%Y-%m-%d %H:%M:%S%.6f").to_string();
         out.put_slice(fmt.as_bytes());
         Ok(IsNull::No)

--- a/src/types/mod.rs
+++ b/src/types/mod.rs
@@ -1,0 +1,55 @@
+use std::{error::Error, fmt};
+
+use bytes::{BufMut, BytesMut};
+use postgres_types::{IsNull, Type};
+
+pub trait ToSqlText: fmt::Debug {
+    /// Converts value to text format of Postgres type.
+    ///
+    /// This trait is modelled after `ToSql` from postgres-types, which is
+    /// for binary encoding.
+    fn to_sql(&self, ty: &Type, out: &mut BytesMut) -> Result<IsNull, Box<dyn Error + Sync + Send>>
+    where
+        Self: Sized;
+}
+
+impl<'a, T> ToSqlText for &'a T
+where
+    T: ToSqlText,
+{
+    fn to_sql(
+        &self,
+        ty: &Type,
+        out: &mut BytesMut,
+    ) -> Result<IsNull, Box<dyn Error + Sync + Send>> {
+        (*self).to_sql(ty, out)
+    }
+}
+
+impl<T: ToSqlText> ToSqlText for Option<T> {
+    fn to_sql(
+        &self,
+        ty: &Type,
+        out: &mut BytesMut,
+    ) -> Result<IsNull, Box<dyn Error + Sync + Send>> {
+        match *self {
+            Some(ref val) => val.to_sql(ty, out),
+            None => Ok(IsNull::Yes),
+        }
+    }
+}
+
+// TODO: array support
+
+impl ToSqlText for String {
+    fn to_sql(&self, ty: &Type, w: &mut BytesMut) -> Result<IsNull, Box<dyn Error + Sync + Send>> {
+        <&str as ToSqlText>::to_sql(&&**self, ty, w)
+    }
+}
+
+impl<'a> ToSqlText for &'a str {
+    fn to_sql(&self, _ty: &Type, w: &mut BytesMut) -> Result<IsNull, Box<dyn Error + Sync + Send>> {
+        w.put_slice(self.as_bytes());
+        Ok(IsNull::No)
+    }
+}

--- a/tests-integration/nodejs/index.js
+++ b/tests-integration/nodejs/index.js
@@ -1,24 +1,31 @@
-const { Client } = require('pg')
+const { strict } = require("node:assert");
+
+const { Client } = require("pg");
 const client = new Client({
-    host: '127.0.0.1',
-    port: 5432,
-    user: 'tom',
-    password: 'pencil',
-    database: 'localdb',
-})
+  host: "127.0.0.1",
+  port: 5432,
+  user: "tom",
+  password: "pencil",
+  database: "localdb",
+});
 
 async function run() {
-    await client.connect()
+  await client.connect();
 
-    const res1 = await client.query('INSERT INTO testable VALUE (1)')
-    console.log(res1.rowCount)
+  const res1 = await client.query("INSERT INTO testable VALUE (1)");
+  console.log(res1.rowCount);
 
-    const res2 = await client.query('SELECT * FROM testtable')
-    console.log(res2.rows)
+  const res2 = await client.query("SELECT * FROM testtable");
+  console.log(res2.rows);
 
-    const res3 = await client.query('SELECT * FROM testtable WHERE id = $1::int', [1])
-    console.log(res3.rows)
-    await client.end()
+  const res3 = await client.query(
+    "SELECT * FROM testtable WHERE id = $1::int",
+    [1]
+  );
+  console.log(res3.rows);
+  strict.equal(res3.rows[0].id, 0);
+  strict.equal(res3.rows[0].name, "Tom");
+  await client.end();
 }
 
-run()
+run();

--- a/tests-integration/test-server/Cargo.lock
+++ b/tests-integration/test-server/Cargo.lock
@@ -553,14 +553,16 @@ dependencies = [
 
 [[package]]
 name = "pgwire"
-version = "0.10.0"
+version = "0.11.1"
 dependencies = [
  "async-trait",
  "base64 0.21.0",
  "bytes",
+ "chrono",
  "derive-new",
  "futures",
  "getset",
+ "hex",
  "log",
  "md5",
  "postgres-types",
@@ -612,6 +614,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "73d946ec7d256b04dfadc4e6a3292324e6f417124750fc5c0950f981b703a0f1"
 dependencies = [
  "bytes",
+ "chrono",
  "fallible-iterator",
  "postgres-protocol",
 ]


### PR DESCRIPTION
Fixes #56 

This patch adds trait `ToSqlText` in addition to `postgres-types`'s `ToSql`, in order to standardize our text encoding.