### PR TITLE
Change ReadyForQuery status to TransactionStatus

### DIFF
--- a/src/api/auth/mod.rs
+++ b/src/api/auth/mod.rs
@@ -7,7 +7,7 @@ use futures::stream;
 
 use super::{ClientInfo, PgWireConnectionState, METADATA_DATABASE, METADATA_USER};
 use crate::error::{PgWireError, PgWireResult};
-use crate::messages::response::{ReadyForQuery, READY_STATUS_IDLE};
+use crate::messages::response::{ReadyForQuery, TransactionStatus};
 use crate::messages::startup::{Authentication, BackendKeyData, ParameterStatus, Startup};
 use crate::messages::{PgWireBackendMessage, PgWireFrontendMessage};
 
@@ -182,7 +182,7 @@ where
         rand::random::<i32>(),
     )));
     messages.push(PgWireBackendMessage::ReadyForQuery(ReadyForQuery::new(
-        READY_STATUS_IDLE,
+        TransactionStatus::Idle,
     )));
     let mut message_stream = stream::iter(messages.into_iter().map(Ok));
     client.send_all(&mut message_stream).await.unwrap();

--- a/src/api/query.rs
+++ b/src/api/query.rs
@@ -19,7 +19,7 @@ use crate::messages::extendedquery::{
     Bind, BindComplete, Close, CloseComplete, Describe, Execute, Parse, ParseComplete,
     Sync as PgSync, TARGET_TYPE_BYTE_PORTAL, TARGET_TYPE_BYTE_STATEMENT,
 };
-use crate::messages::response::{EmptyQueryResponse, ReadyForQuery, READY_STATUS_IDLE};
+use crate::messages::response::{EmptyQueryResponse, ReadyForQuery, TransactionStatus};
 use crate::messages::simplequery::Query;
 use crate::messages::PgWireBackendMessage;
 
@@ -75,7 +75,7 @@ pub trait SimpleQueryHandler: Send + Sync {
 
         client
             .feed(PgWireBackendMessage::ReadyForQuery(ReadyForQuery::new(
-                READY_STATUS_IDLE,
+                TransactionStatus::Idle,
             )))
             .await?;
         client.flush().await?;
@@ -240,7 +240,7 @@ pub trait ExtendedQueryHandler: Send + Sync {
     {
         client
             .send(PgWireBackendMessage::ReadyForQuery(ReadyForQuery::new(
-                READY_STATUS_IDLE,
+                TransactionStatus::Idle,
             )))
             .await?;
         client.flush().await?;

--- a/src/error.rs
+++ b/src/error.rs
@@ -13,6 +13,8 @@ pub enum PgWireError {
     InvalidMessageType(u8),
     #[error("Invalid target type, received {0}")]
     InvalidTargetType(u8),
+    #[error("Invalid transaction status, received {0}")]
+    InvalidTransactionStatus(u8),
     #[error("Invalid startup message")]
     InvalidStartupMessage,
     #[error(transparent)]

--- a/src/messages/mod.rs
+++ b/src/messages/mod.rs
@@ -430,7 +430,11 @@ mod test {
 
     #[test]
     fn test_ready_for_query() {
-        let r4q = ReadyForQuery::new(b'I');
+        let r4q = ReadyForQuery::new(TransactionStatus::Idle);
+        roundtrip!(r4q, ReadyForQuery);
+        let r4q = ReadyForQuery::new(TransactionStatus::Transaction);
+        roundtrip!(r4q, ReadyForQuery);
+        let r4q = ReadyForQuery::new(TransactionStatus::Error);
         roundtrip!(r4q, ReadyForQuery);
     }
 

--- a/src/tokio.rs
+++ b/src/tokio.rs
@@ -15,7 +15,7 @@ use crate::api::query::SimpleQueryHandler;
 use crate::api::{ClientInfo, ClientPortalStore, DefaultClient, PgWireConnectionState};
 use crate::error::{ErrorInfo, PgWireError, PgWireResult};
 use crate::messages::response::ReadyForQuery;
-use crate::messages::response::{SslResponse, READY_STATUS_IDLE};
+use crate::messages::response::{SslResponse, TransactionStatus};
 use crate::messages::startup::{SslRequest, Startup};
 use crate::messages::{Message, PgWireBackendMessage, PgWireFrontendMessage};
 
@@ -189,7 +189,7 @@ where
     } else {
         socket
             .feed(PgWireBackendMessage::ReadyForQuery(ReadyForQuery::new(
-                READY_STATUS_IDLE,
+                TransactionStatus::Idle,
             )))
             .await?;
     }


### PR DESCRIPTION
This PR change the `status` in `ReadyForQuery` to `TransactionStatus`, which can prevent unexpected error to some extent.

Document: [postgresql.org/...#PROTOCOL-MESSAGE-FORMATS-READYFORQUERY](https://www.postgresql.org/docs/current/protocol-message-formats.html#PROTOCOL-MESSAGE-FORMATS-READYFORQUERY)