### PR TITLE
fix: use u16 type for parameters len

### DIFF
--- a/src/messages/data.rs
+++ b/src/messages/data.rs
@@ -106,7 +106,7 @@ impl Message for ParameterDescription {
     }
 
     fn encode_body(&self, buf: &mut BytesMut) -> PgWireResult<()> {
-        buf.put_i16(self.types.len() as i16);
+        buf.put_u16(self.types.len() as u16);
 
         for t in &self.types {
             buf.put_i32(*t as i32);
@@ -116,7 +116,7 @@ impl Message for ParameterDescription {
     }
 
     fn decode_body(buf: &mut BytesMut, _: usize) -> PgWireResult<Self> {
-        let types_len = buf.get_i16();
+        let types_len = buf.get_u16();
         let mut types = Vec::with_capacity(types_len as usize);
 
         for _ in 0..types_len {

--- a/src/messages/extendedquery.rs
+++ b/src/messages/extendedquery.rs
@@ -30,7 +30,7 @@ impl Message for Parse {
         codec::put_option_cstring(buf, &self.name);
         codec::put_cstring(buf, &self.query);
 
-        buf.put_i16(self.type_oids.len() as i16);
+        buf.put_u16(self.type_oids.len() as u16);
         for oid in &self.type_oids {
             buf.put_u32(*oid);
         }
@@ -41,7 +41,7 @@ impl Message for Parse {
     fn decode_body(buf: &mut bytes::BytesMut, _: usize) -> PgWireResult<Self> {
         let name = codec::get_cstring(buf);
         let query = codec::get_cstring(buf).unwrap_or_else(|| "".to_owned());
-        let type_oid_count = buf.get_i16();
+        let type_oid_count = buf.get_u16();
 
         let mut type_oids = Vec::with_capacity(type_oid_count as usize);
         for _ in 0..type_oid_count {
@@ -187,12 +187,12 @@ impl Message for Bind {
         codec::put_option_cstring(buf, &self.portal_name);
         codec::put_option_cstring(buf, &self.statement_name);
 
-        buf.put_i16(self.parameter_format_codes.len() as i16);
+        buf.put_u16(self.parameter_format_codes.len() as u16);
         for c in &self.parameter_format_codes {
             buf.put_i16(*c);
         }
 
-        buf.put_i16(self.parameters.len() as i16);
+        buf.put_u16(self.parameters.len() as u16);
         for v in &self.parameters {
             if let Some(v) = v {
                 buf.put_i32(v.len() as i32);
@@ -214,14 +214,14 @@ impl Message for Bind {
         let portal_name = codec::get_cstring(buf);
         let statement_name = codec::get_cstring(buf);
 
-        let parameter_format_code_len = buf.get_i16();
+        let parameter_format_code_len = buf.get_u16();
         let mut parameter_format_codes = Vec::with_capacity(parameter_format_code_len as usize);
 
         for _ in 0..parameter_format_code_len {
             parameter_format_codes.push(buf.get_i16());
         }
 
-        let parameter_len = buf.get_i16();
+        let parameter_len = buf.get_u16();
         let mut parameters = Vec::with_capacity(parameter_len as usize);
         for _ in 0..parameter_len {
             let data_len = buf.get_i32();

--- a/src/messages/mod.rs
+++ b/src/messages/mod.rs
@@ -512,6 +512,16 @@ mod test {
     }
 
     #[test]
+    fn test_parse_65k() {
+        let parse = Parse::new(
+            Some("many-params".to_owned()),
+            "it won't be parsed anyway".to_owned(),
+            vec![25; u16::MAX as usize],
+        );
+        roundtrip!(parse, Parse);
+    }
+
+    #[test]
     fn test_parse_complete() {
         let parse_complete = ParseComplete::new();
         roundtrip!(parse_complete, ParseComplete);
@@ -533,6 +543,18 @@ mod test {
             Some("find-user-by-id".to_owned()),
             vec![0],
             vec![Some(Bytes::from_static(b"1234"))],
+            vec![0],
+        );
+        roundtrip!(bind, Bind);
+    }
+
+    #[test]
+    fn test_bind_65k() {
+        let bind = Bind::new(
+            Some("lol".to_owned()),
+            Some("kek".to_owned()),
+            vec![0; u16::MAX as usize],
+            vec![Some(Bytes::from_static(b"1234")); u16::MAX as usize],
             vec![0],
         );
         roundtrip!(bind, Bind);


### PR DESCRIPTION
According to the PostgreSQL documentation, the upper limit for query parameters is 65,535, that cannot be represented as i16. (https://www.postgresql.org/docs/16/limits.html)

The old implementation caused a panic for parse and bind messages with more than 32,767 parameters. For instance, 65,535 turned into -1, which when cast to usize resulted in usize::MAX. This led to a panic during the allocation of a vector for usize::MAX parameters.