### PR TITLE
refactor: introducing handler factory

### DIFF
--- a/examples/duckdb.rs
+++ b/examples/duckdb.rs
@@ -6,7 +6,7 @@ use duckdb::Rows;
 use duckdb::{params, types::ValueRef, Connection, Statement, ToSql};
 use futures::stream;
 use futures::Stream;
-use pgwire::api::auth::md5pass::{hash_md5_password, MakeMd5PasswordAuthStartupHandler};
+use pgwire::api::auth::md5pass::{hash_md5_password, Md5PasswordAuthStartupHandler};
 use pgwire::api::auth::{AuthSource, DefaultServerParameterProvider, LoginInfo, Password};
 use pgwire::api::copy::NoopCopyHandler;
 use pgwire::api::portal::{Format, Portal};
@@ -16,7 +16,7 @@ use pgwire::api::results::{
     Response, Tag,
 };
 use pgwire::api::stmt::{NoopQueryParser, StoredStatement};
-use pgwire::api::{ClientInfo, MakeHandler, Type};
+use pgwire::api::{ClientInfo, Type};
 use pgwire::error::{ErrorInfo, PgWireError, PgWireResult};
 use pgwire::messages::data::DataRow;
 use pgwire::tokio::process_socket;
@@ -315,60 +315,43 @@ impl ExtendedQueryHandler for DuckDBBackend {
     }
 }
 
