### PR TITLE
refactor: make all pub type non_exhaustive

### DIFF
--- a/src/api/portal.rs
+++ b/src/api/portal.rs
@@ -13,6 +13,7 @@ use super::{results::FieldFormat, stmt::StoredStatement, DEFAULT_NAME};
 
 /// Represent a prepared sql statement and its parameters bound by a `Bind`
 /// request.
+#[non_exhaustive]
 #[derive(Debug, Default, Clone)]
 pub struct Portal<S> {
     pub name: String,

--- a/src/messages/copy.rs
+++ b/src/messages/copy.rs
@@ -6,6 +6,7 @@ use crate::error::PgWireResult;
 
 pub const MESSAGE_TYPE_BYTE_COPY_DATA: u8 = b'd';
 
+#[non_exhaustive]
 #[derive(PartialEq, Eq, Debug, Default, new)]
 pub struct CopyData {
     pub data: Bytes,
@@ -34,6 +35,7 @@ impl Message for CopyData {
 
 pub const MESSAGE_TYPE_BYTE_COPY_DONE: u8 = b'c';
 
+#[non_exhaustive]
 #[derive(PartialEq, Eq, Debug, Default, new)]
 pub struct CopyDone;
 
@@ -58,6 +60,7 @@ impl Message for CopyDone {
 
 pub const MESSAGE_TYPE_BYTE_COPY_FAIL: u8 = b'f';
 
+#[non_exhaustive]
 #[derive(PartialEq, Eq, Debug, Default, new)]
 pub struct CopyFail {
     pub message: String,
@@ -86,6 +89,7 @@ impl Message for CopyFail {
 
 pub const MESSAGE_TYPE_BYTE_COPY_IN_RESPONSE: u8 = b'G';
 
+#[non_exhaustive]
 #[derive(PartialEq, Eq, Debug, Default, new)]
 pub struct CopyInResponse {
     pub format: i8,
@@ -126,11 +130,12 @@ impl Message for CopyInResponse {
 
 pub const MESSAGE_TYPE_BYTE_COPY_OUT_RESPONSE: u8 = b'H';
 
+#[non_exhaustive]
 #[derive(PartialEq, Eq, Debug, Default, new)]
 pub struct CopyOutResponse {
-    format: i8,
-    columns: i16,
-    column_formats: Vec<i16>,
+    pub format: i8,
+    pub columns: i16,
+    pub column_formats: Vec<i16>,
 }
 
 impl Message for CopyOutResponse {
@@ -166,11 +171,12 @@ impl Message for CopyOutResponse {
 
 pub const MESSAGE_TYPE_BYTE_COPY_BOTH_RESPONSE: u8 = b'W';
 
+#[non_exhaustive]
 #[derive(PartialEq, Eq, Debug, Default, new)]
 pub struct CopyBothResponse {
-    format: i8,
-    columns: i16,
-    column_formats: Vec<i16>,
+    pub format: i8,
+    pub columns: i16,
+    pub column_formats: Vec<i16>,
 }
 
 impl Message for CopyBothResponse {

--- a/src/messages/data.rs
+++ b/src/messages/data.rs
@@ -8,6 +8,7 @@ use crate::error::PgWireResult;
 pub(crate) const FORMAT_CODE_TEXT: i16 = 0;
 pub(crate) const FORMAT_CODE_BINARY: i16 = 1;
 
+#[non_exhaustive]
 #[derive(PartialEq, Eq, Debug, Default, new)]
 pub struct FieldDescription {
     // the field name
@@ -189,6 +190,7 @@ impl Message for DataRow {
 
 /// postgres response when query returns no data, sent from backend to frontend
 /// in extended query
+#[non_exhaustive]
 #[derive(PartialEq, Eq, Debug, Default, new)]
 pub struct NoData;
 

--- a/src/messages/extendedquery.rs
+++ b/src/messages/extendedquery.rs
@@ -58,6 +58,7 @@ impl Message for Parse {
 }
 
 /// Response for Parse command, sent from backend to frontend
+#[non_exhaustive]
 #[derive(PartialEq, Eq, Debug, new)]
 pub struct ParseComplete;
 
@@ -123,6 +124,7 @@ impl Message for Close {
 }
 
 /// Response for Close command, sent from backend to frontend
+#[non_exhaustive]
 #[derive(PartialEq, Eq, Debug, new)]
 pub struct CloseComplete;
 
@@ -252,6 +254,7 @@ impl Message for Bind {
 }
 
 /// Success response for `Bind`
+#[non_exhaustive]
 #[derive(PartialEq, Eq, Debug, new)]
 pub struct BindComplete;
 
@@ -348,6 +351,7 @@ impl Message for Execute {
     }
 }
 
+#[non_exhaustive]
 #[derive(PartialEq, Eq, Debug, new)]
 pub struct Flush;
 
@@ -374,6 +378,7 @@ impl Message for Flush {
 }
 
 /// Execute portal by its name
+#[non_exhaustive]
 #[derive(PartialEq, Eq, Debug, new)]
 pub struct Sync;
 
@@ -399,6 +404,7 @@ impl Message for Sync {
     }
 }
 
+#[non_exhaustive]
 #[derive(PartialEq, Eq, Debug, new)]
 pub struct PortalSuspended;
 

--- a/src/messages/response.rs
+++ b/src/messages/response.rs
@@ -4,6 +4,7 @@ use super::codec;
 use super::Message;
 use crate::error::PgWireResult;
 
+#[non_exhaustive]
 #[derive(PartialEq, Eq, Debug, new)]
 pub struct CommandComplete {
     pub tag: String,
@@ -34,6 +35,7 @@ impl Message for CommandComplete {
     }
 }
 
+#[non_exhaustive]
 #[derive(PartialEq, Eq, Debug, new)]
 pub struct EmptyQueryResponse;
 
@@ -57,6 +59,7 @@ impl Message for EmptyQueryResponse {
     }
 }
 
+#[non_exhaustive]
 #[derive(PartialEq, Eq, Debug, new)]
 pub struct ReadyForQuery {
     pub status: u8,
@@ -92,6 +95,7 @@ impl Message for ReadyForQuery {
 }
 
 /// postgres error response, sent from backend to frontend
+#[non_exhaustive]
 #[derive(PartialEq, Eq, Debug, Default, new)]
 pub struct ErrorResponse {
     pub fields: Vec<(u8, String)>,
@@ -141,6 +145,7 @@ impl Message for ErrorResponse {
 }
 
 /// postgres error response, sent from backend to frontend
+#[non_exhaustive]
 #[derive(PartialEq, Eq, Debug, Default, new)]
 pub struct NoticeResponse {
     pub fields: Vec<(u8, String)>,
@@ -192,7 +197,9 @@ impl Message for NoticeResponse {
 /// Response to SSLRequest.
 /// To initiate an SSL-encrypted connection, the frontend initially sends an SSLRequest
 /// message rather than a StartupMessage. The server then responds with a single byte
-/// containing 'S' or 'N', indicating that it is willing or unwilling to perform SSL, respectively.
+/// containing 'S' or 'N', indicating that it is willing or unwilling to perform
+/// SSL, respectively.
+#[non_exhaustive]
 #[derive(Debug, PartialEq)]
 pub enum SslResponse {
     Accept,
@@ -247,6 +254,7 @@ impl Message for SslResponse {
 }
 
 /// NotificationResponse
+#[non_exhaustive]
 #[derive(PartialEq, Eq, Debug, Default, new)]
 pub struct NotificationResponse {
     pub pid: i32,

--- a/src/messages/startup.rs
+++ b/src/messages/startup.rs
@@ -105,6 +105,7 @@ impl Message for Startup {
 }
 
 /// authentication response family, sent by backend
+#[non_exhaustive]
 #[derive(PartialEq, Eq, Debug)]
 pub enum Authentication {
     Ok,                   // code 0
@@ -224,6 +225,7 @@ pub const MESSAGE_TYPE_BYTE_PASWORD_MESSAGE_FAMILY: u8 = b'p';
 ///
 /// When using this message in startup handlers, call
 /// `into_password`/`into_sasl_initial_response`/... methods to them
+#[non_exhaustive]
 #[derive(Debug)]
 pub enum PasswordMessageFamily {
     /// The type of message is unknown.
@@ -322,6 +324,7 @@ impl PasswordMessageFamily {
 }
 
 /// password packet sent from frontend
+#[non_exhaustive]
 #[derive(PartialEq, Eq, Debug, new)]
 pub struct Password {
     pub password: String,
@@ -351,6 +354,7 @@ impl Message for Password {
 }
 
 /// parameter ack sent from backend after authentication success
+#[non_exhaustive]
 #[derive(PartialEq, Eq, Debug, new)]
 pub struct ParameterStatus {
     pub name: String,
@@ -386,6 +390,7 @@ impl Message for ParameterStatus {
 
 /// `BackendKeyData` message, sent from backend to frontend for issuing
 /// `CancelRequestMessage`
+#[non_exhaustive]
 #[derive(PartialEq, Eq, Debug, new)]
 pub struct BackendKeyData {
     pub pid: i32,

--- a/src/messages/terminate.rs
+++ b/src/messages/terminate.rs
@@ -1,6 +1,7 @@
 use super::Message;
 use crate::error::PgWireResult;
 
+#[non_exhaustive]
 #[derive(Default, PartialEq, Eq, Debug, new)]
 pub struct Terminate;
 


### PR DESCRIPTION
This patch add `#[non_exhaustive]` attribute to all of our types that provides pub access of its members. 

This is the followup of #144 