### PR TITLE
feat: allow sending custom message from high level handler api

### DIFF
--- a/examples/bench.rs
+++ b/examples/bench.rs
@@ -15,7 +15,11 @@ pub struct DummyProcessor;
 
 #[async_trait]
 impl SimpleQueryHandler for DummyProcessor {
-    async fn do_query<'a, C>(&self, _client: &C, _query: &'a str) -> PgWireResult<Vec<Response<'a>>>
+    async fn do_query<'a, C>(
+        &self,
+        _client: &mut C,
+        _query: &'a str,
+    ) -> PgWireResult<Vec<Response<'a>>>
     where
         C: ClientInfo + Unpin + Send + Sync,
     {

--- a/examples/datafusion.rs
+++ b/examples/datafusion.rs
@@ -32,7 +32,11 @@ impl DfSessionService {
 
 #[async_trait]
 impl SimpleQueryHandler for DfSessionService {
-    async fn do_query<'a, C>(&self, _client: &C, query: &'a str) -> PgWireResult<Vec<Response<'a>>>
+    async fn do_query<'a, C>(
+        &self,
+        _client: &mut C,
+        query: &'a str,
+    ) -> PgWireResult<Vec<Response<'a>>>
     where
         C: ClientInfo + Unpin + Send + Sync,
     {

--- a/examples/gluesql.rs
+++ b/examples/gluesql.rs
@@ -18,7 +18,11 @@ pub struct GluesqlProcessor {
 
 #[async_trait]
 impl SimpleQueryHandler for GluesqlProcessor {
-    async fn do_query<'a, C>(&self, _client: &C, query: &'a str) -> PgWireResult<Vec<Response<'a>>>
+    async fn do_query<'a, C>(
+        &self,
+        _client: &mut C,
+        query: &'a str,
+    ) -> PgWireResult<Vec<Response<'a>>>
     where
         C: ClientInfo + Unpin + Send + Sync,
     {

--- a/examples/scram.rs
+++ b/examples/scram.rs
@@ -22,7 +22,11 @@ pub struct DummyProcessor;
 
 #[async_trait]
 impl SimpleQueryHandler for DummyProcessor {
-    async fn do_query<'a, C>(&self, _client: &C, _query: &'a str) -> PgWireResult<Vec<Response<'a>>>
+    async fn do_query<'a, C>(
+        &self,
+        _client: &mut C,
+        _query: &'a str,
+    ) -> PgWireResult<Vec<Response<'a>>>
     where
         C: ClientInfo + Unpin + Send + Sync,
     {

--- a/examples/secure_server.rs
+++ b/examples/secure_server.rs
@@ -20,7 +20,11 @@ pub struct DummyProcessor;
 
 #[async_trait]
 impl SimpleQueryHandler for DummyProcessor {
-    async fn do_query<'a, C>(&self, _client: &C, query: &'a str) -> PgWireResult<Vec<Response<'a>>>
+    async fn do_query<'a, C>(
+        &self,
+        _client: &mut C,
+        query: &'a str,
+    ) -> PgWireResult<Vec<Response<'a>>>
     where
         C: ClientInfo + Unpin + Send + Sync,
     {

--- a/examples/sqlite.rs
+++ b/examples/sqlite.rs
@@ -44,7 +44,11 @@ impl AuthSource for DummyAuthSource {
 
 #[async_trait]
 impl SimpleQueryHandler for SqliteBackend {
-    async fn do_query<'a, C>(&self, _client: &C, query: &'a str) -> PgWireResult<Vec<Response<'a>>>
+    async fn do_query<'a, C>(
+        &self,
+        _client: &mut C,
+        query: &'a str,
+    ) -> PgWireResult<Vec<Response<'a>>>
     where
         C: ClientInfo + Unpin + Send + Sync,
     {

--- a/src/api/query.rs
+++ b/src/api/query.rs
@@ -84,11 +84,13 @@ pub trait SimpleQueryHandler: Send + Sync {
     /// Provide your query implementation using the incoming query string.
     async fn do_query<'a, 'b: 'a, C>(
         &'b self,
-        client: &C,
+        client: &mut C,
         query: &'a str,
     ) -> PgWireResult<Vec<Response<'a>>>
     where
-        C: ClientInfo + Unpin + Send + Sync;
+        C: ClientInfo + Sink<PgWireBackendMessage> + Unpin + Send + Sync,
+        C::Error: Debug,
+        PgWireError: From<<C as Sink<PgWireBackendMessage>>::Error>;
 }
 
 #[async_trait]
@@ -279,7 +281,9 @@ pub trait ExtendedQueryHandler: Send + Sync {
         target: StatementOrPortal<'_, Self::Statement>,
     ) -> PgWireResult<DescribeResponse>
     where
-        C: ClientInfo + Unpin + Send + Sync;
+        C: ClientInfo + Sink<PgWireBackendMessage> + Unpin + Send + Sync,
+        C::Error: Debug,
+        PgWireError: From<<C as Sink<PgWireBackendMessage>>::Error>;
 
     /// This is the main implementation for query execution. Context has
     /// been provided:
@@ -294,7 +298,9 @@ pub trait ExtendedQueryHandler: Send + Sync {
         max_rows: usize,
     ) -> PgWireResult<Response<'a>>
     where
-        C: ClientInfo + Unpin + Send + Sync;
+        C: ClientInfo + Sink<PgWireBackendMessage> + Unpin + Send + Sync,
+        C::Error: Debug,
+        PgWireError: From<<C as Sink<PgWireBackendMessage>>::Error>;
 }
 
 /// Helper function to send `QueryResponse` and optional `RowDescription` to client

--- a/tests-integration/test-server/src/main.rs
+++ b/tests-integration/test-server/src/main.rs
@@ -63,7 +63,11 @@ impl DummyDatabase {
 
 #[async_trait]
 impl SimpleQueryHandler for DummyDatabase {
-    async fn do_query<'a, C>(&self, _client: &C, query: &'a str) -> PgWireResult<Vec<Response<'a>>>
+    async fn do_query<'a, C>(
+        &self,
+        _client: &mut C,
+        query: &'a str,
+    ) -> PgWireResult<Vec<Response<'a>>>
     where
         C: ClientInfo + Unpin + Send + Sync,
     {


### PR DESCRIPTION
Addressing #132 

Previously we removed `Sink` mark from high level API of query handlers (`do_query`/`do_describe`). To be able to send custom messages, we are adding this feature back.
