### PR TITLE
Revert "chore(deps): update x509-certificate requirement from 0.18 to 0.19"

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -80,6 +80,6 @@ jobs:
     - uses: actions/checkout@v3
     - uses: actions-rs/toolchain@v1
       with:
-        toolchain: "1.65"
+        toolchain: "1.63"
         override: true
     - run: cargo test --all-features

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,7 +30,7 @@ hex = "0.4"
 base64 = "0.21"
 ring = "0.16"
 stringprep = "0.1.2"
-x509-certificate = "0.19"
+x509-certificate = "0.18"
 
 tokio = { version = "1.19", features = ["net", "rt", "io-util"], optional = true}
 tokio-util = { version = "0.7.3", features = ["codec", "io"], optional = true }


### PR DESCRIPTION
Reverts sunng87/pgwire#63

We will update x509-certificate later when syn 2.0 get wider adoption