### PR TITLE
feat: track transaction state

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -88,7 +88,7 @@ jobs:
     - uses: actions/checkout@v4
     - uses: actions-rs/toolchain@v1
       with:
-        toolchain: "1.72"
+        toolchain: "1.74"
         override: true
     - run: cargo build --no-default-features
     - run: cargo build --all-features

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -120,3 +120,7 @@ required-features = ["server-api"]
 [[example]]
 name = "scram"
 required-features = ["scram"]
+
+[[example]]
+name = "transaction"
+required-features = ["server-api"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ homepage = "https://github.com/sunng87/pgwire"
 repository = "https://github.com/sunng87/pgwire"
 documentation = "https://docs.rs/crate/pgwire/"
 readme = "README.md"
-rust-version = "1.72"
+rust-version = "1.74"
 
 [dependencies]
 derive-new = "0.7"

--- a/README.md
+++ b/README.md
@@ -62,6 +62,7 @@ with its usage.
     - [x] Copy-in
     - [x] Copy-out
     - [x] Copy-both
+  - [x] Transaction state
   - [ ] Streaming replication over TCP
   - [ ] Logical streaming replication server API
 

--- a/examples/bench.rs
+++ b/examples/bench.rs
@@ -16,6 +16,8 @@ use pgwire::tokio::process_socket;
 
 pub struct DummyProcessor;
 
+impl NoopStartupHandler for DummyProcessor {}
+
 #[async_trait]
 impl SimpleQueryHandler for DummyProcessor {
     async fn do_query<'a, C>(
@@ -72,7 +74,7 @@ struct DummyProcessorFactory {
 }
 
 impl PgWireHandlerFactory for DummyProcessorFactory {
-    type StartupHandler = NoopStartupHandler;
+    type StartupHandler = DummyProcessor;
     type SimpleQueryHandler = DummyProcessor;
     type ExtendedQueryHandler = PlaceholderExtendedQueryHandler;
     type CopyHandler = NoopCopyHandler;
@@ -86,7 +88,7 @@ impl PgWireHandlerFactory for DummyProcessorFactory {
     }
 
     fn startup_handler(&self) -> Arc<Self::StartupHandler> {
-        Arc::new(NoopStartupHandler)
+        self.handler.clone()
     }
 
     fn copy_handler(&self) -> Arc<Self::CopyHandler> {

--- a/examples/copy.rs
+++ b/examples/copy.rs
@@ -19,6 +19,8 @@ use pgwire::tokio::process_socket;
 
 pub struct DummyProcessor;
 
+impl NoopStartupHandler for DummyProcessor {}
+
 #[async_trait]
 impl SimpleQueryHandler for DummyProcessor {
     async fn do_query<'a, C>(
@@ -105,7 +107,7 @@ struct DummyProcessorFactory {
 }
 
 impl PgWireHandlerFactory for DummyProcessorFactory {
-    type StartupHandler = NoopStartupHandler;
+    type StartupHandler = DummyProcessor;
     type SimpleQueryHandler = DummyProcessor;
     type ExtendedQueryHandler = PlaceholderExtendedQueryHandler;
     type CopyHandler = DummyProcessor;
@@ -119,7 +121,7 @@ impl PgWireHandlerFactory for DummyProcessorFactory {
     }
 
     fn startup_handler(&self) -> Arc<Self::StartupHandler> {
-        Arc::new(NoopStartupHandler)
+        self.handler.clone()
     }
 
     fn copy_handler(&self) -> Arc<Self::CopyHandler> {

--- a/examples/gluesql.rs
+++ b/examples/gluesql.rs
@@ -17,6 +17,8 @@ pub struct GluesqlProcessor {
     glue: Arc<Mutex<Glue<MemoryStorage>>>,
 }
 
+impl NoopStartupHandler for GluesqlProcessor {}
+
 #[async_trait]
 impl SimpleQueryHandler for GluesqlProcessor {
     async fn do_query<'a, C>(
@@ -164,7 +166,7 @@ struct GluesqlHandlerFactory {
 }
 
 impl PgWireHandlerFactory for GluesqlHandlerFactory {
-    type StartupHandler = NoopStartupHandler;
+    type StartupHandler = GluesqlProcessor;
     type SimpleQueryHandler = GluesqlProcessor;
     type ExtendedQueryHandler = PlaceholderExtendedQueryHandler;
     type CopyHandler = NoopCopyHandler;
@@ -178,7 +180,7 @@ impl PgWireHandlerFactory for GluesqlHandlerFactory {
     }
 
     fn startup_handler(&self) -> Arc<Self::StartupHandler> {
-        Arc::new(NoopStartupHandler)
+        self.processor.clone()
     }
 
     fn copy_handler(&self) -> Arc<Self::CopyHandler> {

--- a/examples/secure_server.rs
+++ b/examples/secure_server.rs
@@ -20,6 +20,8 @@ use pgwire::tokio::process_socket;
 
 pub struct DummyProcessor;
 
+impl NoopStartupHandler for DummyProcessor {}
+
 #[async_trait]
 impl SimpleQueryHandler for DummyProcessor {
     async fn do_query<'a, C>(
@@ -84,7 +86,7 @@ struct DummyProcessorFactory {
 }
 
 impl PgWireHandlerFactory for DummyProcessorFactory {
-    type StartupHandler = NoopStartupHandler;
+    type StartupHandler = DummyProcessor;
     type SimpleQueryHandler = DummyProcessor;
     type ExtendedQueryHandler = PlaceholderExtendedQueryHandler;
     type CopyHandler = NoopCopyHandler;
@@ -98,7 +100,7 @@ impl PgWireHandlerFactory for DummyProcessorFactory {
     }
 
     fn startup_handler(&self) -> Arc<Self::StartupHandler> {
-        Arc::new(NoopStartupHandler)
+        self.handler.clone()
     }
 
     fn copy_handler(&self) -> Arc<Self::CopyHandler> {

--- a/examples/server.rs
+++ b/examples/server.rs
@@ -18,6 +18,8 @@ use pgwire::tokio::process_socket;
 
 pub struct DummyProcessor;
 
+impl NoopStartupHandler for DummyProcessor {}
+
 #[async_trait]
 impl SimpleQueryHandler for DummyProcessor {
     async fn do_query<'a, C>(
@@ -74,7 +76,7 @@ struct DummyProcessorFactory {
 }
 
 impl PgWireHandlerFactory for DummyProcessorFactory {
-    type StartupHandler = NoopStartupHandler;
+    type StartupHandler = DummyProcessor;
     type SimpleQueryHandler = DummyProcessor;
     type ExtendedQueryHandler = PlaceholderExtendedQueryHandler;
     type CopyHandler = NoopCopyHandler;
@@ -88,7 +90,7 @@ impl PgWireHandlerFactory for DummyProcessorFactory {
     }
 
     fn startup_handler(&self) -> Arc<Self::StartupHandler> {
-        Arc::new(NoopStartupHandler)
+        self.handler.clone()
     }
 
     fn copy_handler(&self) -> Arc<Self::CopyHandler> {

--- a/examples/transaction.rs
+++ b/examples/transaction.rs
@@ -1,0 +1,131 @@
+use std::fmt::Debug;
+use std::sync::Arc;
+
+use async_trait::async_trait;
+use futures::{stream, Sink, SinkExt};
+use tokio::net::TcpListener;
+
+use pgwire::api::auth::noop::NoopStartupHandler;
+use pgwire::api::copy::NoopCopyHandler;
+use pgwire::api::query::{PlaceholderExtendedQueryHandler, SimpleQueryHandler};
+use pgwire::api::results::{DataRowEncoder, FieldFormat, FieldInfo, QueryResponse, Response, Tag};
+use pgwire::api::{ClientInfo, PgWireHandlerFactory, Type};
+use pgwire::error::ErrorInfo;
+use pgwire::error::{PgWireError, PgWireResult};
+use pgwire::messages::response::NoticeResponse;
+use pgwire::messages::{PgWireBackendMessage, PgWireFrontendMessage};
+use pgwire::tokio::process_socket;
+
+pub struct DummyProcessor;
+
+#[async_trait]
+impl NoopStartupHandler for DummyProcessor {
+    async fn post_startup<C>(
+        &self,
+        client: &mut C,
+        _message: PgWireFrontendMessage,
+    ) -> PgWireResult<()>
+    where
+        C: ClientInfo + Sink<PgWireBackendMessage> + Unpin + Send,
+        C::Error: Debug,
+        PgWireError: From<<C as Sink<PgWireBackendMessage>>::Error>,
+    {
+        println!("Connected: {}", client.socket_addr());
+        client
+            .send(PgWireBackendMessage::NoticeResponse(NoticeResponse::from(
+                ErrorInfo::new(
+                    "NOTICE".to_owned(),
+                    "01000".to_owned(),
+                    "Supported queries in this example:\n- BEGIN;\n- ROLLBACK;\n- COMMIT;\n- SELECT 1;"
+                        .to_string(),
+                ),
+            )))
+            .await?;
+        Ok(())
+    }
+}
+
+#[async_trait]
+impl SimpleQueryHandler for DummyProcessor {
+    async fn do_query<'a, C>(
+        &self,
+        _client: &mut C,
+        query: &'a str,
+    ) -> PgWireResult<Vec<Response<'a>>>
+    where
+        C: ClientInfo + Sink<PgWireBackendMessage> + Unpin + Send + Sync,
+        C::Error: Debug,
+        PgWireError: From<<C as Sink<PgWireBackendMessage>>::Error>,
+    {
+        let resp = match query {
+            "BEGIN;" => Response::TransactionStart(Tag::new("BEGIN")),
+            "ROLLBACK;" => Response::TransactionEnd(Tag::new("ROLLBACK")),
+            "COMMIT;" => Response::TransactionEnd(Tag::new("COMMIT")),
+            "SELECT 1;" => {
+                let f1 =
+                    FieldInfo::new("SELECT 1".into(), None, None, Type::INT4, FieldFormat::Text);
+                let schema = Arc::new(vec![f1]);
+                let schema_ref = schema.clone();
+
+                let row = {
+                    let mut encoder = DataRowEncoder::new(schema_ref.clone());
+                    encoder.encode_field(&Some(1))?;
+
+                    encoder.finish()
+                };
+                let data_row_stream = stream::iter(vec![row]);
+                Response::Query(QueryResponse::new(schema, data_row_stream))
+            }
+            _ => Response::Error(Box::new(ErrorInfo::new(
+                "FATAL".to_string(),
+                "38003".to_string(),
+                "Unsupported statement.".to_string(),
+            ))),
+        };
+
+        Ok(vec![resp])
+    }
+}
+
+struct DummyProcessorFactory {
+    handler: Arc<DummyProcessor>,
+}
+
+impl PgWireHandlerFactory for DummyProcessorFactory {
+    type StartupHandler = DummyProcessor;
+    type SimpleQueryHandler = DummyProcessor;
+    type ExtendedQueryHandler = PlaceholderExtendedQueryHandler;
+    type CopyHandler = NoopCopyHandler;
+
+    fn simple_query_handler(&self) -> Arc<Self::SimpleQueryHandler> {
+        self.handler.clone()
+    }
+
+    fn extended_query_handler(&self) -> Arc<Self::ExtendedQueryHandler> {
+        Arc::new(PlaceholderExtendedQueryHandler)
+    }
+
+    fn startup_handler(&self) -> Arc<Self::StartupHandler> {
+        self.handler.clone()
+    }
+
+    fn copy_handler(&self) -> Arc<Self::CopyHandler> {
+        Arc::new(NoopCopyHandler)
+    }
+}
+
+#[tokio::main]
+pub async fn main() {
+    let factory = Arc::new(DummyProcessorFactory {
+        handler: Arc::new(DummyProcessor),
+    });
+
+    let server_addr = "127.0.0.1:5432";
+    let listener = TcpListener::bind(server_addr).await.unwrap();
+    println!("Listening to {}", server_addr);
+    loop {
+        let incoming_socket = listener.accept().await.unwrap();
+        let factory_ref = factory.clone();
+        tokio::spawn(async move { process_socket(incoming_socket.0, None, factory_ref).await });
+    }
+}

--- a/src/api/auth/cleartext.rs
+++ b/src/api/auth/cleartext.rs
@@ -47,7 +47,7 @@ impl<V: AuthSource, P: ServerParameterProvider> StartupHandler
                 let login_info = LoginInfo::from_client_info(client);
                 let pass = self.auth_source.get_password(&login_info).await?;
                 if pass.password == pwd.password.as_bytes() {
-                    super::finish_authentication(client, &self.parameter_provider).await
+                    super::finish_authentication(client, &self.parameter_provider).await?;
                 } else {
                     let error_info = ErrorInfo::new(
                         "FATAL".to_owned(),

--- a/src/api/auth/md5pass.rs
+++ b/src/api/auth/md5pass.rs
@@ -73,7 +73,7 @@ impl<A: AuthSource, P: ServerParameterProvider> StartupHandler
                 let cached_pass = self.cached_password.lock().await;
 
                 if pwd.password.as_bytes() == *cached_pass {
-                    super::finish_authentication(client, self.parameter_provider.as_ref()).await
+                    super::finish_authentication(client, self.parameter_provider.as_ref()).await?;
                 } else {
                     let error_info = ErrorInfo::new(
                         "FATAL".to_owned(),

--- a/src/api/auth/mod.rs
+++ b/src/api/auth/mod.rs
@@ -186,7 +186,9 @@ where
     )));
     let mut message_stream = stream::iter(messages.into_iter().map(Ok));
     client.send_all(&mut message_stream).await.unwrap();
-    client.set_state(PgWireConnectionState::ReadyForQuery);
+    client.set_state(PgWireConnectionState::ReadyForQuery(
+        TransactionStatus::Idle,
+    ));
 }
 
 pub mod cleartext;

--- a/src/api/auth/mod.rs
+++ b/src/api/auth/mod.rs
@@ -186,9 +186,7 @@ where
     )));
     let mut message_stream = stream::iter(messages.into_iter().map(Ok));
     client.send_all(&mut message_stream).await.unwrap();
-    client.set_state(PgWireConnectionState::ReadyForQuery(
-        TransactionStatus::Idle,
-    ));
+    client.set_state(PgWireConnectionState::ReadyForQuery);
 }
 
 pub mod cleartext;

--- a/src/api/auth/noop.rs
+++ b/src/api/auth/noop.rs
@@ -1,16 +1,35 @@
 use std::fmt::Debug;
 
 use async_trait::async_trait;
-use futures::sink::Sink;
+use futures::sink::{Sink, SinkExt};
 
 use super::{ClientInfo, DefaultServerParameterProvider, StartupHandler};
+use crate::api::PgWireConnectionState;
 use crate::error::{PgWireError, PgWireResult};
+use crate::messages::response::{ReadyForQuery, TransactionStatus};
 use crate::messages::{PgWireBackendMessage, PgWireFrontendMessage};
 
-pub struct NoopStartupHandler;
+#[async_trait]
+pub trait NoopStartupHandler: StartupHandler {
+    async fn post_startup<C>(
+        &self,
+        _client: &mut C,
+        _message: PgWireFrontendMessage,
+    ) -> PgWireResult<()>
+    where
+        C: ClientInfo + Sink<PgWireBackendMessage> + Unpin + Send,
+        C::Error: Debug,
+        PgWireError: From<<C as Sink<PgWireBackendMessage>>::Error>,
+    {
+        Ok(())
+    }
+}
 
 #[async_trait]
-impl StartupHandler for NoopStartupHandler {
+impl<H> StartupHandler for H
+where
+    H: NoopStartupHandler,
+{
     async fn on_startup<C>(
         &self,
         client: &mut C,
@@ -23,8 +42,19 @@ impl StartupHandler for NoopStartupHandler {
     {
         if let PgWireFrontendMessage::Startup(ref startup) = message {
             super::save_startup_parameters_to_metadata(client, startup);
-            super::finish_authentication(client, &DefaultServerParameterProvider::default()).await;
+            super::finish_authentication0(client, &DefaultServerParameterProvider::default())
+                .await?;
+
+            self.post_startup(client, message).await?;
+
+            client
+                .send(PgWireBackendMessage::ReadyForQuery(ReadyForQuery::new(
+                    TransactionStatus::Idle,
+                )))
+                .await?;
+            client.set_state(PgWireConnectionState::ReadyForQuery);
         }
+
         Ok(())
     }
 }

--- a/src/api/auth/scram.rs
+++ b/src/api/auth/scram.rs
@@ -217,7 +217,7 @@ impl<A: AuthSource, P: ServerParameterProvider> StartupHandler
                     .await?;
 
                 if success {
-                    super::finish_authentication(client, self.parameter_provider.as_ref()).await
+                    super::finish_authentication(client, self.parameter_provider.as_ref()).await?;
                 }
             }
             _ => {}

--- a/src/api/mod.rs
+++ b/src/api/mod.rs
@@ -6,6 +6,8 @@ use std::sync::Arc;
 
 pub use postgres_types::Type;
 
+use crate::messages::response::TransactionStatus;
+
 pub mod auth;
 pub mod copy;
 pub mod portal;
@@ -21,7 +23,8 @@ pub enum PgWireConnectionState {
     #[default]
     AwaitingStartup,
     AuthenticationInProgress,
-    ReadyForQuery,
+    // in transaction or not
+    ReadyForQuery(TransactionStatus),
     QueryInProgress,
     CopyInProgress(bool),
     AwaitingSync,

--- a/src/api/results.rs
+++ b/src/api/results.rs
@@ -334,6 +334,12 @@ pub struct CopyResponse {
 /// * Query: the response contains data rows
 /// * Execution: response for ddl/dml execution
 /// * Error: error response
+/// * EmptyQuery: when client sends an empty query
+/// * TransactionStart: indicate previous statement just started a transaction
+/// * TransactionEnd: indicate previous statement just ended a transaction
+/// * CopyIn: response for a copy-in request
+/// * CopyOut: response for a copy-out request
+/// * CopuBoth: response for a copy-both request
 pub enum Response<'a> {
     EmptyQuery,
     Query(QueryResponse<'a>),

--- a/src/api/results.rs
+++ b/src/api/results.rs
@@ -336,6 +336,8 @@ pub enum Response<'a> {
     EmptyQuery,
     Query(QueryResponse<'a>),
     Execution(Tag),
+    TransactionStart(Tag),
+    TransactionEnd(Tag),
     Error(Box<ErrorInfo>),
     CopyIn(CopyResponse),
     CopyOut(CopyResponse),

--- a/src/api/transaction.rs
+++ b/src/api/transaction.rs
@@ -1,0 +1,22 @@
+use crate::messages::response::TransactionStatus;
+
+impl TransactionStatus {
+    pub fn to_idle_state(self) -> TransactionStatus {
+        TransactionStatus::Idle
+    }
+
+    pub fn to_error_state(self) -> TransactionStatus {
+        match self {
+            TransactionStatus::Idle => TransactionStatus::Idle,
+            _ => TransactionStatus::Error,
+        }
+    }
+
+    pub fn to_in_transaction_state(self) -> TransactionStatus {
+        match self {
+            TransactionStatus::Idle => TransactionStatus::Transaction,
+            TransactionStatus::Transaction => TransactionStatus::Transaction,
+            TransactionStatus::Error => TransactionStatus::Error,
+        }
+    }
+}

--- a/src/error.rs
+++ b/src/error.rs
@@ -36,6 +36,8 @@ pub enum PgWireError {
     UnsupportedCertificateSignatureAlgorithm,
     #[error("Username is required")]
     UserNameRequired,
+    #[error("Connection is not ready for query")]
+    NotReadyForQuery,
 
     #[error(transparent)]
     ApiError(#[from] Box<dyn std::error::Error + 'static + Send + Sync>),

--- a/src/tokio.rs
+++ b/src/tokio.rs
@@ -124,7 +124,10 @@ where
         PgWireConnectionState::AwaitingSync => {
             if let PgWireFrontendMessage::Sync(sync) = message {
                 extended_query_handler.on_sync(socket, sync).await?;
-                socket.set_state(PgWireConnectionState::ReadyForQuery);
+                // TODO: confirm if we need to track transaction state there
+                socket.set_state(PgWireConnectionState::ReadyForQuery(
+                    TransactionStatus::Idle,
+                ));
             }
         }
         PgWireConnectionState::CopyInProgress(is_extended_query) => {
@@ -140,7 +143,9 @@ where
                         // query, we should leave the CopyInProgress state
                         // before returning the error in order to resume normal
                         // operation after handling it in process_error.
-                        socket.set_state(PgWireConnectionState::ReadyForQuery);
+                        socket.set_state(PgWireConnectionState::ReadyForQuery(
+                            TransactionStatus::Idle,
+                        ));
                     }
                     match result {
                         Ok(_) => {
@@ -166,7 +171,9 @@ where
                         // we should leave the CopyInProgress state
                         // before returning the error in order to resume normal
                         // operation after handling it in process_error.
-                        socket.set_state(PgWireConnectionState::ReadyForQuery);
+                        socket.set_state(PgWireConnectionState::ReadyForQuery(
+                            TransactionStatus::Idle,
+                        ));
                     }
                     return Err(error);
                 }


### PR DESCRIPTION
Fixes #170 

This patch adds transaction state tracking and allows developer to return transaction state change from `Response` type.

I also refactored `finish_authentication` in `pgwire::api::auth` to remove an `unwrap` usage.

Also set MSRV to 1.74 to fix a Sync marker issue