### PR TITLE
refactor: make tls an optional feature

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -55,6 +55,8 @@ jobs:
       run: cargo test
     - name: Run tests on minimal feature set
       run: cargo test --no-default-features
+    - name: Run tests without tls
+      run: cargo test --no-default-features --features server-api
     - name: Run tests on additional scram+ring feature set
       run: cargo test --features server-api-ring,scram
     - name: Run tests on additional scram+aws-lc-rs feature set

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,8 +29,16 @@ jobs:
         toolchain: nightly
         components: clippy
         override: true
-    - name: Lint
-      run: cargo clippy --all-features -- -D warnings
+    - name: Lint default
+      run: cargo clippy -- -D warnings
+    - name: Lint minimal
+      run: cargo clippy --no-default-features -- -D warnings
+    - name: Lint server-api without tls
+      run: cargo clippy --no-default-features --features server-api -- -D warnings
+    - name: Lint ring
+      run: cargo clippy --no-default-features --features server-api-ring -- -D warnings
+    - name: Lint scram
+      run: cargo clippy --features scram -- -D warnings
 
   test:
     name: Test
@@ -58,7 +66,7 @@ jobs:
     - name: Run tests without tls
       run: cargo test --no-default-features --features server-api
     - name: Run tests on additional scram+ring feature set
-      run: cargo test --features server-api-ring,scram
+      run: cargo test --no-default-features --features server-api-ring,scram
     - name: Run tests on additional scram+aws-lc-rs feature set
       run: cargo test --features scram
     - name: Run check on duckdb and sqlite example
@@ -92,5 +100,8 @@ jobs:
       with:
         toolchain: "1.74"
         override: true
+    - run: cargo build
     - run: cargo build --no-default-features
-    - run: cargo build --all-features
+    - run: cargo build --no-default-features --features server-api
+    - run: cargo build --no-default-features --features server-api-ring
+    - run: cargo build --features scram

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -90,36 +90,36 @@ members = [
 
 [[example]]
 name = "server"
-required-features = ["server-api"]
+required-features = ["server-api-aws-lc-rs"]
 
 [[example]]
 name = "secure_server"
-required-features = ["server-api"]
+required-features = ["server-api-aws-lc-rs"]
 
 [[example]]
 name = "bench"
-required-features = ["server-api"]
+required-features = ["server-api-aws-lc-rs"]
 
 [[example]]
 name = "gluesql"
-required-features = ["server-api"]
+required-features = ["server-api-aws-lc-rs"]
 
 [[example]]
 name = "sqlite"
-required-features = ["server-api", "_sqlite"]
+required-features = ["server-api-aws-lc-rs", "_sqlite"]
 
 [[example]]
 name = "duckdb"
-required-features = ["server-api", "_duckdb"]
+required-features = ["server-api-aws-lc-rs", "_duckdb"]
 
 [[example]]
 name = "copy"
-required-features = ["server-api"]
+required-features = ["server-api-aws-lc-rs"]
 
 [[example]]
 name = "scram"
-required-features = ["scram"]
+required-features = ["server-api-aws-lc-rs", "scram"]
 
 [[example]]
 name = "transaction"
-required-features = ["server-api"]
+required-features = ["server-api-aws-lc-rs"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -47,12 +47,11 @@ lazy-regex = {version = "3.3", default-features = false, features = ["lite"]}
 
 [features]
 default = ["server-api-aws-lc-rs"]
-ring = ["dep:ring", "tokio-rustls/ring"]
-aws-lc-rs = ["dep:aws-lc-rs", "tokio-rustls/aws-lc-rs"]
+_ring = ["dep:ring", "tokio-rustls/ring"]
+_aws-lc-rs = ["dep:aws-lc-rs", "tokio-rustls/aws-lc-rs"]
 server-api = [
     "dep:tokio",
     "dep:tokio-util",
-    "dep:tokio-rustls",
     "dep:futures",
     "dep:async-trait",
     "dep:rand",
@@ -62,8 +61,8 @@ server-api = [
     "dep:chrono",
     "dep:rust_decimal",
 ]
-server-api-ring = ["server-api", "ring"]
-server-api-aws-lc-rs = ["server-api", "aws-lc-rs"]
+server-api-ring = ["server-api", "_ring"]
+server-api-aws-lc-rs = ["server-api", "_aws-lc-rs"]
 scram = ["dep:base64", "dep:stringprep", "dep:x509-certificate"]
 _duckdb = []
 _sqlite = []

--- a/src/api/auth/scram.rs
+++ b/src/api/auth/scram.rs
@@ -13,9 +13,9 @@ use tokio::sync::Mutex;
 use x509_certificate::certificate::CapturedX509Certificate;
 use x509_certificate::SignatureAlgorithm;
 
-#[cfg(not(feature = "ring"))]
+#[cfg(feature = "_aws-lc-rs")]
 use aws_lc_rs::{digest, hmac, pbkdf2};
-#[cfg(feature = "ring")]
+#[cfg(feature = "_ring")]
 use ring::{digest, hmac, pbkdf2};
 
 use crate::api::auth::{AuthSource, LoginInfo, Password};


### PR DESCRIPTION
For those who don't want to include tls libraries, we provide a feature configuration `--no-default-features --features server-api` to exclude rustls library family.