### PR TITLE
refactor: use separated callback and return type for describe

### DIFF
--- a/examples/sqlite.rs
+++ b/examples/sqlite.rs
@@ -6,11 +6,12 @@ use futures::Stream;
 use pgwire::api::auth::md5pass::{hash_md5_password, MakeMd5PasswordAuthStartupHandler};
 use pgwire::api::auth::{AuthSource, DefaultServerParameterProvider, LoginInfo, Password};
 use pgwire::api::portal::{Format, Portal};
-use pgwire::api::query::{ExtendedQueryHandler, SimpleQueryHandler, StatementOrPortal};
+use pgwire::api::query::{ExtendedQueryHandler, SimpleQueryHandler};
 use pgwire::api::results::{
-    DataRowEncoder, DescribeResponse, FieldInfo, QueryResponse, Response, Tag,
+    DataRowEncoder, DescribePortalResponse, DescribeStatementResponse, FieldInfo, QueryResponse,
+    Response, Tag,
 };
-use pgwire::api::stmt::NoopQueryParser;
+use pgwire::api::stmt::{NoopQueryParser, StoredStatement};
 use pgwire::api::{ClientInfo, MakeHandler, Type};
 use pgwire::error::{ErrorInfo, PgWireError, PgWireResult};
 use pgwire::messages::data::DataRow;
@@ -234,32 +235,37 @@ impl ExtendedQueryHandler for SqliteBackend {
         }
     }
 
-    async fn do_describe<C>(
+    async fn do_describe_statement<C>(
         &self,
         _client: &mut C,
-        target: StatementOrPortal<'_, Self::Statement>,
-    ) -> PgWireResult<DescribeResponse>
+        stmt: &StoredStatement<Self::Statement>,
+    ) -> PgWireResult<DescribeStatementResponse>
     where
         C: ClientInfo + Unpin + Send + Sync,
     {
         let conn = self.conn.lock().unwrap();
-        match target {
-            StatementOrPortal::Statement(stmt) => {
-                let param_types = Some(stmt.parameter_types.clone());
-                let stmt = conn
-                    .prepare_cached(&stmt.statement)
-                    .map_err(|e| PgWireError::ApiError(Box::new(e)))?;
-                row_desc_from_stmt(&stmt, &Format::UnifiedBinary)
-                    .map(|fields| DescribeResponse::new(param_types, fields))
-            }
-            StatementOrPortal::Portal(portal) => {
-                let stmt = conn
-                    .prepare_cached(&portal.statement.statement)
-                    .map_err(|e| PgWireError::ApiError(Box::new(e)))?;
-                row_desc_from_stmt(&stmt, &portal.result_column_format)
-                    .map(|fields| DescribeResponse::new(None, fields))
-            }
-        }
+        let param_types = stmt.parameter_types.clone();
+        let stmt = conn
+            .prepare_cached(&stmt.statement)
+            .map_err(|e| PgWireError::ApiError(Box::new(e)))?;
+        row_desc_from_stmt(&stmt, &Format::UnifiedBinary)
+            .map(|fields| DescribeStatementResponse::new(param_types, fields))
+    }
+
+    async fn do_describe_portal<C>(
+        &self,
+        _client: &mut C,
+        portal: &Portal<Self::Statement>,
+    ) -> PgWireResult<DescribePortalResponse>
+    where
+        C: ClientInfo + Unpin + Send + Sync,
+    {
+        let conn = self.conn.lock().unwrap();
+        let stmt = conn
+            .prepare_cached(&portal.statement.statement)
+            .map_err(|e| PgWireError::ApiError(Box::new(e)))?;
+        row_desc_from_stmt(&stmt, &portal.result_column_format)
+            .map(|fields| DescribePortalResponse::new(fields))
     }
 }
 

