### PR TITLE
feat: empty query support for extended query

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,20 @@
 All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
-and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+and this project adheres to [Semantic
+Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased] - ReleaseDate
+
+### Added
+
+- Message `NoData` that sends from backend when empty query executed in extended
+  query context.
+- Add `EmptyQuery` to `Response` enum to represent response for empty query.
+
+### Fixed
+
+- Empty query check for `SimpleQueryHandler`. #75
 
 ## [0.12.0] - 2023-03-26
 

--- a/src/api/query.rs
+++ b/src/api/query.rs
@@ -377,11 +377,13 @@ where
         client
             .send(PgWireBackendMessage::RowDescription(row_desc))
             .await?;
-        client
-            .send(PgWireBackendMessage::ReadyForQuery(ReadyForQuery::new(
-                READY_STATUS_IDLE,
-            )))
-            .await?;
+        if include_parameters {
+            client
+                .send(PgWireBackendMessage::ReadyForQuery(ReadyForQuery::new(
+                    READY_STATUS_IDLE,
+                )))
+                .await?;
+        }
     }
 
     Ok(())

--- a/src/api/results.rs
+++ b/src/api/results.rs
@@ -224,7 +224,21 @@ pub struct DescribeResponse {
     fields: Vec<FieldInfo>,
 }
 
-impl DescribeResponse {}
+impl DescribeResponse {
+    /// Create an no_data instance of `DescribeResponse`. This is typically used
+    /// when client tries to describe an empty query.
+    pub fn no_data() -> Self {
+        DescribeResponse {
+            parameters: None,
+            fields: vec![],
+        }
+    }
+
+    /// Return true if the `DescribeResponse` is empty/nodata
+    pub fn is_no_data(&self) -> bool {
+        self.parameters.is_none() && self.fields.is_empty()
+    }
+}
 
 /// Query response types:
 ///

--- a/src/api/results.rs
+++ b/src/api/results.rs
@@ -232,6 +232,7 @@ impl DescribeResponse {}
 /// * Execution: response for ddl/dml execution
 /// * Error: error response
 pub enum Response<'a> {
+    EmptyQuery,
     Query(QueryResponse<'a>),
     Execution(Tag),
     Error(Box<ErrorInfo>),

--- a/src/messages/data.rs
+++ b/src/messages/data.rs
@@ -187,3 +187,30 @@ impl Message for DataRow {
         Ok(DataRow { fields })
     }
 }
+
+/// postgres response when query returns no data, sent from backend to frontend
+/// in extended query
+#[derive(Getters, Setters, MutGetters, PartialEq, Eq, Debug, Default, new)]
+#[getset(get = "pub", set = "pub", get_mut = "pub")]
+pub struct NoData;
+
+pub const MESSAGE_TYPE_BYTE_NO_DATA: u8 = b'n';
+
+impl Message for NoData {
+    #[inline]
+    fn message_type() -> Option<u8> {
+        Some(MESSAGE_TYPE_BYTE_NO_DATA)
+    }
+
+    fn message_length(&self) -> usize {
+        4
+    }
+
+    fn encode_body(&self, _buf: &mut BytesMut) -> PgWireResult<()> {
+        Ok(())
+    }
+
+    fn decode_body(_buf: &mut BytesMut, _: usize) -> PgWireResult<Self> {
+        Ok(NoData::new())
+    }
+}

--- a/src/messages/mod.rs
+++ b/src/messages/mod.rs
@@ -177,6 +177,7 @@ pub enum PgWireBackendMessage {
     ParameterDescription(data::ParameterDescription),
     RowDescription(data::RowDescription),
     DataRow(data::DataRow),
+    NoData(data::NoData),
 }
 
 impl PgWireBackendMessage {
@@ -200,6 +201,7 @@ impl PgWireBackendMessage {
             Self::ParameterDescription(msg) => msg.encode(buf),
             Self::RowDescription(msg) => msg.encode(buf),
             Self::DataRow(msg) => msg.encode(buf),
+            Self::NoData(msg) => msg.encode(buf),
         }
     }
 
@@ -257,6 +259,9 @@ impl PgWireBackendMessage {
                 }
                 data::MESSAGE_TYPE_BYTE_DATA_ROW => {
                     data::DataRow::decode(buf).map(|v| v.map(Self::DataRow))
+                }
+                data::MESSAGE_TYPE_BYTE_NO_DATA => {
+                    data::NoData::decode(buf).map(|v| v.map(Self::NoData))
                 }
                 _ => Err(PgWireError::InvalidMessageType(first_byte)),
             }
@@ -492,5 +497,11 @@ mod test {
         let item2 = PasswordMessageFamily::decode(&mut buffer).unwrap().unwrap();
         assert_eq!(buffer.remaining(), 0);
         assert_eq!(saslinitialresp, item2.into_sasl_initial_response().unwrap());
+    }
+
+    #[test]
+    fn test_no_data() {
+        let nodata = NoData::new();
+        roundtrip!(nodata, NoData);
     }
 }


### PR DESCRIPTION
This patch further enhanced what we have in #75.

- It adds `NoData` message in our codec
- It adds `EmptyQuery` in `Response` when implementation detects query is empty
- Sents `NoData` on describe
