### PR TITLE
dont send ReadyForQuery after error response

### DIFF
--- a/src/api/mod.rs
+++ b/src/api/mod.rs
@@ -22,6 +22,7 @@ pub enum PgWireConnectionState {
     AuthenticationInProgress,
     ReadyForQuery,
     QueryInProgress,
+    AwaitingSync,
 }
 
 /// Describe a client information holder

--- a/src/messages/mod.rs
+++ b/src/messages/mod.rs
@@ -96,11 +96,7 @@ pub enum PgWireFrontendMessage {
 
 impl PgWireFrontendMessage {
     pub fn is_extended_query(&self) -> bool {
-        if let PgWireFrontendMessage::Query(_) = self {
-            false
-        } else {
-            true
-        }
+        !matches!(self, PgWireFrontendMessage::Query(_))
     }
 
     pub fn encode(&self, buf: &mut BytesMut) -> PgWireResult<()> {

--- a/src/messages/mod.rs
+++ b/src/messages/mod.rs
@@ -96,9 +96,10 @@ pub enum PgWireFrontendMessage {
 
 impl PgWireFrontendMessage {
     pub fn is_extended_query(&self) -> bool {
-        match self {
-            PgWireFrontendMessage::Query(_) => false,
-            _ => true,
+        if let PgWireFrontendMessage::Query(_) = self {
+            false
+        } else {
+            true
         }
     }
 

--- a/src/messages/mod.rs
+++ b/src/messages/mod.rs
@@ -95,6 +95,13 @@ pub enum PgWireFrontendMessage {
 }
 
 impl PgWireFrontendMessage {
+    pub fn is_extended_query(&self) -> bool {
+        match self {
+            PgWireFrontendMessage::Query(_) => false,
+            _ => true,
+        }
+    }
+
     pub fn encode(&self, buf: &mut BytesMut) -> PgWireResult<()> {
         match self {
             Self::Startup(msg) => msg.encode(buf),

--- a/src/tokio.rs
+++ b/src/tokio.rs
@@ -115,13 +115,12 @@ where
         // message, the backend issues ErrorResponse, then reads and discards
         // messages until a Sync is reached, then issues ReadyForQuery and
         // returns to normal message processing.
-        PgWireConnectionState::AwaitingSync => match message {
-            PgWireFrontendMessage::Sync(sync) => {
+        PgWireConnectionState::AwaitingSync => {
+            if let PgWireFrontendMessage::Sync(sync) = message {
                 extended_query_handler.on_sync(socket, sync).await?;
                 socket.set_state(PgWireConnectionState::ReadyForQuery);
             }
-            _ => {}
-        },
+        }
         _ => {
             // query or query in progress
             match message {


### PR DESCRIPTION
- the server needs to wait for Sync message from the frontend
  before it sends ready for query message back to frontend
- read and discard messages until a Sync is received