### PR TITLE
fix: correct lifetime for do query

### DIFF
--- a/examples/bench.rs
+++ b/examples/bench.rs
@@ -24,7 +24,7 @@ impl SimpleQueryHandler for DummyProcessor {
     async fn do_query<'a, C>(
         &self,
         _client: &mut C,
-        _query: &'a str,
+        _query: &str,
     ) -> PgWireResult<Vec<Response<'a>>>
     where
         C: ClientInfo + Unpin + Send + Sync,

--- a/examples/copy.rs
+++ b/examples/copy.rs
@@ -23,11 +23,7 @@ impl NoopStartupHandler for DummyProcessor {}
 
 #[async_trait]
 impl SimpleQueryHandler for DummyProcessor {
-    async fn do_query<'a, C>(
-        &self,
-        client: &mut C,
-        query: &'a str,
-    ) -> PgWireResult<Vec<Response<'a>>>
+    async fn do_query<'a, C>(&self, client: &mut C, query: &str) -> PgWireResult<Vec<Response<'a>>>
     where
         C: ClientInfo + Sink<PgWireBackendMessage> + Unpin + Send + Sync,
         C::Error: Debug,

--- a/examples/duckdb.rs
+++ b/examples/duckdb.rs
@@ -45,11 +45,7 @@ impl AuthSource for DummyAuthSource {
 
 #[async_trait]
 impl SimpleQueryHandler for DuckDBBackend {
-    async fn do_query<'a, C>(
-        &self,
-        _client: &mut C,
-        query: &'a str,
-    ) -> PgWireResult<Vec<Response<'a>>>
+    async fn do_query<'a, C>(&self, _client: &mut C, query: &str) -> PgWireResult<Vec<Response<'a>>>
     where
         C: ClientInfo + Unpin + Send + Sync,
     {

--- a/examples/duckdb.rs
+++ b/examples/duckdb.rs
@@ -243,7 +243,7 @@ impl ExtendedQueryHandler for DuckDBBackend {
     async fn do_query<'a, C>(
         &self,
         _client: &mut C,
-        portal: &'a Portal<Self::Statement>,
+        portal: &Portal<Self::Statement>,
         _max_rows: usize,
     ) -> PgWireResult<Response<'a>>
     where

--- a/examples/gluesql.rs
+++ b/examples/gluesql.rs
@@ -21,11 +21,7 @@ impl NoopStartupHandler for GluesqlProcessor {}
 
 #[async_trait]
 impl SimpleQueryHandler for GluesqlProcessor {
-    async fn do_query<'a, C>(
-        &self,
-        _client: &mut C,
-        query: &'a str,
-    ) -> PgWireResult<Vec<Response<'a>>>
+    async fn do_query<'a, C>(&self, _client: &mut C, query: &str) -> PgWireResult<Vec<Response<'a>>>
     where
         C: ClientInfo + Unpin + Send + Sync,
     {

--- a/examples/scram.rs
+++ b/examples/scram.rs
@@ -27,7 +27,7 @@ impl SimpleQueryHandler for DummyProcessor {
     async fn do_query<'a, C>(
         &self,
         _client: &mut C,
-        _query: &'a str,
+        _query: &str,
     ) -> PgWireResult<Vec<Response<'a>>>
     where
         C: ClientInfo + Unpin + Send + Sync,

--- a/examples/secure_server.rs
+++ b/examples/secure_server.rs
@@ -24,11 +24,7 @@ impl NoopStartupHandler for DummyProcessor {}
 
 #[async_trait]
 impl SimpleQueryHandler for DummyProcessor {
-    async fn do_query<'a, C>(
-        &self,
-        _client: &mut C,
-        query: &'a str,
-    ) -> PgWireResult<Vec<Response<'a>>>
+    async fn do_query<'a, C>(&self, _client: &mut C, query: &str) -> PgWireResult<Vec<Response<'a>>>
     where
         C: ClientInfo + Unpin + Send + Sync,
     {

--- a/examples/server.rs
+++ b/examples/server.rs
@@ -41,11 +41,7 @@ impl NoopStartupHandler for DummyProcessor {
 
 #[async_trait]
 impl SimpleQueryHandler for DummyProcessor {
-    async fn do_query<'a, C>(
-        &self,
-        client: &mut C,
-        query: &'a str,
-    ) -> PgWireResult<Vec<Response<'a>>>
+    async fn do_query<'a, C>(&self, client: &mut C, query: &str) -> PgWireResult<Vec<Response<'a>>>
     where
         C: ClientInfo + Sink<PgWireBackendMessage> + Unpin + Send + Sync,
         C::Error: Debug,

--- a/examples/sqlite.rs
+++ b/examples/sqlite.rs
@@ -47,11 +47,7 @@ impl AuthSource for DummyAuthSource {
 
 #[async_trait]
 impl SimpleQueryHandler for SqliteBackend {
-    async fn do_query<'a, C>(
-        &self,
-        _client: &mut C,
-        query: &'a str,
-    ) -> PgWireResult<Vec<Response<'a>>>
+    async fn do_query<'a, C>(&self, _client: &mut C, query: &str) -> PgWireResult<Vec<Response<'a>>>
     where
         C: ClientInfo + Unpin + Send + Sync,
     {

--- a/examples/sqlite.rs
+++ b/examples/sqlite.rs
@@ -201,7 +201,7 @@ impl ExtendedQueryHandler for SqliteBackend {
     async fn do_query<'a, C>(
         &self,
         _client: &mut C,
-        portal: &'a Portal<Self::Statement>,
+        portal: &Portal<Self::Statement>,
         _max_rows: usize,
     ) -> PgWireResult<Response<'a>>
     where

--- a/examples/transaction.rs
+++ b/examples/transaction.rs
@@ -47,11 +47,7 @@ impl NoopStartupHandler for DummyProcessor {
 
 #[async_trait]
 impl SimpleQueryHandler for DummyProcessor {
-    async fn do_query<'a, C>(
-        &self,
-        _client: &mut C,
-        query: &'a str,
-    ) -> PgWireResult<Vec<Response<'a>>>
+    async fn do_query<'a, C>(&self, _client: &mut C, query: &str) -> PgWireResult<Vec<Response<'a>>>
     where
         C: ClientInfo + Sink<PgWireBackendMessage> + Unpin + Send + Sync,
         C::Error: Debug,

--- a/src/api/query.rs
+++ b/src/api/query.rs
@@ -121,11 +121,7 @@ pub trait SimpleQueryHandler: Send + Sync {
     }
 
     /// Provide your query implementation using the incoming query string.
-    async fn do_query<'a, 'b: 'a, C>(
-        &'b self,
-        client: &mut C,
-        query: &'a str,
-    ) -> PgWireResult<Vec<Response<'a>>>
+    async fn do_query<'a, C>(&self, client: &mut C, query: &str) -> PgWireResult<Vec<Response<'a>>>
     where
         C: ClientInfo + ClientPortalStore + Sink<PgWireBackendMessage> + Unpin + Send + Sync,
         C::Error: Debug,
@@ -388,10 +384,10 @@ pub trait ExtendedQueryHandler: Send + Sync {
     /// - `client`: Information of the client sending the query
     /// - `portal`: Statement and parameters for the query
     /// - `max_rows`: Max requested rows of the query
-    async fn do_query<'a, 'b: 'a, C>(
-        &'b self,
+    async fn do_query<'a, C>(
+        &self,
         client: &mut C,
-        portal: &'a Portal<Self::Statement>,
+        portal: &Portal<Self::Statement>,
         max_rows: usize,
     ) -> PgWireResult<Response<'a>>
     where
@@ -522,10 +518,10 @@ impl ExtendedQueryHandler for PlaceholderExtendedQueryHandler {
         unimplemented!("Extended Query is not implemented on this server.")
     }
 
-    async fn do_query<'a, 'b: 'a, C>(
-        &'b self,
+    async fn do_query<'a, C>(
+        &self,
         _client: &mut C,
-        _portal: &'a Portal<Self::Statement>,
+        _portal: &Portal<Self::Statement>,
         _max_rows: usize,
     ) -> PgWireResult<Response<'a>>
     where

--- a/tests-integration/test-server/src/main.rs
+++ b/tests-integration/test-server/src/main.rs
@@ -78,11 +78,7 @@ impl DummyDatabase {
 
 #[async_trait]
 impl SimpleQueryHandler for DummyDatabase {
-    async fn do_query<'a, C>(
-        &self,
-        _client: &mut C,
-        query: &'a str,
-    ) -> PgWireResult<Vec<Response<'a>>>
+    async fn do_query<'a, C>(&self, _client: &mut C, query: &str) -> PgWireResult<Vec<Response<'a>>>
     where
         C: ClientInfo + Unpin + Send + Sync,
     {
@@ -141,7 +137,7 @@ impl ExtendedQueryHandler for DummyDatabase {
     async fn do_query<'a, C>(
         &self,
         _client: &mut C,
-        portal: &'a Portal<Self::Statement>,
+        portal: &Portal<Self::Statement>,
         _max_rows: usize,
     ) -> PgWireResult<Response<'a>>
     where


### PR DESCRIPTION
Simplify and correct lifetime for do_query methods in query handlers. The Response lifetime doesn't have to be same with the query string.