### PR TITLE
scram: generate random nonce with one call

### DIFF
--- a/examples/scram.rs
+++ b/examples/scram.rs
@@ -36,11 +36,7 @@ impl SimpleQueryHandler for DummyProcessor {
 }
 
 pub fn random_salt() -> Vec<u8> {
-    let mut buf = vec![0u8; 10];
-    for v in buf.iter_mut() {
-        *v = rand::random::<u8>();
-    }
-    buf
+    Vec::from(rand::random::<[u8; 10]>())
 }
 
 const ITERATIONS: usize = 4096;

--- a/src/api/auth/scram.rs
+++ b/src/api/auth/scram.rs
@@ -63,12 +63,7 @@ pub fn gen_salted_password(password: &str, salt: &[u8], iters: usize) -> Vec<u8>
 }
 
 pub fn random_nonce() -> String {
-    let mut buf = [0u8; 18];
-    for v in buf.iter_mut() {
-        *v = rand::random::<u8>();
-    }
-
-    STANDARD.encode(buf)
+    STANDARD.encode(rand::random::<[u8; 18]>())
 }
 
 impl<A, P> SASLScramAuthStartupHandler<A, P> {


### PR DESCRIPTION
This has two benefits:
1. takes 1 lock instead of 18
2. generates multiple bytes per internal random invocation