### PR TITLE
Split api feature

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -82,4 +82,5 @@ jobs:
       with:
         toolchain: "1.72"
         override: true
+    - run: cargo build --no-default-features
     - run: cargo build --all-features

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -80,6 +80,6 @@ jobs:
     - uses: actions/checkout@v4
     - uses: actions-rs/toolchain@v1
       with:
-        toolchain: "1.67"
+        toolchain: "1.72"
         override: true
     - run: cargo build --all-features

--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@
 tests-integration/test-server/target
 tests-integration/rust-client/target
 node_modules
+.DS_Store

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ homepage = "https://github.com/sunng87/pgwire"
 repository = "https://github.com/sunng87/pgwire"
 documentation = "https://docs.rs/crate/pgwire/"
 readme = "README.md"
-rust-version = "1.67"
+rust-version = "1.72"
 
 [dependencies]
 derive-new = "0.6"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,28 +14,52 @@ readme = "README.md"
 rust-version = "1.67"
 
 [dependencies]
-log = "0.4"
 derive-new = "0.6"
 bytes = "1.1.0"
-time = "0.3"
-futures = "0.3"
-async-trait = "0.1"
-rand = "0.8"
 thiserror = "1"
-postgres-types = { version = "0.2", features = ["with-chrono-0_4", "array-impls"]}
-md5 = "0.7"
-hex = "0.4"
-## scram libraries
-base64 = "0.22"
-ring = "0.17"
-stringprep = "0.1.2"
-x509-certificate = "0.23"
-
-tokio = { version = "1.19", features = ["net", "rt", "io-util"], optional = true}
+## api
+tokio = { version = "1.19", features = [
+    "net",
+    "rt",
+    "io-util",
+], optional = true }
 tokio-util = { version = "0.7.3", features = ["codec", "io"], optional = true }
 tokio-rustls = { version = "0.26", optional = true }
+futures = { version = "0.3", optional = true }
+async-trait = { version = "0.1", optional = true }
+rand = { version = "0.8", optional = true }
+md5 = { version = "0.7", optional = true }
+hex = { version = "0.4", optional = true }
+## scram libraries
+base64 = { version = "0.22", optional = true }
+ring = { version = "0.17", optional = true }
+stringprep = { version = "0.1.2", optional = true }
+x509-certificate = { version = "0.23", optional = true }
+## types
+postgres-types = { version = "0.2", features = [
+    "with-chrono-0_4",
+    "array-impls",
+], optional = true }
+chrono = { version = "0.4", features = ["std"], optional = true }
 
-chrono = { version = "0.4", optional = true, features = ["std"] }
+[features]
+default = ["api"]
+api = [
+    "dep:tokio",
+    "dep:tokio-util",
+    "dep:tokio-rustls",
+    "dep:futures",
+    "dep:async-trait",
+    "dep:rand",
+    "dep:md5",
+    "dep:hex",
+    "dep:base64",
+    "dep:ring",
+    "dep:stringprep",
+    "dep:x509-certificate",
+    "dep:postgres-types",
+    "dep:chrono",
+]
 
 [dev-dependencies]
 tokio = { version = "1.19", features = ["rt-multi-thread", "net", "macros"]}
@@ -49,15 +73,6 @@ rustls-pki-types = "1.0"
 ## webpki-roots has mozilla's set of roots
 ## rustls-native-certs loads roots from current system
 gluesql = { version = "0.15", default-features = false, features = ["memory-storage"] }
