### PR TITLE
refactor: add owned version of data_row getters for query response

### DIFF
--- a/src/api/query.rs
+++ b/src/api/query.rs
@@ -342,7 +342,8 @@ where
     Ok(())
 }
 
-async fn send_execution_response<C>(client: &mut C, tag: Tag) -> PgWireResult<()>
+/// Helper function to send response for DMLs.
+pub async fn send_execution_response<C>(client: &mut C, tag: Tag) -> PgWireResult<()>
 where
     C: ClientInfo + Sink<PgWireBackendMessage> + Unpin + Send + Sync,
     C::Error: Debug,
@@ -355,7 +356,8 @@ where
     Ok(())
 }
 
-async fn send_describe_response<C>(
+/// Helper function to send response for `Describe`.
+pub async fn send_describe_response<C>(
     client: &mut C,
     describe_response: &DescribeResponse,
     include_parameters: bool,

--- a/src/api/query.rs
+++ b/src/api/query.rs
@@ -315,10 +315,8 @@ where
     C::Error: Debug,
     PgWireError: From<<C as Sink<PgWireBackendMessage>>::Error>,
 {
-    let QueryResponse {
-        row_schema,
-        mut data_rows,
-    } = results;
+    let row_schema = results.row_schema();
+    let mut data_rows = results.data_rows();
 
     // Simple query has row_schema in query response. For extended query,
     // row_schema is returned as response of `Describe`.

--- a/src/api/results.rs
+++ b/src/api/results.rs
@@ -107,11 +107,9 @@ pub(crate) fn into_row_description(fields: &[FieldInfo]) -> RowDescription {
     RowDescription::new(fields.iter().map(Into::into).collect())
 }
 
-#[derive(Getters)]
-#[getset(get = "pub")]
 pub struct QueryResponse<'a> {
-    pub(crate) row_schema: Arc<Vec<FieldInfo>>,
-    pub(crate) data_rows: BoxStream<'a, PgWireResult<DataRow>>,
+    row_schema: Arc<Vec<FieldInfo>>,
+    data_rows: BoxStream<'a, PgWireResult<DataRow>>,
 }
 
 impl<'a> QueryResponse<'a> {
@@ -124,6 +122,16 @@ impl<'a> QueryResponse<'a> {
             row_schema: field_defs,
             data_rows: row_stream.boxed(),
         }
+    }
+
+    /// Get schema of columns
+    pub fn row_schema(&self) -> Arc<Vec<FieldInfo>> {
+        self.row_schema.clone()
+    }
+
+    /// Get owned `BoxStream` of data rows
+    pub fn data_rows(self) -> BoxStream<'a, PgWireResult<DataRow>> {
+        self.data_rows
     }
 }
 


### PR DESCRIPTION
Fixes #82 

This patch provides owned getters for `QueryResponse`.