### PR TITLE
fix: attempt to fix panic on decoding startup message

### DIFF
--- a/src/error.rs
+++ b/src/error.rs
@@ -13,6 +13,8 @@ pub enum PgWireError {
     InvalidMessageType(u8),
     #[error("Invalid target type, received {0}")]
     InvalidTargetType(u8),
+    #[error("Invalid startup message")]
+    InvalidStartupMessage,
     #[error(transparent)]
     IoError(#[from] std::io::Error),
     #[error("Portal not found for name: {0:?}")]


### PR DESCRIPTION
Fixes #111 

This patch attempts to fix panic as described in #111 . It adds additional checks to ensure that the packet length field from startup message is valid (larger than 8). This should prevent panic on invalid clients. 

