### PR TITLE
feat: add support for direct ssl

### DIFF
--- a/examples/secure_server.rs
+++ b/examples/secure_server.rs
@@ -69,10 +69,12 @@ fn setup_tls() -> Result<TlsAcceptor, IOError> {
         .collect::<Result<Vec<PrivateKeyDer>, IOError>>()?
         .remove(0);
 
-    let config = ServerConfig::builder()
+    let mut config = ServerConfig::builder()
         .with_no_client_auth()
         .with_single_cert(cert, key)
         .map_err(|err| IOError::new(ErrorKind::InvalidInput, err))?;
+
+    config.alpn_protocols = vec![b"postgresql".to_vec()];
 
     Ok(TlsAcceptor::from(Arc::new(config)))
 }

--- a/src/tokio.rs
+++ b/src/tokio.rs
@@ -339,8 +339,9 @@ where
 fn check_alpn_for_direct_ssl<IO>(tls_socket: &TlsStream<IO>) -> Result<(), IOError> {
     let (_, the_conn) = tls_socket.get_ref();
     let mut accept = false;
+
     if let Some(alpn) = the_conn.alpn_protocol() {
-        if alpn == b"\x0apostgresql" {
+        if alpn == b"postgresql" {
             accept = true;
         }
     }

--- a/tests-integration/rust-client/Cargo.toml
+++ b/tests-integration/rust-client/Cargo.toml
@@ -8,4 +8,6 @@ publish = false
 
 [dependencies]
 tokio = { version = "1", features = ["full"] }
-postgres = { version = "0.19" }
+openssl = "0.10"
+postgres = { git = "https://github.com/sunng87/rust-postgres.git", rev = "629991beed1e689bd8ec79e1fd83aed03d049eef"  }
+postgres-openssl = { git = "https://github.com/sunng87/rust-postgres.git", rev = "629991beed1e689bd8ec79e1fd83aed03d049eef" }

--- a/tests-integration/rust-client/src/main.rs
+++ b/tests-integration/rust-client/src/main.rs
@@ -1,11 +1,17 @@
 use std::time::SystemTime;
 
-use postgres::{Client, NoTls, SimpleQueryMessage};
+use openssl::ssl::{SslConnector, SslMethod, SslVerifyMode};
+use postgres::{Client, SimpleQueryMessage};
+use postgres_openssl::MakeTlsConnector;
 
 fn main() {
+    let mut builder = SslConnector::builder(SslMethod::tls()).unwrap();
+    builder.set_verify(SslVerifyMode::NONE);
+    postgres_openssl::set_postgresql_alpn(&mut builder).unwrap();
+    let connector = MakeTlsConnector::new(builder.build());
     let mut client = Client::connect(
-        "host=localhost port=5432 user=postgres password=pencil dbname=localdb keepalives=0",
-        NoTls,
+        "host=localhost port=5432 user=postgres password=pencil dbname=localdb keepalives=0 sslmode=require sslnegotiation=direct",
+        connector,
     )
     .unwrap();
 

--- a/tests-integration/test-server/Cargo.toml
+++ b/tests-integration/test-server/Cargo.toml
@@ -11,3 +11,6 @@ pgwire = { path = "../../", features = ["scram"] }
 async-trait = "0.1"
 futures = "0.3"
 tokio = { version = "1", features = ["full"] }
+tokio-rustls = { version = "0.26", default-features = false, features = ["logging", "tls12"]}
+rustls-pemfile = "2.0"
+rustls-pki-types = "1.0"


### PR DESCRIPTION
Fixes #188 

To adopt postgres/libpq 17's new direct ssl feature, we add a new check for TLS first byte `0x16`. If matches, we go directly to ssl handshake process without SslRequest/SslResponse.