### PR TITLE
pass client when getting PortalStore

### DIFF
--- a/examples/sqlite.rs
+++ b/examples/sqlite.rs
@@ -193,7 +193,10 @@ impl ExtendedQueryHandler for SqliteBackend {
     type PortalStore = MemPortalStore<Self::Statement>;
     type QueryParser = NoopQueryParser;
 
-    fn portal_store(&self) -> Arc<Self::PortalStore> {
+    fn portal_store<C>(&self, _client: &C) -> Arc<Self::PortalStore>
+    where
+        C: ClientInfo,
+    {
         self.portal_store.clone()
     }
 


### PR DESCRIPTION
[Postgres doc](https://www.postgresql.org/docs/current/protocol-overview.html) says prepared statements and portals exist only within a session. So, when getting a portalstore, pass in a client so that store corresponding to that client can be returned. This makes it possible to have different portalstore for different clients. Since default names are used when creating a portal, clients sharing a portalstore would lead to leaks