### PR TITLE
Update gluesql

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -46,10 +46,10 @@ rustls-pemfile = "2.0"
 rustls-pki-types = "1.0"
 ## webpki-roots has mozilla's set of roots
 ## rustls-native-certs loads roots from current system
-gluesql = "0.13"
+gluesql = { version = "0.15", default-features = false, features = ["memory-storage"] }
 ## for datafusion example
 datafusion = "34"
-sqlparser = "0.40"
+sqlparser = "0.41"
 
 [features]
 default = ["tokio", "time-format"]

--- a/examples/gluesql.rs
+++ b/examples/gluesql.rs
@@ -28,7 +28,7 @@ impl SimpleQueryHandler for GluesqlProcessor {
     {
         println!("{:?}", query);
         let mut glue = self.glue.lock().unwrap();
-        glue.execute(query)
+        futures::executor::block_on(glue.execute(query))
             .map_err(|err| PgWireError::ApiError(Box::new(err)))
             .and_then(|payloads| {
                 payloads


### PR DESCRIPTION
[gluesql made all their methods async](https://github.com/gluesql/gluesql/pull/1247),
but even replacing Mutex with tokio's async Mutex doesn't solve borrowing issues, seems gluesql isn't tokio compatible, so execute with futures::executor::block_on

Fixes #127 