### PR TITLE
feat: add SslResponse message

### DIFF
--- a/src/messages/mod.rs
+++ b/src/messages/mod.rs
@@ -197,6 +197,7 @@ pub enum PgWireBackendMessage {
     ReadyForQuery(response::ReadyForQuery),
     ErrorResponse(response::ErrorResponse),
     NoticeResponse(response::NoticeResponse),
+    SslResponse(response::SslResponse),
 
     // data
     ParameterDescription(data::ParameterDescription),
@@ -230,6 +231,7 @@ impl PgWireBackendMessage {
             Self::ReadyForQuery(msg) => msg.encode(buf),
             Self::ErrorResponse(msg) => msg.encode(buf),
             Self::NoticeResponse(msg) => msg.encode(buf),
+            Self::SslResponse(msg) => msg.encode(buf),
 
             Self::ParameterDescription(msg) => msg.encode(buf),
             Self::RowDescription(msg) => msg.encode(buf),
@@ -520,6 +522,14 @@ mod test {
     fn test_sslrequest() {
         let sslreq = SslRequest::new();
         roundtrip!(sslreq, SslRequest);
+    }
+
+    #[test]
+    fn test_sslresponse() {
+        let sslaccept = SslResponse::Accept;
+        roundtrip!(sslaccept, SslResponse);
+        let sslrefuse = SslResponse::Refuse;
+        roundtrip!(sslrefuse, SslResponse);
     }
 
     #[test]


### PR DESCRIPTION
Hello again! I'd like to introduce a new backend message.

The backend should communicate with the frontend using backend messages. But this simple concept is broken when you want to response to SslRequest messsage. There is no such message as SslResponse in postgres, so to answer to SslRequest they use a very special approach: the backend sends a single byte containing 'S' or 'N', indicating that it is willing or unwilling to perform SSL, respectively.

I don't like how this is done in postgres and, as for me, it is very unnatural, so this patch introduces SslResponse message, that simply wraps this single byte and provides the backend with convenient API for responding to an SslRequest message.

Also it is better in terms of symmetry: there is SslRequest in frontend messages, but there is no SslResponse in backend messages.