### PR TITLE
fix: command tag oid now shows up in string

### DIFF
--- a/src/api/results.rs
+++ b/src/api/results.rs
@@ -46,7 +46,9 @@ impl Tag {
 
 impl From<Tag> for CommandComplete {
     fn from(tag: Tag) -> CommandComplete {
-        let tag_string = if let Some(rows) = tag.rows {
+        let tag_string = if let (Some(oid), Some(rows)) = (tag.oid, tag.rows) {
+            format!("{} {oid} {rows}", tag.command)
+        } else if let Some(rows) = tag.rows {
             format!("{} {rows}", tag.command)
         } else {
             tag.command
@@ -350,10 +352,15 @@ mod test {
 
     #[test]
     fn test_command_complete() {
-        let tag = Tag::new("INSERT").with_oid(0).with_rows(100);
+        let tag = Tag::new("INSERT").with_rows(100);
         let cc = CommandComplete::from(tag);
 
         assert_eq!(cc.tag, "INSERT 100");
+
+        let tag = Tag::new("INSERT").with_oid(0).with_rows(100);
+        let cc = CommandComplete::from(tag);
+
+        assert_eq!(cc.tag, "INSERT 0 100");
     }
 
     #[test]


### PR DESCRIPTION
At least with the `psql` client, execution command strings without `oid` print a notice: `could not interpret result from server: <string>`.

This PR changes the serialization of `Tag` to `CommandComplete` by adding `oid` between the tag and `rows`.

The case of `Some(oid)` and `None` `rows` is not covered, because it would serialize in an ambiguous way. This means that `oid` will be ignored if `rows` is `None`.