### PR TITLE
Clientinfo parse_sql

### DIFF
--- a/src/api/query.rs
+++ b/src/api/query.rs
@@ -148,7 +148,7 @@ pub trait ExtendedQueryHandler: Send + Sync {
         PgWireError: From<<C as Sink<PgWireBackendMessage>>::Error>,
     {
         let parser = self.query_parser();
-        let stmt = StoredStatement::parse(&message, parser).await?;
+        let stmt = StoredStatement::parse(client, &message, parser).await?;
         client.portal_store().put_statement(Arc::new(stmt));
         client
             .send(PgWireBackendMessage::ParseComplete(ParseComplete::new()))

--- a/src/api/stmt.rs
+++ b/src/api/stmt.rs
@@ -56,7 +56,7 @@ pub trait QueryParser {
 
     async fn parse_sql<C>(
         &self,
-        client: &mut C,
+        client: &C,
         sql: &str,
         types: &[Type],
     ) -> PgWireResult<Self::Statement>
@@ -73,7 +73,7 @@ where
 
     async fn parse_sql<C>(
         &self,
-        client: &mut C,
+        client: &C,
         sql: &str,
         types: &[Type],
     ) -> PgWireResult<Self::Statement>
@@ -94,7 +94,7 @@ impl QueryParser for NoopQueryParser {
 
     async fn parse_sql<C>(
         &self,
-        _client: &mut C,
+        _client: &C,
         sql: &str,
         _types: &[Type],
     ) -> PgWireResult<Self::Statement>

--- a/src/api/stmt.rs
+++ b/src/api/stmt.rs
@@ -4,8 +4,8 @@ use async_trait::async_trait;
 use futures::Sink;
 use postgres_types::Type;
 
-use crate::{error::PgWireResult, messages::PgWireBackendMessage};
 use crate::messages::extendedquery::Parse;
+use crate::{error::PgWireResult, messages::PgWireBackendMessage};
 
 use super::{ClientInfo, DEFAULT_NAME};
 
@@ -22,9 +22,13 @@ pub struct StoredStatement<S> {
 }
 
 impl<S> StoredStatement<S> {
-    pub(crate) async fn parse<C, Q>(client: &mut C, parse: &Parse, parser: Q) -> PgWireResult<StoredStatement<S>>
+    pub(crate) async fn parse<C, Q>(
+        client: &mut C,
+        parse: &Parse,
+        parser: Q,
+    ) -> PgWireResult<StoredStatement<S>>
     where
-        C: ClientInfo + Sink<PgWireBackendMessage> + Unpin + Send + Sync, 
+        C: ClientInfo + Sink<PgWireBackendMessage> + Unpin + Send + Sync,
         Q: QueryParser<Statement = S>,
     {
         let types = parse
@@ -50,8 +54,13 @@ impl<S> StoredStatement<S> {
 pub trait QueryParser {
     type Statement;
 
-    async fn parse_sql<C>(&self, client: &mut C, sql: &str, types: &[Type]) -> PgWireResult<Self::Statement>
-    where 
+    async fn parse_sql<C>(
+        &self,
+        client: &mut C,
+        sql: &str,
+        types: &[Type],
+    ) -> PgWireResult<Self::Statement>
+    where
         C: ClientInfo + Unpin + Send + Sync;
 }
 
@@ -62,9 +71,14 @@ where
 {
     type Statement = QP::Statement;
 
-    async fn parse_sql<C>(&self, client: &mut C, sql: &str, types: &[Type]) -> PgWireResult<Self::Statement>
-    where 
-        C: ClientInfo + Unpin + Send + Sync, 
+    async fn parse_sql<C>(
+        &self,
+        client: &mut C,
+        sql: &str,
+        types: &[Type],
+    ) -> PgWireResult<Self::Statement>
+    where
+        C: ClientInfo + Unpin + Send + Sync,
     {
         (**self).parse_sql(client, sql, types).await
     }
@@ -78,9 +92,14 @@ pub struct NoopQueryParser;
 impl QueryParser for NoopQueryParser {
     type Statement = String;
 
-    async fn parse_sql<C>(&self, _client: &mut C, sql: &str, _types: &[Type]) -> PgWireResult<Self::Statement> 
-    where 
-        C: ClientInfo + Unpin + Send + Sync, 
+    async fn parse_sql<C>(
+        &self,
+        _client: &mut C,
+        sql: &str,
+        _types: &[Type],
+    ) -> PgWireResult<Self::Statement>
+    where
+        C: ClientInfo + Unpin + Send + Sync,
     {
         Ok(sql.to_owned())
     }

--- a/src/api/stmt.rs
+++ b/src/api/stmt.rs
@@ -23,7 +23,7 @@ pub struct StoredStatement<S> {
 
 impl<S> StoredStatement<S> {
     pub(crate) async fn parse<C, Q>(
-        client: &mut C,
+        client: &C,
         parse: &Parse,
         parser: Q,
     ) -> PgWireResult<StoredStatement<S>>

--- a/src/api/stmt.rs
+++ b/src/api/stmt.rs
@@ -1,12 +1,13 @@
 use std::sync::Arc;
 
 use async_trait::async_trait;
+use futures::Sink;
 use postgres_types::Type;
 
-use crate::error::PgWireResult;
+use crate::{error::PgWireResult, messages::PgWireBackendMessage};
 use crate::messages::extendedquery::Parse;
 
-use super::DEFAULT_NAME;
+use super::{ClientInfo, DEFAULT_NAME};
 
 #[non_exhaustive]
 #[derive(Debug, Default, new)]
@@ -21,8 +22,9 @@ pub struct StoredStatement<S> {
 }
 
 impl<S> StoredStatement<S> {
-    pub(crate) async fn parse<Q>(parse: &Parse, parser: Q) -> PgWireResult<StoredStatement<S>>
+    pub(crate) async fn parse<C, Q>(client: &mut C, parse: &Parse, parser: Q) -> PgWireResult<StoredStatement<S>>
     where
+        C: ClientInfo + Sink<PgWireBackendMessage> + Unpin + Send + Sync, 
         Q: QueryParser<Statement = S>,
     {
         let types = parse
@@ -30,7 +32,7 @@ impl<S> StoredStatement<S> {
             .iter()
             .map(|oid| Type::from_oid(*oid).unwrap_or(Type::UNKNOWN))
             .collect::<Vec<Type>>();
-        let statement = parser.parse_sql(&parse.query, &types).await?;
+        let statement = parser.parse_sql(client, &parse.query, &types).await?;
         Ok(StoredStatement {
             id: parse
                 .name
@@ -48,7 +50,9 @@ impl<S> StoredStatement<S> {
 pub trait QueryParser {
     type Statement;
 
-    async fn parse_sql(&self, sql: &str, types: &[Type]) -> PgWireResult<Self::Statement>;
+    async fn parse_sql<C>(&self, client: &mut C, sql: &str, types: &[Type]) -> PgWireResult<Self::Statement>
+    where 
+        C: ClientInfo + Unpin + Send + Sync;
 }
 
 #[async_trait]
@@ -58,8 +62,11 @@ where
 {
     type Statement = QP::Statement;
 
-    async fn parse_sql(&self, sql: &str, types: &[Type]) -> PgWireResult<Self::Statement> {
-        (**self).parse_sql(sql, types).await
+    async fn parse_sql<C>(&self, client: &mut C, sql: &str, types: &[Type]) -> PgWireResult<Self::Statement>
+    where 
+        C: ClientInfo + Unpin + Send + Sync, 
+    {
+        (**self).parse_sql(client, sql, types).await
     }
 }
 
@@ -71,7 +78,10 @@ pub struct NoopQueryParser;
 impl QueryParser for NoopQueryParser {
     type Statement = String;
 
-    async fn parse_sql(&self, sql: &str, _types: &[Type]) -> PgWireResult<Self::Statement> {
+    async fn parse_sql<C>(&self, _client: &mut C, sql: &str, _types: &[Type]) -> PgWireResult<Self::Statement> 
+    where 
+        C: ClientInfo + Unpin + Send + Sync, 
+    {
         Ok(sql.to_owned())
     }
 }


### PR DESCRIPTION
Adds ClientInfo to the parse_sql so that database, user name, etc is accessible.