### PR TITLE
feat: implement `ToSqlText` for `Decimal`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -42,6 +42,7 @@ postgres-types = { version = "0.2", features = [
     "array-impls",
 ], optional = true }
 chrono = { version = "0.4", features = ["std"], optional = true }
+rust_decimal = { version = "1.35", features = ["db-postgres"], optional = true }
 
 [features]
 default = ["server-api-aws-lc-rs"]
@@ -58,6 +59,7 @@ server-api = [
     "dep:hex",
     "dep:postgres-types",
     "dep:chrono",
+    "dep:rust_decimal",
 ]
 server-api-ring = ["server-api", "ring"]
 server-api-aws-lc-rs = ["server-api", "aws-lc-rs"]


### PR DESCRIPTION
The `rust_decimal` crate provides a `Decimal` type that implements the `ToSQL` trait required for integration with `rust-postgres`.

This is one of the recommended ways[^1] of exposing `NUMERIC` and `DECIMAL` columns in `rust-postgres` / `tokio-postgres` results.

This commit introduces `rust_decimal` as an optional dependency and adds a `ToSqlText` implementation (similar to how the `chrono` types are pulled in and used to provide support for `DATE`/`TIME`/`DATETIME` Postgres types).

[^1]: https://stackoverflow.com/a/72626605