### PR TITLE
feat!: allow server inferenced type for portal

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -80,6 +80,6 @@ jobs:
     - uses: actions/checkout@v3
     - uses: actions-rs/toolchain@v1
       with:
-        toolchain: "1.65"
+        toolchain: "1.67"
         override: true
     - run: cargo build --all-features

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ homepage = "https://github.com/sunng87/pgwire"
 repository = "https://github.com/sunng87/pgwire"
 documentation = "https://docs.rs/crate/pgwire/"
 readme = "README.md"
-rust-version = "1.65"
+rust-version = "1.67"
 
 [dependencies]
 log = "0.4"

--- a/examples/sqlite.rs
+++ b/examples/sqlite.rs
@@ -147,31 +147,31 @@ fn get_params(portal: &Portal<String>) -> Vec<Box<dyn ToSql>> {
         // we only support a small amount of types for demo
         match param_type {
             &Type::BOOL => {
-                let param = portal.parameter::<bool>(i).unwrap();
+                let param = portal.parameter::<bool>(i, param_type).unwrap();
                 results.push(Box::new(param) as Box<dyn ToSql>);
             }
             &Type::INT2 => {
-                let param = portal.parameter::<i16>(i).unwrap();
+                let param = portal.parameter::<i16>(i, param_type).unwrap();
                 results.push(Box::new(param) as Box<dyn ToSql>);
             }
             &Type::INT4 => {
-                let param = portal.parameter::<i32>(i).unwrap();
+                let param = portal.parameter::<i32>(i, param_type).unwrap();
                 results.push(Box::new(param) as Box<dyn ToSql>);
             }
             &Type::INT8 => {
-                let param = portal.parameter::<i64>(i).unwrap();
+                let param = portal.parameter::<i64>(i, param_type).unwrap();
                 results.push(Box::new(param) as Box<dyn ToSql>);
             }
             &Type::TEXT | &Type::VARCHAR => {
-                let param = portal.parameter::<String>(i).unwrap();
+                let param = portal.parameter::<String>(i, param_type).unwrap();
                 results.push(Box::new(param) as Box<dyn ToSql>);
             }
             &Type::FLOAT4 => {
-                let param = portal.parameter::<f32>(i).unwrap();
+                let param = portal.parameter::<f32>(i, param_type).unwrap();
                 results.push(Box::new(param) as Box<dyn ToSql>);
             }
             &Type::FLOAT8 => {
-                let param = portal.parameter::<f64>(i).unwrap();
+                let param = portal.parameter::<f64>(i, param_type).unwrap();
                 results.push(Box::new(param) as Box<dyn ToSql>);
             }
             _ => {

--- a/src/error.rs
+++ b/src/error.rs
@@ -23,8 +23,6 @@ pub enum PgWireError {
     UnknownTypeId(Oid),
     #[error("Parameter index out of bound: {0:?}")]
     ParameterIndexOutOfBound(usize),
-    #[error("Parameter type index out of bound: {0:?}")]
-    ParameterTypeIndexOutOfBound(usize),
     #[error("Cannot convert postgre type {0:?} to given rust type")]
     InvalidRustTypeForParameter(String),
     #[error("Failed to parse parameter: {0:?}")]


### PR DESCRIPTION
This breaking changes update portal api for getting parameter value. It now requires postgre type for parsing the parameter. Previously we relies on client specified type in `Parse` message. However, postgres allows server to inference the type so that client is not required to provide them. 

This patch allow you to provide server inferenced type as argument to this function.