### PR TITLE
refactor: use provided row schema for DataRowEncoder

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -80,6 +80,6 @@ jobs:
     - uses: actions/checkout@v3
     - uses: actions-rs/toolchain@v1
       with:
-        toolchain: "1.63"
+        toolchain: "1.64"
         override: true
     - run: cargo test --all-features

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,12 +16,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - Updated `DataRowEncoder` encode API with unified `encode_field` for both
-  binary and text encoding. It accepts `Format` to decide which encoding to use.
-  In simple query, it's always text encode. In extended query, client describes
-  its preferred formats in `Bind` request, and can be retrieved from `portal`
-  argument in `do_query()`.
+  binary and text encoding. `DataRowEncoder::new` now accepts
+  `Arc<Vec<FieldInfo>>` instead of column count. The encoder now has type and
+  format information for each column. `encode_field` no longer requires `Type`
+  and `FieldFormat`. A new `encode_field_with_type_and_format` is provided for
+  custom use-case.
 - Updated `do_describe` API from `ExtendedQueryHandler` to include full
   information about requested `Statement` or `Portal`.
+- `query_response` function is replaced by `QueryResponse::new`
 
 ## [0.11.1] - 2023-02-26
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ homepage = "https://github.com/sunng87/pgwire"
 repository = "https://github.com/sunng87/pgwire"
 documentation = "https://docs.rs/crate/pgwire/"
 readme = "README.md"
-rust-version = "1.63"
+rust-version = "1.64"
 
 [dependencies]
 log = "0.4"

--- a/examples/datafusion.rs
+++ b/examples/datafusion.rs
@@ -13,9 +13,7 @@ use tokio::sync::Mutex;
 
 use pgwire::api::auth::noop::NoopStartupHandler;
 use pgwire::api::query::{PlaceholderExtendedQueryHandler, SimpleQueryHandler};
-use pgwire::api::results::{
-    query_response, DataRowEncoder, FieldFormat, FieldInfo, QueryResponse, Response, Tag,
-};
+use pgwire::api::results::{DataRowEncoder, FieldFormat, FieldInfo, QueryResponse, Response, Tag};
 use pgwire::api::{ClientInfo, MakeHandler, StatelessMakeHandler, Type};
 use pgwire::error::{ErrorInfo, PgWireError, PgWireResult};
 use pgwire::tokio::process_socket;
@@ -150,7 +148,7 @@ async fn encode_dataframe<'a>(df: DataFrame) -> PgWireResult<QueryResponse<'a>> 
         })
         .flatten();
 