-
-[features]
-default = ["tokio", "time-format"]
-tokio = ["dep:tokio", "dep:tokio-util", "dep:tokio-rustls"]
-time-format = ["dep:chrono"]
-
-[[example]]
-name = "server"
-required-features = ["tokio"]
 
 [workspace]
 members = [

--- a/src/error.rs
+++ b/src/error.rs
@@ -20,9 +20,6 @@ pub enum PgWireError {
     PortalNotFound(String),
     #[error("Statement not found for name: {0:?}")]
     StatementNotFound(String),
-    #[cfg(feature = "api")]
-    #[error("Unknown type: {0}")]
-    UnknownTypeId(u32),
     #[error("Parameter index out of bound: {0:?}")]
     ParameterIndexOutOfBound(usize),
     #[error("Cannot convert postgre type {0:?} to given rust type")]

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,9 +1,6 @@
-use std::io::{Error as IOError, ErrorKind};
-
-use postgres_types::Oid;
-use thiserror::Error;
-
 use crate::messages::response::{ErrorResponse, NoticeResponse};
+use std::io::{Error as IOError, ErrorKind};
+use thiserror::Error;
 
 #[derive(Error, Debug)]
 pub enum PgWireError {
@@ -23,8 +20,9 @@ pub enum PgWireError {
     PortalNotFound(String),
     #[error("Statement not found for name: {0:?}")]
     StatementNotFound(String),
-    #[error("Unknown type: {0:?}")]
-    UnknownTypeId(Oid),
+    #[cfg(feature = "api")]
+    #[error("Unknown type: {0}")]
+    UnknownTypeId(u32),
     #[error("Parameter index out of bound: {0:?}")]
     ParameterIndexOutOfBound(usize),
     #[error("Cannot convert postgre type {0:?} to given rust type")]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -57,13 +57,15 @@
 extern crate derive_new;
 
 /// handler layer and high-level API layer.
+#[cfg(feature = "api")]
 pub mod api;
 /// error types.
 pub mod error;
 /// the protocol layer.
 pub mod messages;
 /// server entry-point for tokio based application.
-#[cfg(feature = "tokio")]
+#[cfg(feature = "api")]
 pub mod tokio;
 /// types and encoding related helper
+#[cfg(feature = "api")]
 pub mod types;

--- a/src/messages/data.rs
+++ b/src/messages/data.rs
@@ -1,12 +1,11 @@
 use bytes::{Buf, BufMut, BytesMut};
-use postgres_types::Oid;
 
 use super::codec;
 use super::Message;
 use crate::error::PgWireResult;
 
-pub(crate) const FORMAT_CODE_TEXT: i16 = 0;
-pub(crate) const FORMAT_CODE_BINARY: i16 = 1;
+pub const FORMAT_CODE_TEXT: i16 = 0;
+pub const FORMAT_CODE_BINARY: i16 = 1;
 
 #[non_exhaustive]
 #[derive(PartialEq, Eq, Debug, Default, new)]
@@ -18,7 +17,7 @@ pub struct FieldDescription {
     // the attribute number of the column, default to 0 if not a column from table
     pub column_id: i16,
     // the object ID of the data type
-    pub type_id: Oid,
+    pub type_id: u32,
     // the size of data type, negative values denote variable-width types
     pub type_size: i16,
     // the type modifier
@@ -92,7 +91,7 @@ impl Message for RowDescription {
 #[derive(PartialEq, Eq, Debug, Default, new, Clone)]
 pub struct ParameterDescription {
     /// parameter types
-    pub types: Vec<Oid>,
+    pub types: Vec<u32>,
 }
 
 pub const MESSAGE_TYPE_BYTE_PARAMETER_DESCRITION: u8 = b't';
@@ -121,7 +120,7 @@ impl Message for ParameterDescription {
         let mut types = Vec::with_capacity(types_len as usize);
 
         for _ in 0..types_len {
-            types.push(buf.get_i32() as Oid);
+            types.push(buf.get_i32() as u32);
         }
 
         Ok(ParameterDescription { types })

--- a/src/messages/extendedquery.rs
+++ b/src/messages/extendedquery.rs
@@ -1,5 +1,4 @@
 use bytes::{Buf, BufMut, Bytes};
-use postgres_types::Oid;
 
 use super::{codec, Message};
 use crate::error::PgWireResult;
@@ -10,7 +9,7 @@ use crate::error::PgWireResult;
 pub struct Parse {
     pub name: Option<String>,
     pub query: String,
-    pub type_oids: Vec<Oid>,
+    pub type_oids: Vec<u32>,
 }
 
 pub const MESSAGE_TYPE_BYTE_PARSE: u8 = b'P';

--- a/tests-integration/rust-client/src/main.rs
+++ b/tests-integration/rust-client/src/main.rs
@@ -19,7 +19,7 @@ fn main() {
     }
 
     for row in client
-        .query("SELECT * FROM testtable WHERE id = ?", &[&1_u32])
+        .query("SELECT * FROM testtable WHERE id = ?", &[&1])
         .unwrap()
     {
         println!("{:?}", row.get::<usize, Option<i32>>(0));

--- a/tests-integration/rust-client/src/main.rs
+++ b/tests-integration/rust-client/src/main.rs
@@ -19,7 +19,7 @@ fn main() {
     }
 
     for row in client
-        .query("SELECT * FROM testtable WHERE id = ?", &[&1])
+        .query("SELECT * FROM testtable WHERE id = ?", &[&1_u32])
         .unwrap()
     {
         println!("{:?}", row.get::<usize, Option<i32>>(0));


### PR DESCRIPTION
This PR split the "server" into the `api feature`, which can significantly reduce the compilation time for those who just want to use the `messages` to write a Postgres client.

```toml
# Consistent with before, there are no breaking changes
pgwire = "..."

# Only messages
# 120+ crates -> 14 crates
pgwire = { version = "...", default-features = false }
```

#### Two unused crates have been deleted.
```toml
log = "0.4"
time = "0.3"
```

#### Export FORMAT_CODE
This helps the client determine the value format
```diff
- pub(crate) const FORMAT_CODE_TEXT: i16 = 0;
+ pub const FORMAT_CODE_TEXT: i16 = 0;
```


