### PR TITLE
use feed instread of send

### DIFF
--- a/src/api/query.rs
+++ b/src/api/query.rs
@@ -328,7 +328,7 @@ where
     while let Some(row) = data_rows.next().await {
         let row = row?;
         rows += 1;
-        client.send(PgWireBackendMessage::DataRow(row)).await?;
+        client.feed(PgWireBackendMessage::DataRow(row)).await?;
     }
 
     let tag = Tag::new_for_query(rows);


### PR DESCRIPTION
If send a lot of data to client, send is far more slow than feed.
It' s a small fix, I tested it.