### PR TITLE
Fix SASL body decode

### DIFF
--- a/src/messages/mod.rs
+++ b/src/messages/mod.rs
@@ -393,6 +393,8 @@ mod test {
             Authentication::Ok,
             Authentication::CleartextPassword,
             Authentication::KerberosV5,
+            Authentication::SASLContinue(Bytes::from("hello")),
+            Authentication::SASLFinal(Bytes::from("world")),
         ];
         for s in ss {
             roundtrip!(s, Authentication);

--- a/src/messages/startup.rs
+++ b/src/messages/startup.rs
@@ -176,7 +176,7 @@ impl Message for Authentication {
         Ok(())
     }
 
-    fn decode_body(buf: &mut BytesMut, msg_len: usize) -> PgWireResult<Self> {
+    fn decode_body(buf: &mut BytesMut, _: usize) -> PgWireResult<Self> {
         let code = buf.get_i32();
         let msg = match code {
             0 => Authentication::Ok,
@@ -194,14 +194,8 @@ impl Message for Authentication {
                 }
                 Authentication::SASL(methods)
             }
-            11 => {
-                let data = buf.split_to(msg_len - 4).freeze();
-                Authentication::SASLContinue(data)
-            }
-            12 => {
-                let data = buf.split_to(msg_len - 4).freeze();
-                Authentication::SASLFinal(data)
-            }
+            11 => Authentication::SASLContinue(buf.split().freeze()),
+            12 => Authentication::SASLFinal(buf.split().freeze()),
             _ => unreachable!(),
         };
 


### PR DESCRIPTION

```rust
let mut bytes = BytesMut::new();
PgWireBackendMessage::Authentication(Authentication::SASLFinal(Bytes::from("Hello")))
        .encode(&mut bytes);
// Panic !!!
PgWireBackendMessage::decode(&mut bytes);
```

#### Error

```
thread 'main' panicked at /Users/.../bytes-1.6.0/src/bytes_mut.rs:386:9:
split_to out of bounds: 9 <= 5
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
```

