### PR TITLE
fix: flush byte is not covered in decode

### DIFF
--- a/src/messages/mod.rs
+++ b/src/messages/mod.rs
@@ -147,6 +147,9 @@ impl PgWireFrontendMessage {
                 extendedquery::MESSAGE_TYPE_BYTE_EXECUTE => {
                     extendedquery::Execute::decode(buf).map(|v| v.map(Self::Execute))
                 }
+                extendedquery::MESSAGE_TYPE_BYTE_FLUSH => {
+                    extendedquery::Flush::decode(buf).map(|v| v.map(Self::Flush))
+                }
                 extendedquery::MESSAGE_TYPE_BYTE_SYNC => {
                     extendedquery::Sync::decode(buf).map(|v| v.map(Self::Sync))
                 }


### PR DESCRIPTION
I'm currently working on extended query protocol, but every time I get a Flush message, decode returns an error.
It looks like someone forgot to cover `MESSAGE_TYPE_BYTE_FLUSH` in `PgWireFrontendMessage::decode`, and this patch fixes that.