### PR TITLE
feat: support array

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,7 +23,7 @@ futures = "0.3"
 async-trait = "0.1"
 rand = "0.8"
 thiserror = "1"
-postgres-types = { version = "0.2", features = ["with-chrono-0_4"]}
+postgres-types = { version = "0.2", features = ["with-chrono-0_4", "array-impls"]}
 md5 = "0.7"
 hex = "0.4"
 ## scram libraries

--- a/examples/datafusion.rs
+++ b/examples/datafusion.rs
@@ -1,7 +1,7 @@
 use std::sync::Arc;
 
 use async_trait::async_trait;
-use datafusion::arrow::array::{Array, BooleanArray, PrimitiveArray, StringArray};
+use datafusion::arrow::array::{Array, BooleanArray, ListArray, PrimitiveArray, StringArray};
 use datafusion::arrow::datatypes::{
     DataType, Float32Type, Float64Type, Int16Type, Int32Type, Int64Type, Int8Type, UInt32Type,
 };
@@ -39,12 +39,12 @@ impl SimpleQueryHandler for DfSessionService {
         // println!("{:?}", query);
         if query.starts_with("LOAD") {
             let command = query.trim_end();
-            let command = command.strip_suffix(";").unwrap_or(command);
-            let args = command.split(" ").collect::<Vec<&str>>();
+            let command = command.strip_suffix(';').unwrap_or(command);
+            let args = command.split(' ').collect::<Vec<&str>>();
             let table_name = args[2];
-            let csv_path = args[1];
+            let json_path = args[1];
             let ctx = self.session_context.lock().await;
-            ctx.register_csv(table_name, csv_path, CsvReadOptions::new())
+            ctx.register_json(table_name, json_path, NdJsonReadOptions::default())
                 .await
                 .map_err(|e| PgWireError::ApiError(Box::new(e)))?;
             Ok(vec![Response::Execution(Tag::new_for_execution(
@@ -64,7 +64,7 @@ impl SimpleQueryHandler for DfSessionService {
             Ok(vec![Response::Error(Box::new(ErrorInfo::new(
                 "ERROR".to_owned(),
                 "XX000".to_owned(),
-                "Datafusion is a readonly execution engine. To load data, call\nLOAD csv_file_path table_name;".to_owned(),
+                "Datafusion is a readonly execution engine. To load data, call\nLOAD json_file_path table_name;".to_owned(),
             )))])
         }
     }
@@ -74,14 +74,10 @@ fn into_pg_type(df_type: &DataType) -> PgWireResult<Type> {
     Ok(match df_type {
         DataType::Null => Type::UNKNOWN,
         DataType::Boolean => Type::BOOL,
-        DataType::Int8 => Type::CHAR,
-        DataType::Int16 => Type::INT2,
-        DataType::Int32 => Type::INT4,
-        DataType::Int64 => Type::INT8,
-        DataType::UInt8 => Type::CHAR,
-        DataType::UInt16 => Type::INT2,
-        DataType::UInt32 => Type::INT4,
-        DataType::UInt64 => Type::INT8,
+        DataType::Int8 | DataType::UInt8 => Type::CHAR,
+        DataType::Int16 | DataType::UInt16 => Type::INT2,
+        DataType::Int32 | DataType::UInt32 => Type::INT4,
+        DataType::Int64 | DataType::UInt64 => Type::INT8,
         DataType::Timestamp(_, _) => Type::TIMESTAMP,
         DataType::Time32(_) | DataType::Time64(_) => Type::TIME,
         DataType::Date32 | DataType::Date64 => Type::DATE,
@@ -89,6 +85,27 @@ fn into_pg_type(df_type: &DataType) -> PgWireResult<Type> {
         DataType::Float32 => Type::FLOAT4,
         DataType::Float64 => Type::FLOAT8,
         DataType::Utf8 => Type::VARCHAR,
+        DataType::List(field) => match field.data_type() {
+            DataType::Boolean => Type::BOOL_ARRAY,
+            DataType::Int8 | DataType::UInt8 => Type::CHAR_ARRAY,
+            DataType::Int16 | DataType::UInt16 => Type::INT2_ARRAY,
+            DataType::Int32 | DataType::UInt32 => Type::INT4_ARRAY,
+            DataType::Int64 | DataType::UInt64 => Type::INT8_ARRAY,
+            DataType::Timestamp(_, _) => Type::TIMESTAMP_ARRAY,
+            DataType::Time32(_) | DataType::Time64(_) => Type::TIME_ARRAY,
+            DataType::Date32 | DataType::Date64 => Type::DATE_ARRAY,
+            DataType::Binary => Type::BYTEA_ARRAY,
+            DataType::Float32 => Type::FLOAT4_ARRAY,
+            DataType::Float64 => Type::FLOAT8_ARRAY,
+            DataType::Utf8 => Type::VARCHAR_ARRAY,
+            list_type => {
+                return Err(PgWireError::UserError(Box::new(ErrorInfo::new(
+                    "ERROR".to_owned(),
+                    "XX000".to_owned(),
+                    format!("Unsupported List Datatype {list_type}"),
+                ))));
+            }
+        },
         _ => {
             return Err(PgWireError::UserError(Box::new(ErrorInfo::new(
                 "ERROR".to_owned(),
@@ -132,7 +149,7 @@ async fn encode_dataframe<'a>(df: DataFrame) -> PgWireResult<QueryResponse<'a>> 
 
             let fields = fields_ref.clone();
 
-            let row_stream = (0..rows).into_iter().map(move |row| {
+            let row_stream = (0..rows).map(move |row| {
                 let mut encoder = DataRowEncoder::new(fields.clone());
                 for col in 0..cols {
                     let array = rb.column(col);
@@ -159,6 +176,16 @@ fn get_bool_value(arr: &Arc<dyn Array>, idx: usize) -> bool {
         .value(idx)
 }
 
+fn get_bool_list_value(arr: &Arc<dyn Array>, idx: usize) -> Vec<Option<bool>> {
+    let list_arr = arr.as_any().downcast_ref::<ListArray>().unwrap().value(idx);
+    list_arr
+        .as_any()
+        .downcast_ref::<BooleanArray>()
+        .unwrap()
+        .iter()
+        .collect()
+}
+
 macro_rules! get_primitive_value {
     ($name:ident, $t:ty, $pt:ty) => {
         fn $name(arr: &Arc<dyn Array>, idx: usize) -> $pt {
@@ -174,18 +201,48 @@ get_primitive_value!(get_i8_value, Int8Type, i8);
 get_primitive_value!(get_i16_value, Int16Type, i16);
 get_primitive_value!(get_i32_value, Int32Type, i32);
 get_primitive_value!(get_i64_value, Int64Type, i64);
-// get_primitive_value!(get_u8_value, UInt8Type, u8);
-// get_primitive_value!(get_u16_value, UInt16Type, u16);
 get_primitive_value!(get_u32_value, UInt32Type, u32);
-// get_primitive_value!(get_u64_value, UInt64Type, u64);
 get_primitive_value!(get_f32_value, Float32Type, f32);
 get_primitive_value!(get_f64_value, Float64Type, f64);
+
+macro_rules! get_primitive_list_value {
+    ($name:ident, $t:ty, $pt:ty) => {
+        fn $name(arr: &Arc<dyn Array>, idx: usize) -> Vec<Option<$pt>> {
+            let list_arr = arr.as_any().downcast_ref::<ListArray>().unwrap().value(idx);
+            list_arr
+                .as_any()
+                .downcast_ref::<PrimitiveArray<$t>>()
+                .unwrap()
+                .iter()
+                .collect()
+        }
+    };
+}
+
+get_primitive_list_value!(get_i8_list_value, Int8Type, i8);
+get_primitive_list_value!(get_i16_list_value, Int16Type, i16);
+get_primitive_list_value!(get_i32_list_value, Int32Type, i32);
+get_primitive_list_value!(get_i64_list_value, Int64Type, i64);
+get_primitive_list_value!(get_u32_list_value, UInt32Type, u32);
+get_primitive_list_value!(get_f32_list_value, Float32Type, f32);
+get_primitive_list_value!(get_f64_list_value, Float64Type, f64);
 
 fn get_utf8_value(arr: &Arc<dyn Array>, idx: usize) -> &str {
     arr.as_any()
         .downcast_ref::<StringArray>()
         .unwrap()
         .value(idx)
+}
+
+fn get_utf8_list_value(arr: &Arc<dyn Array>, idx: usize) -> Vec<Option<String>> {
+    let list_arr = arr.as_any().downcast_ref::<ListArray>().unwrap().value(idx);
+    list_arr
+        .as_any()
+        .downcast_ref::<StringArray>()
+        .unwrap()
+        .iter()
+        .map(|opt| opt.map(|val| val.to_owned()))
+        .collect()
 }
 
 fn encode_value(
@@ -195,14 +252,41 @@ fn encode_value(
 ) -> PgWireResult<()> {
     match arr.data_type() {
         DataType::Boolean => encoder.encode_field(&get_bool_value(arr, idx))?,
-        DataType::Int8 => encoder.encode_field(&get_i8_value(arr, idx))?,
-        DataType::Int16 => encoder.encode_field(&get_i16_value(arr, idx))?,
+        DataType::Int8 | DataType::UInt8 => encoder.encode_field(&get_i8_value(arr, idx))?,
+        DataType::Int16 | DataType::UInt16 => encoder.encode_field(&get_i16_value(arr, idx))?,
         DataType::Int32 => encoder.encode_field(&get_i32_value(arr, idx))?,
-        DataType::Int64 => encoder.encode_field(&get_i64_value(arr, idx))?,
+        DataType::Int64 | DataType::UInt64 => encoder.encode_field(&get_i64_value(arr, idx))?,
         DataType::UInt32 => encoder.encode_field(&get_u32_value(arr, idx))?,
         DataType::Float32 => encoder.encode_field(&get_f32_value(arr, idx))?,
         DataType::Float64 => encoder.encode_field(&get_f64_value(arr, idx))?,
         DataType::Utf8 => encoder.encode_field(&get_utf8_value(arr, idx))?,
+        DataType::List(field) => match field.data_type() {
+            DataType::Boolean => encoder.encode_field(&get_bool_list_value(arr, idx))?,
+            DataType::Int8 | DataType::UInt8 => {
+                encoder.encode_field(&get_i8_list_value(arr, idx))?
+            }
+            DataType::Int16 | DataType::UInt16 => {
+                encoder.encode_field(&get_i16_list_value(arr, idx))?
+            }
+            DataType::Int32 => encoder.encode_field(&get_i32_list_value(arr, idx))?,
+            DataType::Int64 | DataType::UInt64 => {
+                encoder.encode_field(&get_i64_list_value(arr, idx))?
+            }
+            DataType::UInt32 => encoder.encode_field(&get_u32_list_value(arr, idx))?,
+            DataType::Float32 => encoder.encode_field(&get_f32_list_value(arr, idx))?,
+            DataType::Float64 => encoder.encode_field(&get_f64_list_value(arr, idx))?,
+            DataType::Utf8 => encoder.encode_field(&get_utf8_list_value(arr, idx))?,
+            list_type => {
+                return Err(PgWireError::UserError(Box::new(ErrorInfo::new(
+                    "ERROR".to_owned(),
+                    "XX000".to_owned(),
+                    format!(
+                        "Unsupported List Datatype {} and array {:?}",
+                        list_type, &arr
+                    ),
+                ))))
+            }
+        },
         _ => {
             return Err(PgWireError::UserError(Box::new(ErrorInfo::new(
                 "ERROR".to_owned(),
@@ -230,7 +314,7 @@ pub async fn main() {
     let server_addr = "127.0.0.1:5432";
     let listener = TcpListener::bind(server_addr).await.unwrap();
     println!("Listening to {}", server_addr);
-    println!("Execute SQL \"LOAD <path/to/csv> <table name>;\" to load your data as table.");
+    println!("Execute SQL \"LOAD <path/to/json> <table name>;\" to load your data as table.");
     loop {
         let incoming_socket = listener.accept().await.unwrap();
         let authenticator_ref = authenticator.make();


### PR DESCRIPTION
## Array Support

This PR introduces support `Array` type, specifically validated with `DataFusion`. While I'm uncertain whether this qualifies as a formal PR, it has proven beneficial for my use case. I modify the `datafusion.rs` example to facilitate the validation of this PR.

Additionally, I removed the `ToSqlText` impl for `u8`, `u16`, and `u64`. In my view, impl `ToSqlText` should align with the corresponding `ToSql` types in the `postgres-types` crate, and providing `ToSqlText` for these three types could be misleading. I would appreciate your thoughts on this matter.

If there are unfinished tasks to be addressed or if you have any suggestions, please let me know. I am willing to collaborate to complete the support for `Array` type.