### PR TITLE
feat: add API access to client certificates

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -52,8 +52,8 @@ percent-encoding = { version = "2.0", optional = true }
 
 [features]
 default = ["server-api-aws-lc-rs"]
-_ring = ["dep:ring", "tokio-rustls/ring"]
-_aws-lc-rs = ["dep:aws-lc-rs", "tokio-rustls/aws-lc-rs"]
+_ring = ["dep:ring", "tokio-rustls/ring", "dep:rustls-pki-types"]
+_aws-lc-rs = ["dep:aws-lc-rs", "tokio-rustls/aws-lc-rs", "dep:rustls-pki-types"]
 server-api = [
     "dep:tokio",
     "dep:tokio-util",

--- a/src/api/mod.rs
+++ b/src/api/mod.rs
@@ -5,6 +5,7 @@ use std::net::SocketAddr;
 use std::sync::Arc;
 
 pub use postgres_types::Type;
+#[cfg(any(feature = "_ring", feature = "_aws-lc-rs"))]
 use rustls_pki_types::CertificateDer;
 
 use crate::error::PgWireError;

--- a/src/api/mod.rs
+++ b/src/api/mod.rs
@@ -5,6 +5,7 @@ use std::net::SocketAddr;
 use std::sync::Arc;
 
 pub use postgres_types::Type;
+use rustls_pki_types::CertificateDer;
 
 use crate::error::PgWireError;
 use crate::messages::response::TransactionStatus;
@@ -51,6 +52,9 @@ pub trait ClientInfo {
     fn metadata(&self) -> &HashMap<String, String>;
 
     fn metadata_mut(&mut self) -> &mut HashMap<String, String>;
+
+    #[cfg(any(feature = "_ring", feature = "_aws-lc-rs"))]
+    fn client_certificates<'a>(&self) -> Option<&[CertificateDer<'a>]>;
 }
 
 /// Client Portal Store
@@ -105,6 +109,11 @@ impl<S> ClientInfo for DefaultClient<S> {
 
     fn set_transaction_status(&mut self, new_status: TransactionStatus) {
         self.transaction_status = new_status
+    }
+
+    #[cfg(any(feature = "_ring", feature = "_aws-lc-rs"))]
+    fn client_certificates<'a>(&self) -> Option<&[CertificateDer<'a>]> {
+        None
     }
 }
 

--- a/src/tokio/server.rs
+++ b/src/tokio/server.rs
@@ -1,8 +1,11 @@
+use std::any::Any;
 use std::io;
 use std::sync::Arc;
 
 use bytes::Buf;
 use futures::{SinkExt, StreamExt};
+#[cfg(any(feature = "_ring", feature = "_aws-lc-rs"))]
+use rustls_pki_types::CertificateDer;
 use tokio::io::{AsyncRead, AsyncWrite};
 use tokio::net::TcpStream;
 #[cfg(any(feature = "_ring", feature = "_aws-lc-rs"))]
@@ -77,7 +80,7 @@ impl<S> Encoder<PgWireBackendMessage> for PgWireMessageServerCodec<S> {
     }
 }
 
-impl<T, S> ClientInfo for Framed<T, PgWireMessageServerCodec<S>> {
+impl<T: 'static, S> ClientInfo for Framed<T, PgWireMessageServerCodec<S>> {
     fn socket_addr(&self) -> std::net::SocketAddr {
         self.codec().client_info.socket_addr
     }
@@ -111,6 +114,17 @@ impl<T, S> ClientInfo for Framed<T, PgWireMessageServerCodec<S>> {
             .client_info
             .set_transaction_status(new_status);
     }
+
+    #[cfg(any(feature = "_ring", feature = "_aws-lc-rs"))]
+    fn client_certificates<'a>(&self) -> Option<&[CertificateDer<'a>]> {
+        if !self.is_secure() {
+            None
+        } else {
+            let socket = <dyn Any>::downcast_ref::<TlsStream<TcpStream>>(self.get_ref()).unwrap();
+            let (_, tls_session) = socket.get_ref();
+            tls_session.peer_certificates()
+        }
+    }
 }
 
 impl<T, S> ClientPortalStore for Framed<T, PgWireMessageServerCodec<S>> {
@@ -130,7 +144,7 @@ async fn process_message<S, A, Q, EQ, C>(
     copy_handler: Arc<C>,
 ) -> PgWireResult<()>
 where
-    S: AsyncRead + AsyncWrite + Unpin + Send + Sync,
+    S: AsyncRead + AsyncWrite + Unpin + Send + Sync + 'static,
     A: StartupHandler,
     Q: SimpleQueryHandler,
     EQ: ExtendedQueryHandler,
@@ -239,7 +253,7 @@ async fn process_error<S, ST>(
     wait_for_sync: bool,
 ) -> Result<(), io::Error>
 where
-    S: AsyncRead + AsyncWrite + Unpin + Send + Sync,
+    S: AsyncRead + AsyncWrite + Unpin + Send + Sync + 'static,
 {
     let error_info: ErrorInfo = error.into();
     let is_fatal = error_info.is_fatal();
@@ -315,7 +329,7 @@ async fn do_process_socket<S, A, Q, EQ, C, E>(
     error_handler: Arc<E>,
 ) -> Result<(), io::Error>
 where
-    S: AsyncRead + AsyncWrite + Unpin + Send + Sync,
+    S: AsyncRead + AsyncWrite + Unpin + Send + Sync + 'static,
     A: StartupHandler,
     Q: SimpleQueryHandler,
     EQ: ExtendedQueryHandler,

--- a/src/tokio/server.rs
+++ b/src/tokio/server.rs
@@ -1,4 +1,3 @@
-use std::any::Any;
 use std::io;
 use std::sync::Arc;
 
@@ -120,7 +119,8 @@ impl<T: 'static, S> ClientInfo for Framed<T, PgWireMessageServerCodec<S>> {
         if !self.is_secure() {
             None
         } else {
-            let socket = <dyn Any>::downcast_ref::<TlsStream<TcpStream>>(self.get_ref()).unwrap();
+            let socket =
+                <dyn std::any::Any>::downcast_ref::<TlsStream<TcpStream>>(self.get_ref()).unwrap();
             let (_, tls_session) = socket.get_ref();
             tls_session.peer_certificates()
         }


### PR DESCRIPTION
This patch adds `ClientInfo` API access to the client certificate. This allows user to do mTLS in their `StartupHandler` implementation.