### PR TITLE
refactor: make QueryParser async

### DIFF
--- a/src/api/query.rs
+++ b/src/api/query.rs
@@ -113,7 +113,7 @@ pub trait ExtendedQueryHandler: Send + Sync {
         C::Error: Debug,
         PgWireError: From<<C as Sink<PgWireBackendMessage>>::Error>,
     {
-        let parser = self.query_parser().clone();
+        let parser = self.query_parser();
         let stmt = StoredStatement::parse(&message, parser).await?;
         self.portal_store().put_statement(Arc::new(stmt));
         client

--- a/src/api/query.rs
+++ b/src/api/query.rs
@@ -94,7 +94,7 @@ pub trait SimpleQueryHandler: Send + Sync {
 #[async_trait]
 pub trait ExtendedQueryHandler: Send + Sync {
     type Statement: Clone + Send + Sync;
-    type QueryParser: QueryParser<Statement = Self::Statement>;
+    type QueryParser: QueryParser<Statement = Self::Statement> + Send + Sync;
     type PortalStore: PortalStore<Statement = Self::Statement>;
 
     /// Get a reference to associated `PortalStore` implementation
@@ -113,7 +113,8 @@ pub trait ExtendedQueryHandler: Send + Sync {
         C::Error: Debug,
         PgWireError: From<<C as Sink<PgWireBackendMessage>>::Error>,
     {
-        let stmt = StoredStatement::parse(&message, self.query_parser().as_ref())?;
+        let parser = self.query_parser().clone();
+        let stmt = StoredStatement::parse(&message, parser).await?;
         self.portal_store().put_statement(Arc::new(stmt));
         client
             .send(PgWireBackendMessage::ParseComplete(ParseComplete::new()))

--- a/src/api/stmt.rs
+++ b/src/api/stmt.rs
@@ -59,7 +59,7 @@ where
     type Statement = QP::Statement;
 
     async fn parse_sql(&self, sql: &str, types: &[Type]) -> PgWireResult<Self::Statement> {
-        self.parse_sql(sql, types).await
+        (**self).parse_sql(sql, types).await
     }
 }
 

--- a/src/api/stmt.rs
+++ b/src/api/stmt.rs
@@ -1,3 +1,6 @@
+use std::sync::Arc;
+
+use async_trait::async_trait;
 use postgres_types::Type;
 
 use crate::error::{PgWireError, PgWireResult};
@@ -18,7 +21,7 @@ pub struct StoredStatement<S> {
 }
 
 impl<S> StoredStatement<S> {
-    pub(crate) fn parse<Q>(parse: &Parse, parser: &Q) -> PgWireResult<StoredStatement<S>>
+    pub(crate) async fn parse<Q>(parse: &Parse, parser: Q) -> PgWireResult<StoredStatement<S>>
     where
         Q: QueryParser<Statement = S>,
     {
@@ -27,7 +30,7 @@ impl<S> StoredStatement<S> {
             .iter()
             .map(|oid| Type::from_oid(*oid).ok_or_else(|| PgWireError::UnknownTypeId(*oid)))
             .collect::<PgWireResult<Vec<Type>>>()?;
-        let statement = parser.parse_sql(parse.query(), &types)?;
+        let statement = parser.parse_sql(parse.query(), &types).await?;
         Ok(StoredStatement {
             id: parse
                 .name()
@@ -41,20 +44,34 @@ impl<S> StoredStatement<S> {
 
 /// Trait for sql parser. The parser transforms string query into its statement
 /// type.
+#[async_trait]
 pub trait QueryParser {
     type Statement;
 
-    fn parse_sql(&self, sql: &str, types: &[Type]) -> PgWireResult<Self::Statement>;
+    async fn parse_sql(&self, sql: &str, types: &[Type]) -> PgWireResult<Self::Statement>;
+}
+
+#[async_trait]
+impl<QP> QueryParser for Arc<QP>
+where
+    QP: QueryParser + Send + Sync,
+{
+    type Statement = QP::Statement;
+
+    async fn parse_sql(&self, sql: &str, types: &[Type]) -> PgWireResult<Self::Statement> {
+        self.parse_sql(sql, types).await
+    }
 }
 
 /// A demo parser implementation. Never use it in serious application.
 #[derive(new, Debug, Default)]
 pub struct NoopQueryParser;
 
+#[async_trait]
 impl QueryParser for NoopQueryParser {
     type Statement = String;
 
-    fn parse_sql(&self, sql: &str, _types: &[Type]) -> PgWireResult<Self::Statement> {
+    async fn parse_sql(&self, sql: &str, _types: &[Type]) -> PgWireResult<Self::Statement> {
         Ok(sql.to_owned())
     }
 }


### PR DESCRIPTION
This patch makes `QueryParser` in extended subprotocol handler async. We find in some implementation, it is possible to have an async implementation to parse sql into certain execution plan.