### PR TITLE
feat: user visible backend keys

### DIFF
--- a/src/api/auth/mod.rs
+++ b/src/api/auth/mod.rs
@@ -183,11 +183,10 @@ where
         }
     }
 
-    // TODO: store this backend key
+    let (pid, secret_key) = client.pid_and_secret_key();
     client
         .feed(PgWireBackendMessage::BackendKeyData(BackendKeyData::new(
-            std::process::id() as i32,
-            rand::random::<i32>(),
+            pid, secret_key,
         )))
         .await?;
 

--- a/src/api/mod.rs
+++ b/src/api/mod.rs
@@ -42,6 +42,10 @@ pub trait ClientInfo {
 
     fn is_secure(&self) -> bool;
 
+    fn pid_and_secret_key(&self) -> (i32, i32);
+
+    fn set_pid_and_secret_key(&mut self, pid: i32, secret_key: i32);
+
     fn state(&self) -> PgWireConnectionState;
 
     fn set_state(&mut self, new_state: PgWireConnectionState);
@@ -73,6 +77,7 @@ pub const METADATA_DATABASE: &str = "database";
 pub struct DefaultClient<S> {
     pub socket_addr: SocketAddr,
     pub is_secure: bool,
+    pub pid_secret_key: (i32, i32),
     pub state: PgWireConnectionState,
     pub transaction_status: TransactionStatus,
     pub metadata: HashMap<String, String>,
@@ -86,6 +91,14 @@ impl<S> ClientInfo for DefaultClient<S> {
 
     fn is_secure(&self) -> bool {
         self.is_secure
+    }
+
+    fn pid_and_secret_key(&self) -> (i32, i32) {
+        self.pid_secret_key
+    }
+
+    fn set_pid_and_secret_key(&mut self, pid: i32, secret_key: i32) {
+        self.pid_secret_key = (pid, secret_key);
     }
 
     fn state(&self) -> PgWireConnectionState {
@@ -123,6 +136,7 @@ impl<S> DefaultClient<S> {
         DefaultClient {
             socket_addr,
             is_secure,
+            pid_secret_key: (0, 0),
             state: PgWireConnectionState::default(),
             transaction_status: TransactionStatus::Idle,
             metadata: HashMap::new(),

--- a/src/tokio/server.rs
+++ b/src/tokio/server.rs
@@ -88,6 +88,16 @@ impl<T: 'static, S> ClientInfo for Framed<T, PgWireMessageServerCodec<S>> {
         self.codec().client_info.is_secure
     }
 
+    fn pid_and_secret_key(&self) -> (i32, i32) {
+        self.codec().client_info.pid_and_secret_key()
+    }
+
+    fn set_pid_and_secret_key(&mut self, pid: i32, secret_key: i32) {
+        self.codec_mut()
+            .client_info
+            .set_pid_and_secret_key(pid, secret_key);
+    }
+
     fn state(&self) -> PgWireConnectionState {
         self.codec().client_info.state
     }


### PR DESCRIPTION
this is the part one of query termination support. 

Previously the backend key part of this library is unusable. This patch allows user to generate and set unique pid and secret key for query termination. 