### PR TITLE
fix: send ReadyForQuery on error when using simple query subprotocol

### DIFF
--- a/src/messages/mod.rs
+++ b/src/messages/mod.rs
@@ -96,7 +96,16 @@ pub enum PgWireFrontendMessage {
 
 impl PgWireFrontendMessage {
     pub fn is_extended_query(&self) -> bool {
-        !matches!(self, PgWireFrontendMessage::Query(_))
+        matches!(
+            self,
+            Self::Parse(_)
+                | Self::Bind(_)
+                | Self::Close(_)
+                | Self::Describe(_)
+                | Self::Execute(_)
+                | Self::Flush(_)
+                | Self::Sync(_)
+        )
     }
 
     pub fn encode(&self, buf: &mut BytesMut) -> PgWireResult<()> {

--- a/src/tokio.rs
+++ b/src/tokio.rs
@@ -166,15 +166,12 @@ where
             socket
                 .feed(PgWireBackendMessage::ErrorResponse((*error_info).into()))
                 .await?;
-            socket.flush().await?;
         }
         PgWireError::ApiError(e) => {
             let error_info = ErrorInfo::new("ERROR".to_owned(), "XX000".to_owned(), e.to_string());
             socket
                 .feed(PgWireBackendMessage::ErrorResponse(error_info.into()))
                 .await?;
-
-            socket.flush().await?;
         }
         _ => {
             // Internal error
@@ -196,6 +193,8 @@ where
             )))
             .await?;
     }
+    socket.flush().await?;
+
     Ok(())
 }
 


### PR DESCRIPTION
This patch fixes an issue that simple query (psql) client blocks on error as it waits for the `ReadyForQuery` command.

