### PR TITLE
feat: make scram an optional feature

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -58,7 +58,7 @@ jobs:
     - name: Run tests on additional scram+ring feature set
       run: cargo test --features server-api-scram-ring
     - name: Run tests on additional scram+aws-lc-rs feature set
-      run: cargo test --features server-api-scram-aws-lc-rs
+      run: cargo test --features scram
 
   integration:
     name: Integration tests

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -51,10 +51,14 @@ jobs:
       with:
         toolchain: ${{ matrix.rust }}
         override: true
-    - name: Build and run tests
-      run: cargo test --all-features
+    - name: Build and run tests on default feature set
+      run: cargo test
     - name: Run tests on minimal feature set
       run: cargo test --no-default-features
+    - name: Run tests on additional scram+ring feature set
+      run: cargo test --features server-api-scram-ring
+    - name: Run tests on additional scram+aws-lc-rs feature set
+      run: cargo test --features server-api-scram-aws-lc-rs
 
   integration:
     name: Integration tests

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -56,7 +56,7 @@ jobs:
     - name: Run tests on minimal feature set
       run: cargo test --no-default-features
     - name: Run tests on additional scram+ring feature set
-      run: cargo test --features server-api-scram-ring
+      run: cargo test --features server-api-ring,scram
     - name: Run tests on additional scram+aws-lc-rs feature set
       run: cargo test --features scram
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -44,9 +44,7 @@ postgres-types = { version = "0.2", features = [
 chrono = { version = "0.4", features = ["std"], optional = true }
 
 [features]
-default = ["server-api"]
-server-api-scram-ring = ["server-api", "ring", "dep:base64", "dep:stringprep", "dep:x509-certificate"]
-server-api-scram-aws-lc-rs = ["server-api", "aws-lc-rs", "dep:base64", "dep:stringprep", "dep:x509-certificate"]
+default = ["server-api-aws-lc-rs"]
 ring = ["dep:ring", "tokio-rustls/ring"]
 aws-lc-rs = ["dep:aws-lc-rs", "tokio-rustls/aws-lc-rs"]
 server-api = [
@@ -61,6 +59,9 @@ server-api = [
     "dep:postgres-types",
     "dep:chrono",
 ]
+server-api-ring = ["server-api", "ring"]
+server-api-aws-lc-rs = ["server-api", "aws-lc-rs"]
+scram = ["dep:base64", "dep:stringprep", "dep:x509-certificate"]
 
 [dev-dependencies]
 tokio = { version = "1.19", features = ["rt-multi-thread", "net", "macros"]}
@@ -108,4 +109,4 @@ required-features = ["server-api"]
 
 [[example]]
 name = "scram"
-required-features = ["server-api-scram-aws-lc-rs"]
+required-features = ["scram"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -44,9 +44,9 @@ postgres-types = { version = "0.2", features = [
 chrono = { version = "0.4", features = ["std"], optional = true }
 
 [features]
-default = ["server-api-ring"]
-server-api-ring = ["server-api", "ring"]
-server-api-aws-lc-rs = ["server-api", "aws-lc-rs"]
+default = ["server-api"]
+server-api-scram-ring = ["server-api", "ring", "dep:base64", "dep:stringprep", "dep:x509-certificate"]
+server-api-scram-aws-lc-rs = ["server-api", "aws-lc-rs", "dep:base64", "dep:stringprep", "dep:x509-certificate"]
 ring = ["dep:ring", "tokio-rustls/ring"]
 aws-lc-rs = ["dep:aws-lc-rs", "tokio-rustls/aws-lc-rs"]
 server-api = [
@@ -58,9 +58,6 @@ server-api = [
     "dep:rand",
     "dep:md5",
     "dep:hex",
-    "dep:base64",
-    "dep:stringprep",
-    "dep:x509-certificate",
     "dep:postgres-types",
     "dep:chrono",
 ]
@@ -111,4 +108,4 @@ required-features = ["server-api"]
 
 [[example]]
 name = "scram"
-required-features = ["server-api"]
+required-features = ["server-api-scram-aws-lc-rs"]

--- a/README.md
+++ b/README.md
@@ -26,7 +26,8 @@ with its usage.
     - [x] No authentication
     - [x] Clear-text password authentication
     - [x] Md5 Password authentication
-    - [x] SASL SCRAM authentication
+    - [x] SASL SCRAM authentication (optional feature `server-api-scram-ring` or
+          `server-api-scram-aws-lc-rs`)
       - [x] SCRAM-SHA-256
       - [x] SCRAM-SHA-256-PLUS
   - [x] Simple Query and Response

--- a/src/api/auth/mod.rs
+++ b/src/api/auth/mod.rs
@@ -192,8 +192,5 @@ where
 pub mod cleartext;
 pub mod md5pass;
 pub mod noop;
-#[cfg(any(
-    feature = "server-api-scram-ring",
-    feature = "server-api-scram-aws-lc-rs"
-))]
+#[cfg(feature = "scram")]
 pub mod scram;

--- a/src/api/auth/mod.rs
+++ b/src/api/auth/mod.rs
@@ -192,4 +192,8 @@ where
 pub mod cleartext;
 pub mod md5pass;
 pub mod noop;
+#[cfg(any(
+    feature = "server-api-scram-ring",
+    feature = "server-api-scram-aws-lc-rs"
+))]
 pub mod scram;

--- a/tests-integration/test-server/Cargo.toml
+++ b/tests-integration/test-server/Cargo.toml
@@ -7,7 +7,7 @@ publish = false
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-pgwire = { path = "../../" }
+pgwire = { path = "../../", features = ["server-api-scram-ring"] }
 async-trait = "0.1"
 futures = "0.3"
 tokio = { version = "1", features = ["full"] }

--- a/tests-integration/test-server/Cargo.toml
+++ b/tests-integration/test-server/Cargo.toml
@@ -7,7 +7,7 @@ publish = false
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-pgwire = { path = "../../", features = ["server-api-scram-ring"] }
+pgwire = { path = "../../", features = ["scram"] }
 async-trait = "0.1"
 futures = "0.3"
 tokio = { version = "1", features = ["full"] }


### PR DESCRIPTION
This patch makes scram an optional feature completely as it introduces a few cypto libraries you might not want if you do not use scram in your application.

cc @serprex , this changes some behaviour introduced in #179 