### PR TITLE
feat: respect `CopyInProgress` state

### DIFF
--- a/src/api/mod.rs
+++ b/src/api/mod.rs
@@ -23,7 +23,7 @@ pub enum PgWireConnectionState {
     AuthenticationInProgress,
     ReadyForQuery,
     QueryInProgress,
-    CopyInProgress,
+    CopyInProgress(bool),
     AwaitingSync,
 }
 


### PR DESCRIPTION
The recently introduced `CopyInProgress` state would be usually set by the code that handles a `COPY <t> FROM STDIN` statement.

The `process_message` loop should respect this behavior and only act on `CopyData` / `CopyDone` / `CopyFail` messages in this state.

In addition, the default `SimpleQueryHandler::on_query` implementation should no transition back to a `ReadyForQuery` state or send a response to the client if the `do_query` method ended with initiating a `COPY` phase.