### PR TITLE
fix: check peek return value of dead stream

### DIFF
--- a/src/tokio.rs
+++ b/src/tokio.rs
@@ -263,7 +263,7 @@ async fn check_ssl_negotiation(tcp_socket: &TcpStream) -> Result<SslNegotiationT
 
         // the tcp_stream has ended
         if n == 0 {
-            return Ok(SslNegotiationType::None)
+            return Ok(SslNegotiationType::None);
         }
 
         if n >= SslRequest::BODY_SIZE {

--- a/src/tokio.rs
+++ b/src/tokio.rs
@@ -260,6 +260,12 @@ async fn check_ssl_negotiation(tcp_socket: &TcpStream) -> Result<SslNegotiationT
     let mut buf = [0u8; SslRequest::BODY_SIZE];
     loop {
         let n = tcp_socket.peek(&mut buf).await?;
+
+        // the tcp_stream has ended
+        if n == 0 {
+            return Ok(SslNegotiationType::None)
+        }
+
         if n >= SslRequest::BODY_SIZE {
             break;
         }


### PR DESCRIPTION
This fixes an issue that when client disconnected before sending any bytes, the server goes into a dead loop.

This issue was introduced in #189 