### PR TITLE
refactor: do not require Arc for handler factory

### DIFF
--- a/src/api/mod.rs
+++ b/src/api/mod.rs
@@ -122,3 +122,29 @@ pub trait PgWireHandlerFactory {
 
     fn copy_handler(&self) -> Arc<Self::CopyHandler>;
 }
+
+impl<T> PgWireHandlerFactory for Arc<T>
+where
+    T: PgWireHandlerFactory,
+{
+    type StartupHandler = T::StartupHandler;
+    type SimpleQueryHandler = T::SimpleQueryHandler;
+    type ExtendedQueryHandler = T::ExtendedQueryHandler;
+    type CopyHandler = T::CopyHandler;
+
+    fn simple_query_handler(&self) -> Arc<Self::SimpleQueryHandler> {
+        (**self).simple_query_handler()
+    }
+
+    fn extended_query_handler(&self) -> Arc<Self::ExtendedQueryHandler> {
+        (**self).extended_query_handler()
+    }
+
+    fn startup_handler(&self) -> Arc<Self::StartupHandler> {
+        (**self).startup_handler()
+    }
+
+    fn copy_handler(&self) -> Arc<Self::CopyHandler> {
+        (**self).copy_handler()
+    }
+}

--- a/src/tokio.rs
+++ b/src/tokio.rs
@@ -359,7 +359,7 @@ fn check_alpn_for_direct_ssl<IO>(tls_socket: &TlsStream<IO>) -> Result<(), IOErr
 pub async fn process_socket<H>(
     tcp_socket: TcpStream,
     tls_acceptor: Option<Arc<TlsAcceptor>>,
-    handlers: Arc<H>,
+    handlers: H,
 ) -> Result<(), IOError>
 where
     H: PgWireHandlerFactory,


### PR DESCRIPTION
We just have too much Arc wrappers required for `process_socket` and in some case it's totally not necessary. This change removes requirement for `Arc` and make it optional only when you are using a stateless handler.