### PR TITLE
feat: improve error code and message generation

### DIFF
--- a/src/error.rs
+++ b/src/error.rs
@@ -201,13 +201,13 @@ impl From<PgWireError> for ErrorInfo {
                 ErrorInfo::new("FATAL".to_owned(), "08P01".to_owned(), error.to_string())
             }
             PgWireError::InvalidAuthenticationMessageCode(_) => {
-                ErrorInfo::new("FATAL".to_owned(), "28P01".to_owned(), error.to_string())
+                ErrorInfo::new("FATAL".to_owned(), "08P01".to_owned(), error.to_string())
             }
             PgWireError::IoError(_) => {
                 ErrorInfo::new("FATAL".to_owned(), "58030".to_owned(), error.to_string())
             }
             PgWireError::PortalNotFound(_) => {
-                ErrorInfo::new("ERROR".to_owned(), "42P03".to_owned(), error.to_string())
+                ErrorInfo::new("ERROR".to_owned(), "26000".to_owned(), error.to_string())
             }
             PgWireError::StatementNotFound(_) => {
                 ErrorInfo::new("ERROR".to_owned(), "26000".to_owned(), error.to_string())
@@ -222,7 +222,7 @@ impl From<PgWireError> for ErrorInfo {
                 ErrorInfo::new("ERROR".to_owned(), "22P02".to_owned(), error.to_string())
             }
             PgWireError::InvalidScramMessage(_) => {
-                ErrorInfo::new("FATAL".to_owned(), "28P01".to_owned(), error.to_string())
+                ErrorInfo::new("FATAL".to_owned(), "08P01".to_owned(), error.to_string())
             }
             PgWireError::UnsupportedCertificateSignatureAlgorithm => {
                 ErrorInfo::new("FATAL".to_owned(), "0A000".to_owned(), error.to_string())
@@ -231,7 +231,7 @@ impl From<PgWireError> for ErrorInfo {
                 ErrorInfo::new("FATAL".to_owned(), "28000".to_owned(), error.to_string())
             }
             PgWireError::NotReadyForQuery => {
-                ErrorInfo::new("FATAL".to_owned(), "57014".to_owned(), error.to_string())
+                ErrorInfo::new("FATAL".to_owned(), "08P01".to_owned(), error.to_string())
             }
             #[cfg(feature = "client-api")]
             PgWireError::InvalidConfig(_) => {

--- a/src/error.rs
+++ b/src/error.rs
@@ -164,6 +164,10 @@ impl ErrorInfo {
 
         fields
     }
+
+    pub fn is_fatal(&self) -> bool {
+        self.severity == "FATAL"
+    }
 }
 
 impl From<ErrorInfo> for ErrorResponse {
@@ -175,6 +179,81 @@ impl From<ErrorInfo> for ErrorResponse {
 impl From<ErrorInfo> for NoticeResponse {
     fn from(ei: ErrorInfo) -> NoticeResponse {
         NoticeResponse::new(ei.into_fields())
+    }
+}
+
+impl From<PgWireError> for ErrorInfo {
+    fn from(error: PgWireError) -> Self {
+        match error {
+            PgWireError::InvalidProtocolVersion(_) => {
+                ErrorInfo::new("FATAL".to_owned(), "08P01".to_owned(), error.to_string())
+            }
+            PgWireError::InvalidMessageType(_) => {
+                ErrorInfo::new("FATAL".to_owned(), "08P01".to_owned(), error.to_string())
+            }
+            PgWireError::InvalidTargetType(_) => {
+                ErrorInfo::new("FATAL".to_owned(), "08P01".to_owned(), error.to_string())
+            }
+            PgWireError::InvalidTransactionStatus(_) => {
+                ErrorInfo::new("FATAL".to_owned(), "08P01".to_owned(), error.to_string())
+            }
+            PgWireError::InvalidStartupMessage => {
+                ErrorInfo::new("FATAL".to_owned(), "08P01".to_owned(), error.to_string())
+            }
+            PgWireError::InvalidAuthenticationMessageCode(_) => {
+                ErrorInfo::new("FATAL".to_owned(), "28P01".to_owned(), error.to_string())
+            }
+            PgWireError::IoError(_) => {
+                ErrorInfo::new("FATAL".to_owned(), "58030".to_owned(), error.to_string())
+            }
+            PgWireError::PortalNotFound(_) => {
+                ErrorInfo::new("ERROR".to_owned(), "42P03".to_owned(), error.to_string())
+            }
+            PgWireError::StatementNotFound(_) => {
+                ErrorInfo::new("ERROR".to_owned(), "26000".to_owned(), error.to_string())
+            }
+            PgWireError::ParameterIndexOutOfBound(_) => {
+                ErrorInfo::new("ERROR".to_owned(), "22023".to_owned(), error.to_string())
+            }
+            PgWireError::InvalidRustTypeForParameter(_) => {
+                ErrorInfo::new("ERROR".to_owned(), "22023".to_owned(), error.to_string())
+            }
+            PgWireError::FailedToParseParameter(_) => {
+                ErrorInfo::new("ERROR".to_owned(), "22P02".to_owned(), error.to_string())
+            }
+            PgWireError::InvalidScramMessage(_) => {
+                ErrorInfo::new("FATAL".to_owned(), "28P01".to_owned(), error.to_string())
+            }
+            PgWireError::UnsupportedCertificateSignatureAlgorithm => {
+                ErrorInfo::new("FATAL".to_owned(), "0A000".to_owned(), error.to_string())
+            }
+            PgWireError::UserNameRequired => {
+                ErrorInfo::new("FATAL".to_owned(), "28000".to_owned(), error.to_string())
+            }
+            PgWireError::NotReadyForQuery => {
+                ErrorInfo::new("FATAL".to_owned(), "57014".to_owned(), error.to_string())
+            }
+            #[cfg(feature = "client-api")]
+            PgWireError::InvalidConfig(_) => {
+                ErrorInfo::new("FATAL".to_owned(), "22023".to_owned(), error.to_string())
+            }
+            #[cfg(feature = "client-api")]
+            PgWireError::UnknownConfig(_) => {
+                ErrorInfo::new("FATAL".to_owned(), "22023".to_owned(), error.to_string())
+            }
+            #[cfg(feature = "client-api")]
+            PgWireError::InvalidUtf8ConfigValue(_) => {
+                ErrorInfo::new("FATAL".to_owned(), "22021".to_owned(), error.to_string())
+            }
+            #[cfg(feature = "client-api")]
+            PgWireError::ClientMessageSendError(_) => {
+                ErrorInfo::new("FATAL".to_owned(), "58000".to_owned(), error.to_string())
+            }
+            PgWireError::ApiError(_) => {
+                ErrorInfo::new("FATAL".to_owned(), "XX000".to_owned(), error.to_string())
+            }
+            PgWireError::UserError(info) => *info,
+        }
     }
 }
 


### PR DESCRIPTION
Fixes #238 

This patch changes how errors are processed for server. We will generate `ErrorInfo` for each variant of `PgWireError`, specify the error severity and code. For fatal errors, we will disconnect the client.