--- a/src/api/query.rs
+++ b/src/api/query.rs
@@ -434,7 +434,7 @@ impl ExtendedQueryHandler for PlaceholderExtendedQueryHandler {
         &self,
         _client: &mut C,
         _statement: &StoredStatement<Self::Statement>,
-    ) -> PgWireResult<DescribeResponse>
+    ) -> PgWireResult<DescribeStatementResponse>
     where
         C: ClientInfo + Unpin + Send + Sync,
     {
@@ -445,7 +445,7 @@ impl ExtendedQueryHandler for PlaceholderExtendedQueryHandler {
         &self,
         _client: &mut C,
         _portal: &Portal<Self::Statement>,
-    ) -> PgWireResult<DescribeResponse>
+    ) -> PgWireResult<DescribePortalResponse>
     where
         C: ClientInfo + Unpin + Send + Sync,
     {

--- a/src/api/results.rs
+++ b/src/api/results.rs
@@ -269,7 +269,7 @@ pub struct DescribeStatementResponse {
 
 impl DescribeResponse for DescribeStatementResponse {
     fn parameters(&self) -> Option<&[Type]> {
-        Some(self.parameters.as_deref())
+        Some(self.parameters.as_ref())
     }
 
     fn fields(&self) -> &[FieldInfo] {
@@ -280,14 +280,14 @@ impl DescribeResponse for DescribeStatementResponse {
     /// when client tries to describe an empty query.
     fn no_data() -> Self {
         DescribeStatementResponse {
-            parameters: None,
+            parameters: vec![],
             fields: vec![],
         }
     }
 
     /// Return true if the `DescribeStatementResponse` is empty/nodata
     fn is_no_data(&self) -> bool {
-        self.parameters.is_none() && self.fields.is_empty()
+        self.parameters.is_empty() && self.fields.is_empty()
     }
 }
 

--- a/src/api/results.rs
+++ b/src/api/results.rs
@@ -245,40 +245,77 @@ impl DataRowEncoder {
     }
 }
 
-/// Response for frontend describe requests.
-///
-/// There are two types of describe: statement and portal. When describing
-/// statement, frontend expects parameter types inferenced by server. And both
-/// describe messages will require column definitions for resultset being
-/// returned.
-#[non_exhaustive]
-#[derive(Debug, new)]
-pub struct DescribeResponse {
-    pub parameters: Option<Vec<Type>>,
-    pub fields: Vec<FieldInfo>,
-}
+/// Get response data for a `Describe` command
+pub trait DescribeResponse {
+    fn parameters(&self) -> Option<&[Type]>;
 
-impl DescribeResponse {
-    pub fn parameters(&self) -> Option<&[Type]> {
-        self.parameters.as_deref()
-    }
-
-    pub fn fields(&self) -> &[FieldInfo] {
-        &self.fields
-    }
+    fn fields(&self) -> &[FieldInfo];
 
     /// Create an no_data instance of `DescribeResponse`. This is typically used
     /// when client tries to describe an empty query.
-    pub fn no_data() -> Self {
-        DescribeResponse {
+    fn no_data() -> Self;
+
+    /// Return true if the `DescribeResponse` is empty/nodata
+    fn is_no_data(&self) -> bool;
+}
+
+/// Response for frontend describe statement requests.
+#[non_exhaustive]
+#[derive(Debug, new)]
+pub struct DescribeStatementResponse {
+    pub parameters: Vec<Type>,
+    pub fields: Vec<FieldInfo>,
+}
+
+impl DescribeResponse for DescribeStatementResponse {
+    fn parameters(&self) -> Option<&[Type]> {
+        Some(self.parameters.as_deref())
+    }
+
+    fn fields(&self) -> &[FieldInfo] {
+        &self.fields
+    }
+
+    /// Create an no_data instance of `DescribeStatementResponse`. This is typically used
+    /// when client tries to describe an empty query.
+    fn no_data() -> Self {
+        DescribeStatementResponse {
             parameters: None,
             fields: vec![],
         }
     }
 
-    /// Return true if the `DescribeResponse` is empty/nodata
-    pub fn is_no_data(&self) -> bool {
+    /// Return true if the `DescribeStatementResponse` is empty/nodata
+    fn is_no_data(&self) -> bool {
         self.parameters.is_none() && self.fields.is_empty()
+    }
+}
+
+/// Response for frontend describe portal requests.
+#[non_exhaustive]
+#[derive(Debug, new)]
+pub struct DescribePortalResponse {
+    pub fields: Vec<FieldInfo>,
+}
+
+impl DescribeResponse for DescribePortalResponse {
+    fn parameters(&self) -> Option<&[Type]> {
+        None
+    }
+
+    fn fields(&self) -> &[FieldInfo] {
+        &self.fields
+    }
+
+    /// Create an no_data instance of `DescribePortalResponse`. This is typically used
+    /// when client tries to describe an empty query.
+    fn no_data() -> Self {
+        DescribePortalResponse { fields: vec![] }
+    }
+
+    /// Return true if the `DescribePortalResponse` is empty/nodata
+    fn is_no_data(&self) -> bool {
+        self.fields.is_empty()
     }
 }
 


### PR DESCRIPTION
This patch refactors `do_describe` in `ExtendedQueryHandler` to avoid misunderstanding of different data requirement for describing statement or portal. 

It split `do_describe` into `do_describe_statement` and `do_describe_portal`, and uses accurate return type for each. 