### PR TITLE
fix: avoid busy loop on insufficient bytes on connection

### DIFF
--- a/src/api/mod.rs
+++ b/src/api/mod.rs
@@ -19,6 +19,7 @@ pub const DEFAULT_NAME: &str = "POSTGRESQL_DEFAULT_NAME";
 #[derive(Debug, Clone, Copy, Default)]
 pub enum PgWireConnectionState {
     #[default]
+    AwaitingSslRequest,
     AwaitingStartup,
     AuthenticationInProgress,
     ReadyForQuery,


### PR DESCRIPTION
Our previous implementation of peeking first packet can result in busy loop when insufficient bytes sent to server. This is because `peek` will return immediately when it has bytes available.