### PR TITLE
feat: Copy messages

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ with its usage.
   - [x] Frontend-Backend protocol messages
   - [ ] Logical replication streaming protocol message
 - [x] Backend TCP/TLS server on Tokio
-- [ ] Frontend-Backend interaction over TCP
+- [x] Frontend-Backend interaction over TCP
   - [x] SSL Request and Response
   - [x] Startup
     - [x] No authentication
@@ -38,7 +38,7 @@ with its usage.
   - [x] Termination
   - [x] Cancel
   - [x] Error and Notice
-  - [ ] Copy
+  - [x] Copy
 - [ ] Logical replication over TCP
 - [ ] APIs
   - [x] Startup APIs
@@ -51,6 +51,10 @@ with its usage.
   - [x] ResultSet builder/encoder API
   - [ ] Query Cancellation API
   - [x] Error and Notice API
+  - [ ] Copy API
+    - [ ] Copy-in
+    - [ ] Copy-out
+    - [ ] Copy-both
   - [ ] Logical replication server API
 
 ## About Postgres Wire Protocol

--- a/src/messages/copy.rs
+++ b/src/messages/copy.rs
@@ -1,0 +1,211 @@
+use bytes::{Buf, BufMut, Bytes, BytesMut};
+
+use super::codec;
+use super::Message;
+use crate::error::PgWireResult;
+
+pub const MESSAGE_TYPE_BYTE_COPY_DATA: u8 = b'd';
+
+#[derive(Getters, Setters, MutGetters, PartialEq, Eq, Debug, Default, new)]
+#[getset(get = "pub", set = "pub", get_mut = "pub")]
+pub struct CopyData {
+    data: Bytes,
+}
+
+impl Message for CopyData {
+    #[inline]
+    fn message_type() -> Option<u8> {
+        Some(MESSAGE_TYPE_BYTE_COPY_DATA)
+    }
+
+    fn message_length(&self) -> usize {
+        4 + self.data.len()
+    }
+
+    fn encode_body(&self, buf: &mut BytesMut) -> PgWireResult<()> {
+        buf.put(self.data.as_ref());
+        Ok(())
+    }
+
+    fn decode_body(buf: &mut BytesMut, len: usize) -> PgWireResult<Self> {
+        let data = buf.split_to(len - 4).freeze();
+        Ok(Self::new(data))
+    }
+}
+
+pub const MESSAGE_TYPE_BYTE_COPY_DONE: u8 = b'c';
+
+#[derive(Getters, Setters, MutGetters, PartialEq, Eq, Debug, Default, new)]
+#[getset(get = "pub", set = "pub", get_mut = "pub")]
+pub struct CopyDone;
+
+impl Message for CopyDone {
+    #[inline]
+    fn message_type() -> Option<u8> {
+        Some(MESSAGE_TYPE_BYTE_COPY_DONE)
+    }
+
+    fn message_length(&self) -> usize {
+        4
+    }
+
+    fn encode_body(&self, _buf: &mut BytesMut) -> PgWireResult<()> {
+        Ok(())
+    }
+
+    fn decode_body(_buf: &mut BytesMut, _len: usize) -> PgWireResult<Self> {
+        Ok(Self::new())
+    }
+}
+
+pub const MESSAGE_TYPE_BYTE_COPY_FAIL: u8 = b'f';
+
+#[derive(Getters, Setters, MutGetters, PartialEq, Eq, Debug, Default, new)]
+#[getset(get = "pub", set = "pub", get_mut = "pub")]
+pub struct CopyFail {
+    message: String,
+}
+
+impl Message for CopyFail {
+    #[inline]
+    fn message_type() -> Option<u8> {
+        Some(MESSAGE_TYPE_BYTE_COPY_DONE)
+    }
+
+    fn message_length(&self) -> usize {
+        4 + self.message.as_bytes().len() + 1
+    }
+
+    fn encode_body(&self, buf: &mut BytesMut) -> PgWireResult<()> {
+        codec::put_cstring(buf, &self.message);
+        Ok(())
+    }
+
+    fn decode_body(buf: &mut BytesMut, _len: usize) -> PgWireResult<Self> {
+        let msg = codec::get_cstring(buf).unwrap_or_else(|| "".to_owned());
+        Ok(Self::new(msg))
+    }
+}
+
+pub const MESSAGE_TYPE_BYTE_COPY_IN_RESPONSE: u8 = b'G';
+
+#[derive(Getters, Setters, MutGetters, PartialEq, Eq, Debug, Default, new)]
+#[getset(get = "pub", set = "pub", get_mut = "pub")]
+pub struct CopyInResponse {
+    format: i8,
+    columns: i16,
+    column_formats: Vec<i16>,
+}
+
+impl Message for CopyInResponse {
+    #[inline]
+    fn message_type() -> Option<u8> {
+        Some(MESSAGE_TYPE_BYTE_COPY_IN_RESPONSE)
+    }
+
+    fn message_length(&self) -> usize {
+        4 + 1 + 2 + self.column_formats.len() * 2
+    }
+
+    fn encode_body(&self, buf: &mut BytesMut) -> PgWireResult<()> {
+        buf.put_i8(self.format);
+        buf.put_i16(self.columns);
+        for cf in &self.column_formats {
+            buf.put_i16(*cf);
+        }
+        Ok(())
+    }
+
+    fn decode_body(buf: &mut BytesMut, _len: usize) -> PgWireResult<Self> {
+        let format = buf.get_i8();
+        let columns = buf.get_i16();
+        let mut column_formats = Vec::with_capacity(columns as usize);
+        for _ in 0..columns {
+            column_formats.push(buf.get_i16());
+        }
+
+        Ok(Self::new(format, columns, column_formats))
+    }
+}
+
+pub const MESSAGE_TYPE_BYTE_COPY_OUT_RESPONSE: u8 = b'H';
+
+#[derive(Getters, Setters, MutGetters, PartialEq, Eq, Debug, Default, new)]
+#[getset(get = "pub", set = "pub", get_mut = "pub")]
+pub struct CopyOutResponse {
+    format: i8,
+    columns: i16,
+    column_formats: Vec<i16>,
+}
+
+impl Message for CopyOutResponse {
+    #[inline]
+    fn message_type() -> Option<u8> {
+        Some(MESSAGE_TYPE_BYTE_COPY_OUT_RESPONSE)
+    }
+
+    fn message_length(&self) -> usize {
+        4 + 1 + 2 + self.column_formats.len() * 2
+    }
+
+    fn encode_body(&self, buf: &mut BytesMut) -> PgWireResult<()> {
+        buf.put_i8(self.format);
+        buf.put_i16(self.columns);
+        for cf in &self.column_formats {
+            buf.put_i16(*cf);
+        }
+        Ok(())
+    }
+
+    fn decode_body(buf: &mut BytesMut, _len: usize) -> PgWireResult<Self> {
+        let format = buf.get_i8();
+        let columns = buf.get_i16();
+        let mut column_formats = Vec::with_capacity(columns as usize);
+        for _ in 0..columns {
+            column_formats.push(buf.get_i16());
+        }
+
+        Ok(Self::new(format, columns, column_formats))
+    }
+}
+
+pub const MESSAGE_TYPE_BYTE_COPY_BOTH_RESPONSE: u8 = b'W';
+
+#[derive(Getters, Setters, MutGetters, PartialEq, Eq, Debug, Default, new)]
+#[getset(get = "pub", set = "pub", get_mut = "pub")]
+pub struct CopyBothResponse {
+    format: i8,
+    columns: i16,
+    column_formats: Vec<i16>,
+}
+
+impl Message for CopyBothResponse {
+    #[inline]
+    fn message_type() -> Option<u8> {
+        Some(MESSAGE_TYPE_BYTE_COPY_BOTH_RESPONSE)
+    }
+
+    fn message_length(&self) -> usize {
+        4 + 1 + 2 + self.column_formats.len() * 2
+    }
+
+    fn encode_body(&self, buf: &mut BytesMut) -> PgWireResult<()> {
+        buf.put_i8(self.format);
+        buf.put_i16(self.columns);
+        for cf in &self.column_formats {
+            buf.put_i16(*cf);
+        }
+        Ok(())
+    }
+
+    fn decode_body(buf: &mut BytesMut, _len: usize) -> PgWireResult<Self> {
+        let format = buf.get_i8();
+        let columns = buf.get_i16();
+        let mut column_formats = Vec::with_capacity(columns as usize);
+        for _ in 0..columns {
+            column_formats.push(buf.get_i16());
+        }
+
+        Ok(Self::new(format, columns, column_formats))
+    }
+}