-/// The parent handler that creates a handler instance for each incoming
-/// connection.
-struct MakeDuckDBBackend {
-    conn: Arc<Mutex<Connection>>,
-    query_parser: Arc<NoopQueryParser>,
-}
-
-impl MakeDuckDBBackend {
-    fn new() -> MakeDuckDBBackend {
-        MakeDuckDBBackend {
+impl DuckDBBackend {
+    fn new() -> DuckDBBackend {
+        DuckDBBackend {
             conn: Arc::new(Mutex::new(Connection::open_in_memory().unwrap())),
             query_parser: Arc::new(NoopQueryParser::new()),
         }
     }
 }
 
-impl MakeHandler for MakeDuckDBBackend {
-    type Handler = Arc<DuckDBBackend>;
-
-    fn make(&self) -> Self::Handler {
-        Arc::new(DuckDBBackend {
-            conn: self.conn.clone(),
-            query_parser: self.query_parser.clone(),
-        })
-    }
-}
-
 #[tokio::main]
 pub async fn main() {
-    let parameters = DefaultServerParameterProvider::default();
+    let parameters = Arc::new(DefaultServerParameterProvider::default());
 
-    let authenticator = Arc::new(MakeMd5PasswordAuthStartupHandler::new(
-        Arc::new(DummyAuthSource),
-        Arc::new(parameters),
-    ));
-    let processor = Arc::new(MakeDuckDBBackend::new());
     let noop_copy_handler = Arc::new(NoopCopyHandler);
 
     let server_addr = "127.0.0.1:5432";
     let listener = TcpListener::bind(server_addr).await.unwrap();
-    println!("Listening to {}", server_addr);
+    println!(
+        "Listening to {}, use password `pencil` to connect",
+        server_addr
+    );
     loop {
         let incoming_socket = listener.accept().await.unwrap();
-        let authenticator_ref = authenticator.make();
-        let processor_ref = processor.make();
+        let authenticator = Arc::new(Md5PasswordAuthStartupHandler::new(
+            Arc::new(DummyAuthSource),
+            parameters.clone(),
+        ));
+        let processor = Arc::new(DuckDBBackend::new());
         let copy_handler_ref = noop_copy_handler.clone();
 
         tokio::spawn(async move {
             process_socket(
                 incoming_socket.0,
                 None,
-                authenticator_ref,
-                processor_ref.clone(),
-                processor_ref,
+                authenticator,
+                processor.clone(),
+                processor,
                 copy_handler_ref,
             )
             .await

--- a/examples/gluesql.rs
+++ b/examples/gluesql.rs
@@ -9,7 +9,7 @@ use pgwire::api::auth::noop::NoopStartupHandler;
 use pgwire::api::copy::NoopCopyHandler;
 use pgwire::api::query::{PlaceholderExtendedQueryHandler, SimpleQueryHandler};
 use pgwire::api::results::{DataRowEncoder, FieldFormat, FieldInfo, QueryResponse, Response, Tag};
-use pgwire::api::{ClientInfo, MakeHandler, StatelessMakeHandler, Type};
+use pgwire::api::{ClientInfo, Type};
 use pgwire::error::{PgWireError, PgWireResult};
 use pgwire::tokio::process_socket;
 
@@ -165,12 +165,10 @@ pub async fn main() {
         glue: Arc::new(Mutex::new(Glue::new(MemoryStorage::default()))),
     };
 
-    let processor = Arc::new(StatelessMakeHandler::new(Arc::new(gluesql)));
+    let processor = Arc::new(gluesql);
     // We have not implemented extended query in this server, use placeholder instead
-    let placeholder = Arc::new(StatelessMakeHandler::new(Arc::new(
-        PlaceholderExtendedQueryHandler,
-    )));
-    let authenticator = Arc::new(StatelessMakeHandler::new(Arc::new(NoopStartupHandler)));
+    let placeholder = Arc::new(PlaceholderExtendedQueryHandler);
+    let authenticator = Arc::new(NoopStartupHandler);
     let noop_copy_handler = Arc::new(NoopCopyHandler);
 
     let server_addr = "127.0.0.1:5432";
@@ -178,9 +176,9 @@ pub async fn main() {
     println!("Listening to {}", server_addr);
     loop {
         let incoming_socket = listener.accept().await.unwrap();
-        let authenticator_ref = authenticator.make();
-        let processor_ref = processor.make();
-        let placeholder_ref = placeholder.make();
+        let authenticator_ref = authenticator.clone();
+        let processor_ref = processor.clone();
+        let placeholder_ref = placeholder.clone();
         let copy_handler_ref = noop_copy_handler.clone();
 
         tokio::spawn(async move {

--- a/examples/gluesql.rs
+++ b/examples/gluesql.rs
@@ -9,7 +9,7 @@ use pgwire::api::auth::noop::NoopStartupHandler;
 use pgwire::api::copy::NoopCopyHandler;
 use pgwire::api::query::{PlaceholderExtendedQueryHandler, SimpleQueryHandler};
 use pgwire::api::results::{DataRowEncoder, FieldFormat, FieldInfo, QueryResponse, Response, Tag};
-use pgwire::api::{ClientInfo, Type};
+use pgwire::api::{ClientInfo, PgWireHandlerFactory, Type};
 use pgwire::error::{PgWireError, PgWireResult};
 use pgwire::tokio::process_socket;
 
@@ -159,38 +159,50 @@ impl SimpleQueryHandler for GluesqlProcessor {
     }
 }
 
+struct GluesqlHandlerFactory {
+    processor: Arc<GluesqlProcessor>,
+}
+
+impl PgWireHandlerFactory for GluesqlHandlerFactory {
+    type StartupHandler = NoopStartupHandler;
+    type SimpleQueryHandler = GluesqlProcessor;
+    type ExtendedQueryHandler = PlaceholderExtendedQueryHandler;
+    type CopyHandler = NoopCopyHandler;
+
+    fn simple_query_handler(&self) -> Arc<Self::SimpleQueryHandler> {
+        self.processor.clone()
+    }
+
+    fn extended_query_handler(&self) -> Arc<Self::ExtendedQueryHandler> {
+        Arc::new(PlaceholderExtendedQueryHandler)
+    }
+
+    fn startup_handler(&self) -> Arc<Self::StartupHandler> {
+        Arc::new(NoopStartupHandler)
+    }
+
+    fn copy_handler(&self) -> Arc<Self::CopyHandler> {
+        Arc::new(NoopCopyHandler)
+    }
+}
+
 #[tokio::main]
 pub async fn main() {
     let gluesql = GluesqlProcessor {
         glue: Arc::new(Mutex::new(Glue::new(MemoryStorage::default()))),
     };
 
-    let processor = Arc::new(gluesql);
-    // We have not implemented extended query in this server, use placeholder instead
-    let placeholder = Arc::new(PlaceholderExtendedQueryHandler);
-    let authenticator = Arc::new(NoopStartupHandler);
-    let noop_copy_handler = Arc::new(NoopCopyHandler);
+    let factory = Arc::new(GluesqlHandlerFactory {
+        processor: Arc::new(gluesql),
+    });
 
     let server_addr = "127.0.0.1:5432";
     let listener = TcpListener::bind(server_addr).await.unwrap();
     println!("Listening to {}", server_addr);
     loop {
         let incoming_socket = listener.accept().await.unwrap();
-        let authenticator_ref = authenticator.clone();
-        let processor_ref = processor.clone();
-        let placeholder_ref = placeholder.clone();
-        let copy_handler_ref = noop_copy_handler.clone();
+        let factory_ref = factory.clone();
 
-        tokio::spawn(async move {
-            process_socket(
-                incoming_socket.0,
-                None,
-                authenticator_ref,
-                processor_ref,
-                placeholder_ref,
-                copy_handler_ref,
-            )
-            .await
-        });
+        tokio::spawn(async move { process_socket(incoming_socket.0, None, factory_ref).await });
     }
 }

--- a/examples/secure_server.rs
+++ b/examples/secure_server.rs
@@ -14,7 +14,7 @@ use pgwire::api::auth::noop::NoopStartupHandler;
 use pgwire::api::copy::NoopCopyHandler;
 use pgwire::api::query::{PlaceholderExtendedQueryHandler, SimpleQueryHandler};
 use pgwire::api::results::{DataRowEncoder, FieldFormat, FieldInfo, QueryResponse, Response, Tag};
-use pgwire::api::{ClientInfo, MakeHandler, StatelessMakeHandler, Type};
+use pgwire::api::{ClientInfo, Type};
 use pgwire::error::PgWireResult;
 use pgwire::tokio::process_socket;
 
@@ -79,12 +79,10 @@ fn setup_tls() -> Result<TlsAcceptor, IOError> {
 
 #[tokio::main]
 pub async fn main() {
-    let processor = Arc::new(StatelessMakeHandler::new(Arc::new(DummyProcessor)));
+    let processor = Arc::new(DummyProcessor);
     // We have not implemented extended query in this server, use placeholder instead
-    let placeholder = Arc::new(StatelessMakeHandler::new(Arc::new(
-        PlaceholderExtendedQueryHandler,
-    )));
-    let authenticator = Arc::new(StatelessMakeHandler::new(Arc::new(NoopStartupHandler)));
+    let placeholder = Arc::new(PlaceholderExtendedQueryHandler);
+    let authenticator = Arc::new(NoopStartupHandler);
     let noop_copy_handler = Arc::new(NoopCopyHandler);
 
     let server_addr = "127.0.0.1:5433";
@@ -95,9 +93,9 @@ pub async fn main() {
     loop {
         let incoming_socket = listener.accept().await.unwrap();
         let tls_acceptor_ref = tls_acceptor.clone();
-        let authenticator_ref = authenticator.make();
-        let processor_ref = processor.make();
-        let placeholder_ref = placeholder.make();
+        let authenticator_ref = authenticator.clone();
+        let processor_ref = processor.clone();
+        let placeholder_ref = placeholder.clone();
         let copy_handler_ref = noop_copy_handler.clone();
         tokio::spawn(async move {
             process_socket(

--- a/examples/server.rs
+++ b/examples/server.rs
@@ -9,7 +9,7 @@ use pgwire::api::auth::noop::NoopStartupHandler;
 use pgwire::api::copy::NoopCopyHandler;
 use pgwire::api::query::{PlaceholderExtendedQueryHandler, SimpleQueryHandler};
 use pgwire::api::results::{DataRowEncoder, FieldFormat, FieldInfo, QueryResponse, Response, Tag};
-use pgwire::api::{ClientInfo, Type};
+use pgwire::api::{ClientInfo, PgWireHandlerFactory, Type};
 use pgwire::error::ErrorInfo;
 use pgwire::error::{PgWireError, PgWireResult};
 use pgwire::messages::response::NoticeResponse;
@@ -69,33 +69,45 @@ impl SimpleQueryHandler for DummyProcessor {
     }
 }
 
+struct DummyProcessorFactory {
+    handler: Arc<DummyProcessor>,
+}
+
+impl PgWireHandlerFactory for DummyProcessorFactory {
+    type StartupHandler = NoopStartupHandler;
+    type SimpleQueryHandler = DummyProcessor;
+    type ExtendedQueryHandler = PlaceholderExtendedQueryHandler;
+    type CopyHandler = NoopCopyHandler;
+
+    fn simple_query_handler(&self) -> Arc<Self::SimpleQueryHandler> {
+        self.handler.clone()
+    }
+
+    fn extended_query_handler(&self) -> Arc<Self::ExtendedQueryHandler> {
+        Arc::new(PlaceholderExtendedQueryHandler)
+    }
+
+    fn startup_handler(&self) -> Arc<Self::StartupHandler> {
+        Arc::new(NoopStartupHandler)
+    }
+
+    fn copy_handler(&self) -> Arc<Self::CopyHandler> {
+        Arc::new(NoopCopyHandler)
+    }
+}
+
 #[tokio::main]
 pub async fn main() {
-    let processor = Arc::new(DummyProcessor);
-    // We have not implemented extended query in this server, use placeholder instead
-    let placeholder = Arc::new(PlaceholderExtendedQueryHandler);
-    let authenticator = Arc::new(NoopStartupHandler);
-    let noop_copy_handler = Arc::new(NoopCopyHandler);
+    let factory = Arc::new(DummyProcessorFactory {
+        handler: Arc::new(DummyProcessor),
+    });
 
     let server_addr = "127.0.0.1:5432";
     let listener = TcpListener::bind(server_addr).await.unwrap();
     println!("Listening to {}", server_addr);
     loop {
         let incoming_socket = listener.accept().await.unwrap();
-        let authenticator_ref = authenticator.clone();
-        let processor_ref = processor.clone();
-        let placeholder_ref = placeholder.clone();
-        let copy_handler_ref = noop_copy_handler.clone();
-        tokio::spawn(async move {
-            process_socket(
-                incoming_socket.0,
-                None,
-                authenticator_ref,
-                processor_ref,
-                placeholder_ref,
-                copy_handler_ref,
-            )
-            .await
-        });
+        let factory_ref = factory.clone();
+        tokio::spawn(async move { process_socket(incoming_socket.0, None, factory_ref).await });
     }
 }

--- a/examples/server.rs
+++ b/examples/server.rs
@@ -9,7 +9,7 @@ use pgwire::api::auth::noop::NoopStartupHandler;
 use pgwire::api::copy::NoopCopyHandler;
 use pgwire::api::query::{PlaceholderExtendedQueryHandler, SimpleQueryHandler};
 use pgwire::api::results::{DataRowEncoder, FieldFormat, FieldInfo, QueryResponse, Response, Tag};
-use pgwire::api::{ClientInfo, MakeHandler, StatelessMakeHandler, Type};
+use pgwire::api::{ClientInfo, Type};
 use pgwire::error::ErrorInfo;
 use pgwire::error::{PgWireError, PgWireResult};
 use pgwire::messages::response::NoticeResponse;
@@ -71,12 +71,10 @@ impl SimpleQueryHandler for DummyProcessor {
 
 #[tokio::main]
 pub async fn main() {
-    let processor = Arc::new(StatelessMakeHandler::new(Arc::new(DummyProcessor)));
+    let processor = Arc::new(DummyProcessor);
     // We have not implemented extended query in this server, use placeholder instead
-    let placeholder = Arc::new(StatelessMakeHandler::new(Arc::new(
-        PlaceholderExtendedQueryHandler,
-    )));
-    let authenticator = Arc::new(StatelessMakeHandler::new(Arc::new(NoopStartupHandler)));
+    let placeholder = Arc::new(PlaceholderExtendedQueryHandler);
+    let authenticator = Arc::new(NoopStartupHandler);
     let noop_copy_handler = Arc::new(NoopCopyHandler);
 
     let server_addr = "127.0.0.1:5432";
@@ -84,9 +82,9 @@ pub async fn main() {
     println!("Listening to {}", server_addr);
     loop {
         let incoming_socket = listener.accept().await.unwrap();
-        let authenticator_ref = authenticator.make();
-        let processor_ref = processor.make();
-        let placeholder_ref = placeholder.make();
+        let authenticator_ref = authenticator.clone();
+        let processor_ref = processor.clone();
+        let placeholder_ref = placeholder.clone();
         let copy_handler_ref = noop_copy_handler.clone();
         tokio::spawn(async move {
             process_socket(

--- a/src/api/mod.rs
+++ b/src/api/mod.rs
@@ -2,7 +2,6 @@
 
 use std::collections::HashMap;
 use std::net::SocketAddr;
-use std::sync::Arc;
 
 pub use postgres_types::Type;
 
@@ -105,22 +104,5 @@ impl<S> ClientPortalStore for DefaultClient<S> {
 
     fn portal_store(&self) -> &Self::PortalStore {
         &self.portal_store
-    }
-}
-
-pub trait MakeHandler {
-    type Handler;
-
-    fn make(&self) -> Self::Handler;
-}
-
-#[derive(new)]
-pub struct StatelessMakeHandler<H>(Arc<H>);
-
-impl<H> MakeHandler for StatelessMakeHandler<H> {
-    type Handler = Arc<H>;
-
-    fn make(&self) -> Self::Handler {
-        self.0.clone()
     }
 }

--- a/src/api/mod.rs
+++ b/src/api/mod.rs
@@ -2,6 +2,7 @@
 
 use std::collections::HashMap;
 use std::net::SocketAddr;
+use std::sync::Arc;
 
 pub use postgres_types::Type;
 
@@ -105,4 +106,19 @@ impl<S> ClientPortalStore for DefaultClient<S> {
     fn portal_store(&self) -> &Self::PortalStore {
         &self.portal_store
     }
+}
+
+pub trait PgWireHandlerFactory {
+    type StartupHandler: auth::StartupHandler;
+    type SimpleQueryHandler: query::SimpleQueryHandler;
+    type ExtendedQueryHandler: query::ExtendedQueryHandler;
+    type CopyHandler: copy::CopyHandler;
+
+    fn simple_query_handler(&self) -> Arc<Self::SimpleQueryHandler>;
+
+    fn extended_query_handler(&self) -> Arc<Self::ExtendedQueryHandler>;
+
+    fn startup_handler(&self) -> Arc<Self::StartupHandler>;
+
+    fn copy_handler(&self) -> Arc<Self::CopyHandler>;
 }


### PR DESCRIPTION
As we have more and more handlers, startup, simple query, extended query and now copy, with logical replication may come soon, the `process_socket` api may need to accept a lot of arguments and break every time we introduce a new handler.

This patch sunsets our previous `MakeHandler` api and updated it to the new factory based api for both:

1. include all handler types in the API
2. take a responsibility of `MakeHandler` to control whether all not to create a new handler on new connections.