### PR TITLE
Add done_query methods to query traits

### DIFF
--- a/src/api/query.rs
+++ b/src/api/query.rs
@@ -268,6 +268,8 @@ pub trait ExtendedQueryHandler: Send + Sync {
                 client.set_transaction_status(transaction_status);
             };
 
+            self.done_query(client).await?;
+
             Ok(())
         } else {
             Err(PgWireError::PortalNotFound(portal_name.to_owned()))

--- a/src/api/query.rs
+++ b/src/api/query.rs
@@ -117,6 +117,8 @@ pub trait SimpleQueryHandler: Send + Sync {
             send_ready_for_query(client, transaction_status).await?;
         };
 
+        self.done_query(client).await?;
+
         Ok(())
     }
 
@@ -126,6 +128,16 @@ pub trait SimpleQueryHandler: Send + Sync {
         C: ClientInfo + ClientPortalStore + Sink<PgWireBackendMessage> + Unpin + Send + Sync,
         C::Error: Debug,
         PgWireError: From<<C as Sink<PgWireBackendMessage>>::Error>;
+
+    /// Called after the query has been completed
+    async fn done_query<C>(&self, _client: &mut C) -> PgWireResult<()>
+    where
+        C: ClientInfo + ClientPortalStore + Sink<PgWireBackendMessage> + Unpin + Send + Sync,
+        C::Error: Debug,
+        PgWireError: From<<C as Sink<PgWireBackendMessage>>::Error>,
+    {
+        Ok(())
+    }
 }
 
 #[async_trait]
@@ -395,6 +407,17 @@ pub trait ExtendedQueryHandler: Send + Sync {
         C::PortalStore: PortalStore<Statement = Self::Statement>,
         C::Error: Debug,
         PgWireError: From<<C as Sink<PgWireBackendMessage>>::Error>;
+
+    /// Called after the query has been completed
+    async fn done_query<C>(&self, _client: &mut C) -> PgWireResult<()>
+    where
+        C: ClientInfo + ClientPortalStore + Sink<PgWireBackendMessage> + Unpin + Send + Sync,
+        C::PortalStore: PortalStore<Statement = Self::Statement>,
+        C::Error: Debug,
+        PgWireError: From<<C as Sink<PgWireBackendMessage>>::Error>,
+    {
+        Ok(())
+    }
 }
 
 /// Helper function to send `QueryResponse` and optional `RowDescription` to client


### PR DESCRIPTION
Hi @sunng87,

Another PR, this one adds done_query to the simple and extended handlers. The purpose is to allow clean up code to run after the query is successfully executed. I added default implementations so it doesn't break existing logic. Let me know if there is a better way to achieve this.