-    Ok(query_response(fields, pg_row_stream))
+    Ok(QueryResponse::new(fields, pg_row_stream))
 }
 
 fn get_bool_value(arr: &Arc<dyn Array>, idx: usize) -> bool {

--- a/examples/datafusion.rs
+++ b/examples/datafusion.rs
@@ -103,27 +103,29 @@ fn into_pg_type(df_type: &DataType) -> PgWireResult<Type> {
 
 async fn encode_dataframe<'a>(df: DataFrame) -> PgWireResult<QueryResponse<'a>> {
     let schema = df.schema();
-    let fields = schema
-        .fields()
-        .iter()
-        .map(|f| {
-            let pg_type = into_pg_type(f.data_type())?;
-            Ok(FieldInfo::new(
-                f.name().into(),
-                None,
-                None,
-                pg_type,
-                FieldFormat::Text,
-            ))
-        })
-        .collect::<PgWireResult<Vec<FieldInfo>>>()?;
+    let fields = Arc::new(
+        schema
+            .fields()
+            .iter()
+            .map(|f| {
+                let pg_type = into_pg_type(f.data_type())?;
+                Ok(FieldInfo::new(
+                    f.name().into(),
+                    None,
+                    None,
+                    pg_type,
+                    FieldFormat::Text,
+                ))
+            })
+            .collect::<PgWireResult<Vec<FieldInfo>>>()?,
+    );
 
     let recordbatch_stream = df
         .execute_stream()
         .await
         .map_err(|e| PgWireError::ApiError(Box::new(e)))?;
-    let fields2 = fields.clone();
 
+    let fields_ref = fields.clone();
     let pg_row_stream = recordbatch_stream
         .map(move |rb: datafusion::error::Result<RecordBatch>| {
             let rb = rb.unwrap();
@@ -132,16 +134,13 @@ async fn encode_dataframe<'a>(df: DataFrame) -> PgWireResult<QueryResponse<'a>> 
             let mut results = Vec::with_capacity(rows);
 
             for row in 0..rows {
-                let mut encoder = DataRowEncoder::new(cols);
+                let mut encoder = DataRowEncoder::new(fields_ref.clone());
                 for col in 0..cols {
                     let array = rb.column(col);
-                    let f = &fields2[col];
                     if array.is_null(row) {
-                        encoder
-                            .encode_field(&None::<i8>, f.datatype(), *f.format())
-                            .unwrap();
+                        encoder.encode_field(&None::<i8>).unwrap();
                     } else {
-                        encode_value(&mut encoder, array, row, f.datatype(), *f.format()).unwrap();
+                        encode_value(&mut encoder, array, row).unwrap();
                     }
                 }
                 results.push(encoder.finish());
@@ -151,7 +150,7 @@ async fn encode_dataframe<'a>(df: DataFrame) -> PgWireResult<QueryResponse<'a>> 
         })
         .flatten();
 
-    Ok(query_response(Some(fields.clone()), pg_row_stream))
+    Ok(query_response(fields, pg_row_stream))
 }
 
 fn get_bool_value(arr: &Arc<dyn Array>, idx: usize) -> bool {
@@ -194,19 +193,17 @@ fn encode_value(
     encoder: &mut DataRowEncoder,
     arr: &Arc<dyn Array>,
     idx: usize,
-    pg_type: &Type,
-    format: FieldFormat,
 ) -> PgWireResult<()> {
     match arr.data_type() {
-        DataType::Boolean => encoder.encode_field(&get_bool_value(arr, idx), pg_type, format)?,
-        DataType::Int8 => encoder.encode_field(&get_i8_value(arr, idx), pg_type, format)?,
-        DataType::Int16 => encoder.encode_field(&get_i16_value(arr, idx), pg_type, format)?,
-        DataType::Int32 => encoder.encode_field(&get_i32_value(arr, idx), pg_type, format)?,
-        DataType::Int64 => encoder.encode_field(&get_i64_value(arr, idx), pg_type, format)?,
-        DataType::UInt32 => encoder.encode_field(&get_u32_value(arr, idx), pg_type, format)?,
-        DataType::Float32 => encoder.encode_field(&get_f32_value(arr, idx), pg_type, format)?,
-        DataType::Float64 => encoder.encode_field(&get_f64_value(arr, idx), pg_type, format)?,
-        DataType::Utf8 => encoder.encode_field(&get_utf8_value(arr, idx), pg_type, format)?,
+        DataType::Boolean => encoder.encode_field(&get_bool_value(arr, idx))?,
+        DataType::Int8 => encoder.encode_field(&get_i8_value(arr, idx))?,
+        DataType::Int16 => encoder.encode_field(&get_i16_value(arr, idx))?,
+        DataType::Int32 => encoder.encode_field(&get_i32_value(arr, idx))?,
+        DataType::Int64 => encoder.encode_field(&get_i64_value(arr, idx))?,
+        DataType::UInt32 => encoder.encode_field(&get_u32_value(arr, idx))?,
+        DataType::Float32 => encoder.encode_field(&get_f32_value(arr, idx))?,
+        DataType::Float64 => encoder.encode_field(&get_f64_value(arr, idx))?,
+        DataType::Utf8 => encoder.encode_field(&get_utf8_value(arr, idx))?,
         _ => {
             return Err(PgWireError::UserError(Box::new(ErrorInfo::new(
                 "ERROR".to_owned(),

--- a/examples/gluesql.rs
+++ b/examples/gluesql.rs
@@ -7,7 +7,7 @@ use tokio::net::TcpListener;
 use gluesql::prelude::*;
 use pgwire::api::auth::noop::NoopStartupHandler;
 use pgwire::api::query::{PlaceholderExtendedQueryHandler, SimpleQueryHandler};
-use pgwire::api::results::{query_response, DataRowEncoder, FieldFormat, FieldInfo, Response, Tag};
+use pgwire::api::results::{DataRowEncoder, FieldFormat, FieldInfo, QueryResponse, Response, Tag};
 use pgwire::api::{ClientInfo, MakeHandler, StatelessMakeHandler, Type};
 use pgwire::error::{PgWireError, PgWireResult};
 use pgwire::tokio::process_socket;
@@ -126,7 +126,7 @@ impl SimpleQueryHandler for GluesqlProcessor {
                                 results.push(encoder.finish());
                             }
 
-                            Ok(Response::Query(query_response(
+                            Ok(Response::Query(QueryResponse::new(
                                 fields,
                                 stream::iter(results.into_iter()),
                             )))

--- a/examples/gluesql.rs
+++ b/examples/gluesql.rs
@@ -43,73 +43,83 @@ impl SimpleQueryHandler for GluesqlProcessor {
                                     )
                                 })
                                 .collect::<Vec<_>>();
-                            let nfields = fields.len();
+                            let fields = Arc::new(fields);
 
                             let mut results = Vec::with_capacity(rows.len());
                             for row in rows {
-                                let mut encoder = DataRowEncoder::new(nfields);
+                                let mut encoder = DataRowEncoder::new(fields.clone());
                                 for field in row.iter() {
                                     match field {
-                                        Value::Bool(v) => encoder.encode_field(
-                                            v,
-                                            &Type::BOOL,
-                                            FieldFormat::Text,
-                                        )?,
-                                        Value::I8(v) => encoder.encode_field(
+                                        Value::Bool(v) => encoder
+                                            .encode_field_with_type_and_format(
+                                                v,
+                                                &Type::BOOL,
+                                                FieldFormat::Text,
+                                            )?,
+                                        Value::I8(v) => encoder.encode_field_with_type_and_format(
                                             v,
                                             &Type::CHAR,
                                             FieldFormat::Text,
                                         )?,
-                                        Value::I16(v) => encoder.encode_field(
-                                            v,
-                                            &Type::INT2,
-                                            FieldFormat::Text,
-                                        )?,
-                                        Value::I32(v) => encoder.encode_field(
-                                            v,
-                                            &Type::INT4,
-                                            FieldFormat::Text,
-                                        )?,
-                                        Value::I64(v) => encoder.encode_field(
-                                            v,
-                                            &Type::INT8,
-                                            FieldFormat::Text,
-                                        )?,
-                                        Value::U8(v) => encoder.encode_field(
+                                        Value::I16(v) => encoder
+                                            .encode_field_with_type_and_format(
+                                                v,
+                                                &Type::INT2,
+                                                FieldFormat::Text,
+                                            )?,
+                                        Value::I32(v) => encoder
+                                            .encode_field_with_type_and_format(
+                                                v,
+                                                &Type::INT4,
+                                                FieldFormat::Text,
+                                            )?,
+                                        Value::I64(v) => encoder
+                                            .encode_field_with_type_and_format(
+                                                v,
+                                                &Type::INT8,
+                                                FieldFormat::Text,
+                                            )?,
+                                        Value::U8(v) => encoder.encode_field_with_type_and_format(
                                             &(*v as i8),
                                             &Type::CHAR,
                                             FieldFormat::Text,
                                         )?,
-                                        Value::F64(v) => encoder.encode_field(
-                                            v,
-                                            &Type::FLOAT8,
-                                            FieldFormat::Text,
-                                        )?,
-                                        Value::Str(v) => encoder.encode_field(
-                                            v,
-                                            &Type::VARCHAR,
-                                            FieldFormat::Text,
-                                        )?,
-                                        Value::Bytea(v) => encoder.encode_field(
-                                            v,
-                                            &Type::BYTEA,
-                                            FieldFormat::Text,
-                                        )?,
-                                        Value::Date(v) => encoder.encode_field(
-                                            v,
-                                            &Type::DATE,
-                                            FieldFormat::Text,
-                                        )?,
-                                        Value::Time(v) => encoder.encode_field(
-                                            v,
-                                            &Type::TIME,
-                                            FieldFormat::Text,
-                                        )?,
-                                        Value::Timestamp(v) => encoder.encode_field(
-                                            v,
-                                            &Type::TIMESTAMP,
-                                            FieldFormat::Text,
-                                        )?,
+                                        Value::F64(v) => encoder
+                                            .encode_field_with_type_and_format(
+                                                v,
+                                                &Type::FLOAT8,
+                                                FieldFormat::Text,
+                                            )?,
+                                        Value::Str(v) => encoder
+                                            .encode_field_with_type_and_format(
+                                                v,
+                                                &Type::VARCHAR,
+                                                FieldFormat::Text,
+                                            )?,
+                                        Value::Bytea(v) => encoder
+                                            .encode_field_with_type_and_format(
+                                                v,
+                                                &Type::BYTEA,
+                                                FieldFormat::Text,
+                                            )?,
+                                        Value::Date(v) => encoder
+                                            .encode_field_with_type_and_format(
+                                                v,
+                                                &Type::DATE,
+                                                FieldFormat::Text,
+                                            )?,
+                                        Value::Time(v) => encoder
+                                            .encode_field_with_type_and_format(
+                                                v,
+                                                &Type::TIME,
+                                                FieldFormat::Text,
+                                            )?,
+                                        Value::Timestamp(v) => encoder
+                                            .encode_field_with_type_and_format(
+                                                v,
+                                                &Type::TIMESTAMP,
+                                                FieldFormat::Text,
+                                            )?,
                                         _ => unimplemented!(),
                                     }
                                 }
@@ -117,7 +127,7 @@ impl SimpleQueryHandler for GluesqlProcessor {
                             }
 
                             Ok(Response::Query(query_response(
-                                Some(fields),
+                                fields,
                                 stream::iter(results.into_iter()),
                             )))
                         }

--- a/examples/secure_server.rs
+++ b/examples/secure_server.rs
@@ -11,7 +11,7 @@ use tokio_rustls::TlsAcceptor;
 
 use pgwire::api::auth::noop::NoopStartupHandler;
 use pgwire::api::query::{PlaceholderExtendedQueryHandler, SimpleQueryHandler};
-use pgwire::api::results::{query_response, DataRowEncoder, FieldFormat, FieldInfo, Response, Tag};
+use pgwire::api::results::{DataRowEncoder, FieldFormat, FieldInfo, QueryResponse, Response, Tag};
 use pgwire::api::{ClientInfo, MakeHandler, StatelessMakeHandler, Type};
 use pgwire::error::PgWireResult;
 use pgwire::tokio::process_socket;
@@ -44,7 +44,7 @@ impl SimpleQueryHandler for DummyProcessor {
                 encoder.finish()
             });
 
-            Ok(vec![Response::Query(query_response(
+            Ok(vec![Response::Query(QueryResponse::new(
                 schema,
                 data_row_stream,
             ))])

--- a/examples/secure_server.rs
+++ b/examples/secure_server.rs
@@ -28,22 +28,24 @@ impl SimpleQueryHandler for DummyProcessor {
         if query.starts_with("SELECT") {
             let f1 = FieldInfo::new("id".into(), None, None, Type::INT4, FieldFormat::Text);
             let f2 = FieldInfo::new("name".into(), None, None, Type::VARCHAR, FieldFormat::Text);
+            let schema = Arc::new(vec![f1, f2]);
 
             let data = vec![
                 (Some(0), Some("Tom")),
                 (Some(1), Some("Jerry")),
                 (Some(2), None),
             ];
-            let data_row_stream = stream::iter(data.into_iter()).map(|r| {
-                let mut encoder = DataRowEncoder::new(2);
-                encoder.encode_field(&r.0, &Type::INT4, FieldFormat::Text)?;
-                encoder.encode_field(&r.1, &Type::VARCHAR, FieldFormat::Text)?;
+            let schema_ref = schema.clone();
+            let data_row_stream = stream::iter(data.into_iter()).map(move |r| {
+                let mut encoder = DataRowEncoder::new(schema_ref.clone());
+                encoder.encode_field(&r.0)?;
+                encoder.encode_field(&r.1)?;
 
                 encoder.finish()
             });
 
             Ok(vec![Response::Query(query_response(
-                Some(vec![f1, f2]),
+                schema,
                 data_row_stream,
             ))])
         } else {

--- a/examples/server.rs
+++ b/examples/server.rs
@@ -6,7 +6,7 @@ use tokio::net::TcpListener;
 
 use pgwire::api::auth::noop::NoopStartupHandler;
 use pgwire::api::query::{PlaceholderExtendedQueryHandler, SimpleQueryHandler};
-use pgwire::api::results::{query_response, DataRowEncoder, FieldFormat, FieldInfo, Response, Tag};
+use pgwire::api::results::{DataRowEncoder, FieldFormat, FieldInfo, QueryResponse, Response, Tag};
 use pgwire::api::{ClientInfo, MakeHandler, StatelessMakeHandler, Type};
 use pgwire::error::PgWireResult;
 use pgwire::tokio::process_socket;
@@ -39,7 +39,7 @@ impl SimpleQueryHandler for DummyProcessor {
                 encoder.finish()
             });
 
-            Ok(vec![Response::Query(query_response(
+            Ok(vec![Response::Query(QueryResponse::new(
                 schema,
                 data_row_stream,
             ))])

--- a/examples/server.rs
+++ b/examples/server.rs
@@ -23,22 +23,24 @@ impl SimpleQueryHandler for DummyProcessor {
         if query.starts_with("SELECT") {
             let f1 = FieldInfo::new("id".into(), None, None, Type::INT4, FieldFormat::Text);
             let f2 = FieldInfo::new("name".into(), None, None, Type::VARCHAR, FieldFormat::Text);
+            let schema = Arc::new(vec![f1, f2]);
 
             let data = vec![
                 (Some(0), Some("Tom")),
                 (Some(1), Some("Jerry")),
                 (Some(2), None),
             ];
-            let data_row_stream = stream::iter(data.into_iter()).map(|r| {
-                let mut encoder = DataRowEncoder::new(2);
-                encoder.encode_field(&r.0, &Type::INT4, FieldFormat::Text)?;
-                encoder.encode_field(&r.1, &Type::VARCHAR, FieldFormat::Text)?;
+            let schema_ref = schema.clone();
+            let data_row_stream = stream::iter(data.into_iter()).map(move |r| {
+                let mut encoder = DataRowEncoder::new(schema_ref.clone());
+                encoder.encode_field(&r.0)?;
+                encoder.encode_field(&r.1)?;
 
                 encoder.finish()
             });
 
             Ok(vec![Response::Query(query_response(
-                Some(vec![f1, f2]),
+                schema,
                 data_row_stream,
             ))])
         } else {

--- a/examples/sqlite.rs
+++ b/examples/sqlite.rs
@@ -11,7 +11,7 @@ use pgwire::api::auth::{
 use pgwire::api::portal::{Format, Portal};
 use pgwire::api::query::{ExtendedQueryHandler, SimpleQueryHandler, StatementOrPortal};
 use pgwire::api::results::{
-    query_response, DataRowEncoder, DescribeResponse, FieldInfo, Response, Tag,
+    DataRowEncoder, DescribeResponse, FieldInfo, QueryResponse, Response, Tag,
 };
 use pgwire::api::stmt::NoopQueryParser;
 use pgwire::api::store::MemPortalStore;
@@ -87,7 +87,7 @@ impl SimpleQueryHandler for SqliteBackend {
             stmt.query(())
                 .map(|rows| {
                     let s = encode_row_data(rows, header.clone());
-                    vec![Response::Query(query_response(header, s))]
+                    vec![Response::Query(QueryResponse::new(header, s))]
                 })
                 .map_err(|e| PgWireError::ApiError(Box::new(e)))
         } else {
@@ -252,7 +252,7 @@ impl ExtendedQueryHandler for SqliteBackend {
             stmt.query::<&[&dyn rusqlite::ToSql]>(params_ref.as_ref())
                 .map(|rows| {
                     let s = encode_row_data(rows, header.clone());
-                    Response::Query(query_response(header, s))
+                    Response::Query(QueryResponse::new(header, s))
                 })
                 .map_err(|e| PgWireError::ApiError(Box::new(e)))
         } else {

--- a/src/api/results.rs
+++ b/src/api/results.rs
@@ -103,7 +103,7 @@ impl From<&FieldInfo> for FieldDescription {
     }
 }
 
-pub(crate) fn into_row_description(fields: &Vec<FieldInfo>) -> RowDescription {
+pub(crate) fn into_row_description(fields: &[FieldInfo]) -> RowDescription {
     RowDescription::new(fields.iter().map(Into::into).collect())
 }
 

--- a/tests-integration/test-server/Cargo.lock
+++ b/tests-integration/test-server/Cargo.lock
@@ -203,12 +203,11 @@ dependencies = [
 
 [[package]]
 name = "der"
-version = "0.7.1"
+version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bc906908ea6458456e5eaa160a9c08543ec3d1e6f71e2235cedd660cb65f9df0"
+checksum = "f1a467a65c5e759bce6e65eaf91cc29f466cdc57cb65777bd646872a8a1fd4de"
 dependencies = [
  "const-oid",
- "zeroize",
 ]
 
 [[package]]
@@ -821,9 +820,9 @@ checksum = "6e63cff320ae2c57904679ba7cb63280a3dc4613885beafb148ee7bf9aa9042d"
 
 [[package]]
 name = "spki"
-version = "0.7.0"
+version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c0445c905640145c7ea8c1993555957f65e7c46d0535b91ba501bc9bfc85522f"
+checksum = "67cf02bbac7a337dc36e4f5a693db6c21e7863f45070f7064577eb4367a3212b"
 dependencies = [
  "base64ct",
  "der",
@@ -1269,9 +1268,9 @@ checksum = "447660ad36a13288b1db4d4248e857b510e8c3a225c822ba4fb748c0aafecffd"
 
 [[package]]
 name = "x509-certificate"
-version = "0.19.0"
+version = "0.18.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bf14059fbc1dce14de1d08535c411ba0b18749c2550a12550300da90b7ba350b"
+checksum = "b6ae06cd45e681e1ae216e2e668e30ce1c4f02db026374bde8c0644684af1721"
 dependencies = [
  "bcder",
  "bytes",
@@ -1284,9 +1283,3 @@ dependencies = [
  "spki",
  "thiserror",
 ]
-
-[[package]]
-name = "zeroize"
-version = "1.5.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c394b5bd0c6f669e7275d9c20aa90ae064cb22e75a1cad54e1b34088034b149f"

--- a/tests-integration/test-server/src/main.rs
+++ b/tests-integration/test-server/src/main.rs
@@ -12,7 +12,7 @@ use pgwire::api::auth::{
 use pgwire::api::portal::{Format, Portal};
 use pgwire::api::query::{ExtendedQueryHandler, SimpleQueryHandler, StatementOrPortal};
 use pgwire::api::results::{
-    query_response, DataRowEncoder, DescribeResponse, FieldInfo, Response, Tag,
+    DataRowEncoder, DescribeResponse, FieldInfo, QueryResponse, Response, Tag,
 };
 use pgwire::api::stmt::NoopQueryParser;
 use pgwire::api::store::MemPortalStore;
@@ -106,7 +106,7 @@ impl SimpleQueryHandler for DummyDatabase {
                 encoder.finish()
             });
 
-            Ok(vec![Response::Query(query_response(
+            Ok(vec![Response::Query(QueryResponse::new(
                 schema,
                 data_row_stream,
             ))])
@@ -166,7 +166,7 @@ impl ExtendedQueryHandler for DummyDatabase {
                 encoder.finish()
             });
 
-            Ok(Response::Query(query_response(schema, data_row_stream)))
+            Ok(Response::Query(QueryResponse::new(schema, data_row_stream)))
         } else {
             Ok(Response::Execution(Tag::new_for_execution("OK", Some(1))))
         }


### PR DESCRIPTION
Use schema of columns for DataRowEncoder so we can simplify `encode_value` function. Redundant information like type and format are already included in `FieldInfo`s . 