### PR TITLE
chore: rename api feature to server-api

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -53,6 +53,8 @@ jobs:
         override: true
     - name: Build and run tests
       run: cargo test --all-features
+    - name: Run tests on minimal feature set
+      run: cargo test --no-default-features
 
   integration:
     name: Integration tests

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -43,8 +43,8 @@ postgres-types = { version = "0.2", features = [
 chrono = { version = "0.4", features = ["std"], optional = true }
 
 [features]
-default = ["api"]
-api = [
+default = ["server-api"]
+server-api = [
     "dep:tokio",
     "dep:tokio-util",
     "dep:tokio-rustls",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -80,3 +80,31 @@ members = [
     "tests-integration/rust-client",
     "tests-integration/test-server"
 ]
+
+[[example]]
+name = "server"
+required-features = ["server-api"]
+
+[[example]]
+name = "secure_server"
+required-features = ["server-api"]
+
+[[example]]
+name = "bench"
+required-features = ["server-api"]
+
+[[example]]
+name = "gluesql"
+required-features = ["server-api"]
+
+[[example]]
+name = "sqlite"
+required-features = ["server-api"]
+
+[[example]]
+name = "duckdb"
+required-features = ["server-api"]
+
+[[example]]
+name = "scram"
+required-features = ["server-api"]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -57,15 +57,15 @@
 extern crate derive_new;
 
 /// handler layer and high-level API layer.
-#[cfg(feature = "api")]
+#[cfg(feature = "server-api")]
 pub mod api;
 /// error types.
 pub mod error;
 /// the protocol layer.
 pub mod messages;
 /// server entry-point for tokio based application.
-#[cfg(feature = "api")]
+#[cfg(feature = "server-api")]
 pub mod tokio;
 /// types and encoding related helper
-#[cfg(feature = "api")]
+#[cfg(feature = "server-api")]
 pub mod types;


### PR DESCRIPTION
This is a follow-up for #177 

And it seems we should rename the `api` module to `server-api` as well. But to avoid bringing breaking change ahead of time, I'm going to do it when there is actual client api.