--- a/src/messages/mod.rs
+++ b/src/messages/mod.rs
@@ -55,6 +55,8 @@ pub trait Message: Sized {
 }
 
 mod codec;
+/// Copy messages
+pub mod copy;
 /// Data related messages
 pub mod data;
 /// Extended query messages, including request/response for parse, bind and etc.
@@ -85,6 +87,10 @@ pub enum PgWireFrontendMessage {
     Sync(extendedquery::Sync),
 
     Terminate(terminate::Terminate),
+
+    CopyData(copy::CopyData),
+    CopyFail(copy::CopyFail),
+    CopyDone(copy::CopyDone),
 }
 
 impl PgWireFrontendMessage {
@@ -104,6 +110,10 @@ impl PgWireFrontendMessage {
             Self::Sync(msg) => msg.encode(buf),
 
             Self::Terminate(msg) => msg.encode(buf),
+
+            Self::CopyData(msg) => msg.encode(buf),
+            Self::CopyFail(msg) => msg.encode(buf),
+            Self::CopyDone(msg) => msg.encode(buf),
         }
     }
 
@@ -144,6 +154,16 @@ impl PgWireFrontendMessage {
                 terminate::MESSAGE_TYPE_BYTE_TERMINATE => {
                     terminate::Terminate::decode(buf).map(|v| v.map(Self::Terminate))
                 }
+
+                copy::MESSAGE_TYPE_BYTE_COPY_DATA => {
+                    copy::CopyData::decode(buf).map(|v| v.map(Self::CopyData))
+                }
+                copy::MESSAGE_TYPE_BYTE_COPY_FAIL => {
+                    copy::CopyFail::decode(buf).map(|v| v.map(Self::CopyFail))
+                }
+                copy::MESSAGE_TYPE_BYTE_COPY_DONE => {
+                    copy::CopyDone::decode(buf).map(|v| v.map(Self::CopyDone))
+                }
                 _ => Err(PgWireError::InvalidMessageType(first_byte)),
             }
         } else {
@@ -178,6 +198,14 @@ pub enum PgWireBackendMessage {
     RowDescription(data::RowDescription),
     DataRow(data::DataRow),
     NoData(data::NoData),
+
+    // copy
+    CopyData(copy::CopyData),
+    CopyFail(copy::CopyFail),
+    CopyDone(copy::CopyDone),
+    CopyInResponse(copy::CopyInResponse),
+    CopyOutResponse(copy::CopyOutResponse),
+    CopyBothResponse(copy::CopyBothResponse),
 }
 
 impl PgWireBackendMessage {
@@ -202,6 +230,13 @@ impl PgWireBackendMessage {
             Self::RowDescription(msg) => msg.encode(buf),
             Self::DataRow(msg) => msg.encode(buf),
             Self::NoData(msg) => msg.encode(buf),
+
+            Self::CopyData(msg) => msg.encode(buf),
+            Self::CopyFail(msg) => msg.encode(buf),
+            Self::CopyDone(msg) => msg.encode(buf),
+            Self::CopyInResponse(msg) => msg.encode(buf),
+            Self::CopyOutResponse(msg) => msg.encode(buf),
+            Self::CopyBothResponse(msg) => msg.encode(buf),
         }
     }
 
@@ -263,6 +298,25 @@ impl PgWireBackendMessage {
                 data::MESSAGE_TYPE_BYTE_NO_DATA => {
                     data::NoData::decode(buf).map(|v| v.map(Self::NoData))
                 }
+
+                copy::MESSAGE_TYPE_BYTE_COPY_DATA => {
+                    copy::CopyData::decode(buf).map(|v| v.map(Self::CopyData))
+                }
+                copy::MESSAGE_TYPE_BYTE_COPY_FAIL => {
+                    copy::CopyFail::decode(buf).map(|v| v.map(Self::CopyFail))
+                }
+                copy::MESSAGE_TYPE_BYTE_COPY_DONE => {
+                    copy::CopyDone::decode(buf).map(|v| v.map(Self::CopyDone))
+                }
+                copy::MESSAGE_TYPE_BYTE_COPY_IN_RESPONSE => {
+                    copy::CopyInResponse::decode(buf).map(|v| v.map(Self::CopyInResponse))
+                }
+                copy::MESSAGE_TYPE_BYTE_COPY_OUT_RESPONSE => {
+                    copy::CopyOutResponse::decode(buf).map(|v| v.map(Self::CopyOutResponse))
+                }
+                copy::MESSAGE_TYPE_BYTE_COPY_BOTH_RESPONSE => {
+                    copy::CopyBothResponse::decode(buf).map(|v| v.map(Self::CopyBothResponse))
+                }
                 _ => Err(PgWireError::InvalidMessageType(first_byte)),
             }
         } else {
@@ -273,6 +327,7 @@ impl PgWireBackendMessage {
 
 #[cfg(test)]
 mod test {
+    use super::copy::*;
     use super::data::*;
     use super::extendedquery::*;
     use super::response::*;
@@ -285,11 +340,13 @@ mod test {
     macro_rules! roundtrip {
         ($ins:ident, $st:ty) => {
             let mut buffer = BytesMut::new();
-            $ins.encode(&mut buffer).unwrap();
+            $ins.encode(&mut buffer).expect("encode packet");
 
             assert!(buffer.remaining() > 0);
 
-            let item2 = <$st>::decode(&mut buffer).unwrap().unwrap();
+            let item2 = <$st>::decode(&mut buffer)
+                .expect("decode packet")
+                .expect("packet is none");
 
             assert_eq!(buffer.remaining(), 0);
             assert_eq!($ins, item2);
@@ -503,5 +560,11 @@ mod test {
     fn test_no_data() {
         let nodata = NoData::new();
         roundtrip!(nodata, NoData);
+    }
+
+    #[test]
+    fn test_copy_data() {
+        let copydata = CopyData::new(Bytes::from_static("tomcat".as_bytes()));
+        roundtrip!(copydata, CopyData);
     }
 }

--- a/src/messages/mod.rs
+++ b/src/messages/mod.rs
@@ -567,4 +567,28 @@ mod test {
         let copydata = CopyData::new(Bytes::from_static("tomcat".as_bytes()));
         roundtrip!(copydata, CopyData);
     }
+
+    #[test]
+    fn test_copy_done() {
+        let copydone = CopyDone::new();
+        roundtrip!(copydone, CopyDone);
+    }
+
+    #[test]
+    fn test_copy_fail() {
+        let copyfail = CopyFail::new("copy failed".to_owned());
+        roundtrip!(copyfail, CopyFail);
+    }
+
+    #[test]
+    fn test_copy_response() {
+        let copyresponse = CopyInResponse::new(0, 3, vec![0, 0, 0]);
+        roundtrip!(copyresponse, CopyInResponse);
+
+        let copyresponse = CopyOutResponse::new(0, 3, vec![0, 0, 0]);
+        roundtrip!(copyresponse, CopyOutResponse);
+
+        let copyresponse = CopyBothResponse::new(0, 3, vec![0, 0, 0]);
+        roundtrip!(copyresponse, CopyBothResponse);
+    }
 }


### PR DESCRIPTION
This patch adds codec for copy messages:

- CopyData
- CopyDone
- CopyFail
- Copy[In|Out|Both]Response