### PR TITLE
chore: skip building duckdb

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -59,6 +59,8 @@ jobs:
       run: cargo test --features server-api-ring,scram
     - name: Run tests on additional scram+aws-lc-rs feature set
       run: cargo test --features scram
+    - name: Run tests on _duckdb example
+      run: cargo test --features _duckdb
 
   integration:
     name: Integration tests

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -64,12 +64,13 @@ server-api = [
 server-api-ring = ["server-api", "ring"]
 server-api-aws-lc-rs = ["server-api", "aws-lc-rs"]
 scram = ["dep:base64", "dep:stringprep", "dep:x509-certificate"]
+_duckdb = []
 
 [dev-dependencies]
 tokio = { version = "1.19", features = ["rt-multi-thread", "net", "macros"]}
 rusqlite = { version = "0.31.0", features = ["bundled", "column_decltype"] }
 ## for duckdb example
-duckdb = { version = "0.10.0", features = ["bundled"] }
+duckdb = { version = "1.0.0" }
 
 ## for loading custom cert files
 rustls-pemfile = "2.0"
@@ -107,7 +108,7 @@ required-features = ["server-api"]
 
 [[example]]
 name = "duckdb"
-required-features = ["server-api"]
+required-features = ["server-api", "_duckdb"]
 
 [[example]]
 name = "copy"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -70,7 +70,7 @@ _duckdb = []
 tokio = { version = "1.19", features = ["rt-multi-thread", "net", "macros"]}
 rusqlite = { version = "0.31.0", features = ["bundled", "column_decltype"] }
 ## for duckdb example
-duckdb = { version = "1.0.0" }
+duckdb = { version = "1.0.0", features = ["bundled"] }
 
 ## for loading custom cert files
 rustls-pemfile = "2.0"


### PR DESCRIPTION
This patch feature gated the duckdb example to speedup our test build