### PR TITLE
refactor!: change PgWireServerHandlers to use impl trait return value

### DIFF
--- a/examples/bench.rs
+++ b/examples/bench.rs
@@ -3,22 +3,15 @@ use std::sync::Arc;
 use async_trait::async_trait;
 use futures::stream;
 use futures::StreamExt;
-use pgwire::api::cancel::NoopCancelHandler;
-use pgwire::api::NoopErrorHandler;
-use pgwire::api::PgWireServerHandlers;
 use tokio::net::TcpListener;
 
-use pgwire::api::auth::noop::NoopStartupHandler;
-use pgwire::api::copy::NoopCopyHandler;
-use pgwire::api::query::{PlaceholderExtendedQueryHandler, SimpleQueryHandler};
+use pgwire::api::query::SimpleQueryHandler;
 use pgwire::api::results::{DataRowEncoder, FieldFormat, FieldInfo, QueryResponse, Response};
-use pgwire::api::{ClientInfo, Type};
+use pgwire::api::{ClientInfo, PgWireServerHandlers, Type};
 use pgwire::error::PgWireResult;
 use pgwire::tokio::process_socket;
 
 pub struct DummyProcessor;
-
-impl NoopStartupHandler for DummyProcessor {}
 
 #[async_trait]
 impl SimpleQueryHandler for DummyProcessor {
@@ -76,35 +69,8 @@ struct DummyProcessorFactory {
 }
 
 impl PgWireServerHandlers for DummyProcessorFactory {
-    type StartupHandler = DummyProcessor;
-    type SimpleQueryHandler = DummyProcessor;
-    type ExtendedQueryHandler = PlaceholderExtendedQueryHandler;
-    type CopyHandler = NoopCopyHandler;
-    type CancelHandler = NoopCancelHandler;
-    type ErrorHandler = NoopErrorHandler;
-
-    fn simple_query_handler(&self) -> Arc<Self::SimpleQueryHandler> {
+    fn simple_query_handler(&self) -> Arc<impl SimpleQueryHandler> {
         self.handler.clone()
-    }
-
-    fn extended_query_handler(&self) -> Arc<Self::ExtendedQueryHandler> {
-        Arc::new(PlaceholderExtendedQueryHandler)
-    }
-
-    fn startup_handler(&self) -> Arc<Self::StartupHandler> {
-        self.handler.clone()
-    }
-
-    fn copy_handler(&self) -> Arc<Self::CopyHandler> {
-        Arc::new(NoopCopyHandler)
-    }
-
-    fn cancel_handler(&self) -> Arc<Self::CancelHandler> {
-        Arc::new(NoopCancelHandler)
-    }
-
-    fn error_handler(&self) -> Arc<Self::ErrorHandler> {
-        Arc::new(NoopErrorHandler)
     }
 }
 

--- a/examples/common/mod.rs
+++ b/examples/common/mod.rs
@@ -1,0 +1,62 @@
+use std::sync::Arc;
+
+use async_trait::async_trait;
+use futures::{stream, StreamExt};
+
+use pgwire::api::auth::noop::NoopStartupHandler;
+use pgwire::api::query::SimpleQueryHandler;
+use pgwire::api::results::{DataRowEncoder, FieldFormat, FieldInfo, QueryResponse, Response, Tag};
+use pgwire::api::{ClientInfo, Type};
+use pgwire::error::PgWireResult;
+
+pub struct DummyProcessor;
+
+impl NoopStartupHandler for DummyProcessor {}
+
+#[async_trait]
+impl SimpleQueryHandler for DummyProcessor {
+    async fn do_query<'a, C>(&self, _client: &mut C, query: &str) -> PgWireResult<Vec<Response<'a>>>
+    where
+        C: ClientInfo + Unpin + Send + Sync,
+    {
+        println!("{:?}", query);
+        if query.starts_with("SELECT") {
+            let f1 = FieldInfo::new("id".into(), None, None, Type::INT4, FieldFormat::Text);
+            let f2 = FieldInfo::new("name".into(), None, None, Type::VARCHAR, FieldFormat::Text);
+            let schema = Arc::new(vec![f1, f2]);
+
+            let data = vec![
+                (Some(0), Some("Tom")),
+                (Some(1), Some("Jerry")),
+                (Some(2), None),
+            ];
+            let schema_ref = schema.clone();
+            let data_row_stream = stream::iter(data.into_iter()).map(move |r| {
+                let mut encoder = DataRowEncoder::new(schema_ref.clone());
+                encoder.encode_field(&r.0)?;
+                encoder.encode_field(&r.1)?;
+
+                encoder.finish()
+            });
+
+            Ok(vec![Response::Query(QueryResponse::new(
+                schema,
+                data_row_stream,
+            ))])
+        } else {
+            Ok(vec![Response::Execution(Tag::new("OK").with_rows(1))])
+        }
+    }
+}
+
+pub struct DummyProcessorFactory {
+    pub handler: Arc<DummyProcessor>,
+}
+
+impl DummyProcessorFactory {
+    pub fn new() -> DummyProcessorFactory {
+        Self {
+            handler: Arc::new(DummyProcessor),
+        }
+    }
+}

--- a/examples/duckdb.rs
+++ b/examples/duckdb.rs
@@ -7,16 +7,16 @@ use async_trait::async_trait;
 use duckdb::{params, Connection, Statement, ToSql};
 use futures::stream;
 use pgwire::api::auth::md5pass::{hash_md5_password, Md5PasswordAuthStartupHandler};
-use pgwire::api::auth::{AuthSource, DefaultServerParameterProvider, LoginInfo, Password};
-use pgwire::api::cancel::NoopCancelHandler;
-use pgwire::api::copy::NoopCopyHandler;
+use pgwire::api::auth::{
+    AuthSource, DefaultServerParameterProvider, LoginInfo, Password, StartupHandler,
+};
 use pgwire::api::portal::{Format, Portal};
 use pgwire::api::query::{ExtendedQueryHandler, SimpleQueryHandler};
 use pgwire::api::results::{
     DescribePortalResponse, DescribeStatementResponse, FieldInfo, QueryResponse, Response, Tag,
 };
 use pgwire::api::stmt::{NoopQueryParser, StoredStatement};
-use pgwire::api::{ClientInfo, NoopErrorHandler, PgWireServerHandlers, Type};
+use pgwire::api::{ClientInfo, PgWireServerHandlers, Type};
 use pgwire::error::{PgWireError, PgWireResult};
 use pgwire::tokio::process_socket;
 use tokio::net::TcpListener;

--- a/examples/duckdb.rs
+++ b/examples/duckdb.rs
@@ -245,39 +245,19 @@ struct DuckDBBackendFactory {
 }
 
 impl PgWireServerHandlers for DuckDBBackendFactory {
-    type StartupHandler =
-        Md5PasswordAuthStartupHandler<DummyAuthSource, DefaultServerParameterProvider>;
-    type SimpleQueryHandler = DuckDBBackend;
-    type ExtendedQueryHandler = DuckDBBackend;
-    type CopyHandler = NoopCopyHandler;
-    type CancelHandler = NoopCancelHandler;
-    type ErrorHandler = NoopErrorHandler;
-
-    fn simple_query_handler(&self) -> Arc<Self::SimpleQueryHandler> {
+    fn simple_query_handler(&self) -> Arc<impl SimpleQueryHandler> {
         self.handler.clone()
     }
 
-    fn extended_query_handler(&self) -> Arc<Self::ExtendedQueryHandler> {
+    fn extended_query_handler(&self) -> Arc<impl ExtendedQueryHandler> {
         self.handler.clone()
     }
 
-    fn startup_handler(&self) -> Arc<Self::StartupHandler> {
+    fn startup_handler(&self) -> Arc<impl StartupHandler> {
         Arc::new(Md5PasswordAuthStartupHandler::new(
             Arc::new(DummyAuthSource),
             Arc::new(DefaultServerParameterProvider::default()),
         ))
-    }
-
-    fn cancel_handler(&self) -> Arc<Self::CancelHandler> {
-        Arc::new(NoopCancelHandler)
-    }
-
-    fn copy_handler(&self) -> Arc<Self::CopyHandler> {
-        Arc::new(NoopCopyHandler)
-    }
-
-    fn error_handler(&self) -> Arc<Self::ErrorHandler> {
-        Arc::new(NoopErrorHandler)
     }
 }
 

--- a/examples/scram.rs
+++ b/examples/scram.rs
@@ -4,7 +4,6 @@ use std::sync::Arc;
 
 use async_trait::async_trait;
 
-use pgwire::api::cancel::NoopCancelHandler;
 use rustls_pemfile::{certs, pkcs8_private_keys};
 use rustls_pki_types::{CertificateDer, PrivateKeyDer};
 use tokio::net::TcpListener;
@@ -12,30 +11,12 @@ use tokio_rustls::rustls::ServerConfig;
 use tokio_rustls::TlsAcceptor;
 
 use pgwire::api::auth::scram::{gen_salted_password, SASLScramAuthStartupHandler};
-use pgwire::api::auth::{AuthSource, DefaultServerParameterProvider, LoginInfo, Password};
-use pgwire::api::copy::NoopCopyHandler;
-use pgwire::api::query::{PlaceholderExtendedQueryHandler, SimpleQueryHandler};
-use pgwire::api::results::{Response, Tag};
-
-use pgwire::api::{ClientInfo, NoopErrorHandler, PgWireServerHandlers};
+use pgwire::api::auth::{
+    AuthSource, DefaultServerParameterProvider, LoginInfo, Password, StartupHandler,
+};
+use pgwire::api::PgWireServerHandlers;
 use pgwire::error::PgWireResult;
 use pgwire::tokio::process_socket;
-
-pub struct DummyProcessor;
-
-#[async_trait]
-impl SimpleQueryHandler for DummyProcessor {
-    async fn do_query<'a, C>(
-        &self,
-        _client: &mut C,
-        _query: &str,
-    ) -> PgWireResult<Vec<Response<'a>>>
-    where
-        C: ClientInfo + Unpin + Send + Sync,
-    {
-        Ok(vec![Response::Execution(Tag::new("OK").with_rows(1))])
-    }
-}
 
 pub fn random_salt() -> Vec<u8> {
     Vec::from(rand::random::<[u8; 10]>())
@@ -75,27 +56,11 @@ fn setup_tls() -> Result<TlsAcceptor, IOError> {
 }
 
 struct DummyProcessorFactory {
-    handler: Arc<DummyProcessor>,
     cert: Vec<u8>,
 }
 
 impl PgWireServerHandlers for DummyProcessorFactory {
-    type StartupHandler = SASLScramAuthStartupHandler<DummyAuthDB, DefaultServerParameterProvider>;
-    type SimpleQueryHandler = DummyProcessor;
-    type ExtendedQueryHandler = PlaceholderExtendedQueryHandler;
-    type CopyHandler = NoopCopyHandler;
-    type CancelHandler = NoopCancelHandler;
-    type ErrorHandler = NoopErrorHandler;
-
-    fn simple_query_handler(&self) -> Arc<Self::SimpleQueryHandler> {
-        self.handler.clone()
-    }
-
-    fn extended_query_handler(&self) -> Arc<Self::ExtendedQueryHandler> {
-        Arc::new(PlaceholderExtendedQueryHandler)
-    }
-
-    fn startup_handler(&self) -> Arc<Self::StartupHandler> {
+    fn startup_handler(&self) -> Arc<impl StartupHandler> {
         let mut authenticator = SASLScramAuthStartupHandler::new(
             Arc::new(DummyAuthDB),
             Arc::new(DefaultServerParameterProvider::default()),
@@ -107,27 +72,12 @@ impl PgWireServerHandlers for DummyProcessorFactory {
 
         Arc::new(authenticator)
     }
-
-    fn copy_handler(&self) -> Arc<Self::CopyHandler> {
-        Arc::new(NoopCopyHandler)
-    }
-
-    fn cancel_handler(&self) -> Arc<Self::CancelHandler> {
-        Arc::new(NoopCancelHandler)
-    }
-
-    fn error_handler(&self) -> Arc<Self::ErrorHandler> {
-        Arc::new(NoopErrorHandler)
-    }
 }
 
 #[tokio::main]
 pub async fn main() {
     let cert = fs::read("examples/ssl/server.crt").unwrap();
-    let factory = Arc::new(DummyProcessorFactory {
-        handler: Arc::new(DummyProcessor),
-        cert,
-    });
+    let factory = Arc::new(DummyProcessorFactory { cert });
 
     let server_addr = "127.0.0.1:5432";
     let tls_acceptor = setup_tls().unwrap();

--- a/examples/secure_server.rs
+++ b/examples/secure_server.rs
@@ -2,62 +2,18 @@ use std::fs::File;
 use std::io::{BufReader, Error as IOError, ErrorKind};
 use std::sync::Arc;
 
-use async_trait::async_trait;
-use futures::{stream, StreamExt};
-use pgwire::api::cancel::NoopCancelHandler;
 use rustls_pemfile::{certs, pkcs8_private_keys};
 use rustls_pki_types::{CertificateDer, PrivateKeyDer};
 use tokio::net::TcpListener;
 use tokio_rustls::rustls::ServerConfig;
 use tokio_rustls::TlsAcceptor;
 
-use pgwire::api::auth::noop::NoopStartupHandler;
-use pgwire::api::copy::NoopCopyHandler;
-use pgwire::api::query::{PlaceholderExtendedQueryHandler, SimpleQueryHandler};
-use pgwire::api::results::{DataRowEncoder, FieldFormat, FieldInfo, QueryResponse, Response, Tag};
-use pgwire::api::{ClientInfo, NoopErrorHandler, PgWireServerHandlers, Type};
-use pgwire::error::PgWireResult;
+use pgwire::api::auth::StartupHandler;
+use pgwire::api::query::SimpleQueryHandler;
+use pgwire::api::PgWireServerHandlers;
 use pgwire::tokio::process_socket;
 
-pub struct DummyProcessor;
-
-impl NoopStartupHandler for DummyProcessor {}
-
-#[async_trait]
-impl SimpleQueryHandler for DummyProcessor {
-    async fn do_query<'a, C>(&self, _client: &mut C, query: &str) -> PgWireResult<Vec<Response<'a>>>
-    where
-        C: ClientInfo + Unpin + Send + Sync,
-    {
-        println!("{:?}", query);
-        if query.starts_with("SELECT") {
-            let f1 = FieldInfo::new("id".into(), None, None, Type::INT4, FieldFormat::Text);
-            let f2 = FieldInfo::new("name".into(), None, None, Type::VARCHAR, FieldFormat::Text);
-            let schema = Arc::new(vec![f1, f2]);
-
-            let data = vec![
-                (Some(0), Some("Tom")),
-                (Some(1), Some("Jerry")),
-                (Some(2), None),
-            ];
-            let schema_ref = schema.clone();
-            let data_row_stream = stream::iter(data.into_iter()).map(move |r| {
-                let mut encoder = DataRowEncoder::new(schema_ref.clone());
-                encoder.encode_field(&r.0)?;
-                encoder.encode_field(&r.1)?;
-
-                encoder.finish()
-            });
-
-            Ok(vec![Response::Query(QueryResponse::new(
-                schema,
-                data_row_stream,
-            ))])
-        } else {
-            Ok(vec![Response::Execution(Tag::new("OK").with_rows(1))])
-        }
-    }
-}
+mod common;
 
 fn setup_tls() -> Result<TlsAcceptor, IOError> {
     let cert = certs(&mut BufReader::new(File::open("examples/ssl/server.crt")?))
@@ -78,48 +34,19 @@ fn setup_tls() -> Result<TlsAcceptor, IOError> {
     Ok(TlsAcceptor::from(Arc::new(config)))
 }
 
-struct DummyProcessorFactory {
-    handler: Arc<DummyProcessor>,
-}
-
-impl PgWireServerHandlers for DummyProcessorFactory {
-    type StartupHandler = DummyProcessor;
-    type SimpleQueryHandler = DummyProcessor;
-    type ExtendedQueryHandler = PlaceholderExtendedQueryHandler;
-    type CopyHandler = NoopCopyHandler;
-    type CancelHandler = NoopCancelHandler;
-    type ErrorHandler = NoopErrorHandler;
-
-    fn simple_query_handler(&self) -> Arc<Self::SimpleQueryHandler> {
+impl PgWireServerHandlers for common::DummyProcessorFactory {
+    fn simple_query_handler(&self) -> Arc<impl SimpleQueryHandler> {
         self.handler.clone()
     }
 
-    fn extended_query_handler(&self) -> Arc<Self::ExtendedQueryHandler> {
-        Arc::new(PlaceholderExtendedQueryHandler)
-    }
-
-    fn startup_handler(&self) -> Arc<Self::StartupHandler> {
+    fn startup_handler(&self) -> Arc<impl StartupHandler> {
         self.handler.clone()
-    }
-
-    fn copy_handler(&self) -> Arc<Self::CopyHandler> {
-        Arc::new(NoopCopyHandler)
-    }
-
-    fn cancel_handler(&self) -> Arc<Self::CancelHandler> {
-        Arc::new(NoopCancelHandler)
-    }
-
-    fn error_handler(&self) -> Arc<Self::ErrorHandler> {
-        Arc::new(NoopErrorHandler)
     }
 }
 
 #[tokio::main]
 pub async fn main() {
-    let factory = Arc::new(DummyProcessorFactory {
-        handler: Arc::new(DummyProcessor),
-    });
+    let factory = Arc::new(common::DummyProcessorFactory::new());
 
     let server_addr = "127.0.0.1:5433";
     let tls_acceptor = setup_tls().unwrap();

--- a/examples/server.rs
+++ b/examples/server.rs
@@ -1,136 +1,27 @@
-use std::fmt::Debug;
 use std::sync::Arc;
 
-use async_trait::async_trait;
-use futures::{stream, Sink, SinkExt, StreamExt};
-use pgwire::api::cancel::NoopCancelHandler;
 use tokio::net::TcpListener;
 
-use pgwire::api::auth::noop::NoopStartupHandler;
-use pgwire::api::copy::NoopCopyHandler;
-use pgwire::api::query::{PlaceholderExtendedQueryHandler, SimpleQueryHandler};
-use pgwire::api::results::{DataRowEncoder, FieldFormat, FieldInfo, QueryResponse, Response, Tag};
-use pgwire::api::{ClientInfo, NoopErrorHandler, PgWireServerHandlers, Type};
-use pgwire::error::ErrorInfo;
-use pgwire::error::{PgWireError, PgWireResult};
-use pgwire::messages::response::NoticeResponse;
-use pgwire::messages::{PgWireBackendMessage, PgWireFrontendMessage};
+use pgwire::api::auth::StartupHandler;
+use pgwire::api::query::SimpleQueryHandler;
+use pgwire::api::PgWireServerHandlers;
 use pgwire::tokio::process_socket;
 
-pub struct DummyProcessor;
+mod common;
 
-#[async_trait]
-impl NoopStartupHandler for DummyProcessor {
-    async fn post_startup<C>(
-        &self,
-        client: &mut C,
-        _message: PgWireFrontendMessage,
-    ) -> PgWireResult<()>
-    where
-        C: ClientInfo + Sink<PgWireBackendMessage> + Unpin + Send,
-        C::Error: Debug,
-        PgWireError: From<<C as Sink<PgWireBackendMessage>>::Error>,
-    {
-        println!(
-            "connected {:?}: {:?}",
-            client.socket_addr(),
-            client.metadata()
-        );
-        Ok(())
-    }
-}
-
-#[async_trait]
-impl SimpleQueryHandler for DummyProcessor {
-    async fn do_query<'a, C>(&self, client: &mut C, query: &str) -> PgWireResult<Vec<Response<'a>>>
-    where
-        C: ClientInfo + Sink<PgWireBackendMessage> + Unpin + Send + Sync,
-        C::Error: Debug,
-        PgWireError: From<<C as Sink<PgWireBackendMessage>>::Error>,
-    {
-        client
-            .send(PgWireBackendMessage::NoticeResponse(NoticeResponse::from(
-                ErrorInfo::new(
-                    "NOTICE".to_owned(),
-                    "01000".to_owned(),
-                    format!("Query received {}", query),
-                ),
-            )))
-            .await?;
-
-        if query.starts_with("SELECT") {
-            let f1 = FieldInfo::new("id".into(), None, None, Type::INT4, FieldFormat::Text);
-            let f2 = FieldInfo::new("name".into(), None, None, Type::VARCHAR, FieldFormat::Text);
-            let schema = Arc::new(vec![f1, f2]);
-
-            let data = vec![
-                (Some(0), Some("Tom")),
-                (Some(1), Some("Jerry")),
-                (Some(2), None),
-            ];
-            let schema_ref = schema.clone();
-            let data_row_stream = stream::iter(data.into_iter()).map(move |r| {
-                let mut encoder = DataRowEncoder::new(schema_ref.clone());
-                encoder.encode_field(&r.0)?;
-                encoder.encode_field(&r.1)?;
-
-                encoder.finish()
-            });
-
-            // tokio::time::sleep(Duration::from_millis(10000)).await;
-
-            Ok(vec![Response::Query(QueryResponse::new(
-                schema,
-                data_row_stream,
-            ))])
-        } else {
-            Ok(vec![Response::Execution(Tag::new("OK").with_rows(1))])
-        }
-    }
-}
-
-struct DummyProcessorFactory {
-    handler: Arc<DummyProcessor>,
-}
-
-impl PgWireServerHandlers for DummyProcessorFactory {
-    type StartupHandler = DummyProcessor;
-    type SimpleQueryHandler = DummyProcessor;
-    type ExtendedQueryHandler = PlaceholderExtendedQueryHandler;
-    type CopyHandler = NoopCopyHandler;
-    type ErrorHandler = NoopErrorHandler;
-    type CancelHandler = NoopCancelHandler;
-
-    fn simple_query_handler(&self) -> Arc<Self::SimpleQueryHandler> {
+impl PgWireServerHandlers for common::DummyProcessorFactory {
+    fn simple_query_handler(&self) -> Arc<impl SimpleQueryHandler> {
         self.handler.clone()
     }
 
-    fn extended_query_handler(&self) -> Arc<Self::ExtendedQueryHandler> {
-        Arc::new(PlaceholderExtendedQueryHandler)
-    }
-
-    fn startup_handler(&self) -> Arc<Self::StartupHandler> {
+    fn startup_handler(&self) -> Arc<impl StartupHandler> {
         self.handler.clone()
-    }
-
-    fn copy_handler(&self) -> Arc<Self::CopyHandler> {
-        Arc::new(NoopCopyHandler)
-    }
-
-    fn cancel_handler(&self) -> Arc<Self::CancelHandler> {
-        Arc::new(NoopCancelHandler)
-    }
-
-    fn error_handler(&self) -> Arc<Self::ErrorHandler> {
-        Arc::new(NoopErrorHandler)
     }
 }
 
 #[tokio::main]
 pub async fn main() {
-    let factory = Arc::new(DummyProcessorFactory {
-        handler: Arc::new(DummyProcessor),
-    });
+    let factory = Arc::new(common::DummyProcessorFactory::new());
 
     let server_addr = "127.0.0.1:5432";
     let listener = TcpListener::bind(server_addr).await.unwrap();

--- a/examples/sqlite.rs
+++ b/examples/sqlite.rs
@@ -8,9 +8,9 @@ use rusqlite::{types::ValueRef, Connection, Statement, ToSql};
 use tokio::net::TcpListener;
 
 use pgwire::api::auth::md5pass::{hash_md5_password, Md5PasswordAuthStartupHandler};
-use pgwire::api::auth::{AuthSource, DefaultServerParameterProvider, LoginInfo, Password};
-use pgwire::api::cancel::NoopCancelHandler;
-use pgwire::api::copy::NoopCopyHandler;
+use pgwire::api::auth::{
+    AuthSource, DefaultServerParameterProvider, LoginInfo, Password, StartupHandler,
+};
 use pgwire::api::portal::{Format, Portal};
 use pgwire::api::query::{ExtendedQueryHandler, SimpleQueryHandler};
 use pgwire::api::results::{
@@ -18,9 +18,7 @@ use pgwire::api::results::{
     Response, Tag,
 };
 use pgwire::api::stmt::{NoopQueryParser, StoredStatement};
-use pgwire::api::NoopErrorHandler;
-use pgwire::api::PgWireServerHandlers;
-use pgwire::api::{ClientInfo, Type};
+use pgwire::api::{ClientInfo, PgWireServerHandlers, Type};
 use pgwire::error::{ErrorInfo, PgWireError, PgWireResult};
 use pgwire::messages::data::DataRow;
 use pgwire::tokio::process_socket;

--- a/examples/sqlite.rs
+++ b/examples/sqlite.rs
@@ -3,6 +3,9 @@ use std::sync::{Arc, Mutex};
 use async_trait::async_trait;
 use futures::stream;
 use futures::Stream;
+use rusqlite::Rows;
+use rusqlite::{types::ValueRef, Connection, Statement, ToSql};
+use tokio::net::TcpListener;
 
 use pgwire::api::auth::md5pass::{hash_md5_password, Md5PasswordAuthStartupHandler};
 use pgwire::api::auth::{AuthSource, DefaultServerParameterProvider, LoginInfo, Password};
@@ -21,9 +24,6 @@ use pgwire::api::{ClientInfo, Type};
 use pgwire::error::{ErrorInfo, PgWireError, PgWireResult};
 use pgwire::messages::data::DataRow;
 use pgwire::tokio::process_socket;
-use rusqlite::Rows;
-use rusqlite::{types::ValueRef, Connection, Statement, ToSql};
-use tokio::net::TcpListener;
 
 pub struct SqliteBackend {
     conn: Arc<Mutex<Connection>>,
@@ -284,23 +284,15 @@ struct SqliteBackendFactory {
 }
 
 impl PgWireServerHandlers for SqliteBackendFactory {
-    type StartupHandler =
-        Md5PasswordAuthStartupHandler<DummyAuthSource, DefaultServerParameterProvider>;
-    type SimpleQueryHandler = SqliteBackend;
-    type ExtendedQueryHandler = SqliteBackend;
-    type CopyHandler = NoopCopyHandler;
-    type CancelHandler = NoopCancelHandler;
-    type ErrorHandler = NoopErrorHandler;
-
-    fn simple_query_handler(&self) -> Arc<Self::SimpleQueryHandler> {
+    fn simple_query_handler(&self) -> Arc<impl SimpleQueryHandler> {
         self.handler.clone()
     }
 
-    fn extended_query_handler(&self) -> Arc<Self::ExtendedQueryHandler> {
+    fn extended_query_handler(&self) -> Arc<impl ExtendedQueryHandler> {
         self.handler.clone()
     }
 
-    fn startup_handler(&self) -> Arc<Self::StartupHandler> {
+    fn startup_handler(&self) -> Arc<impl StartupHandler> {
         let mut parameters = DefaultServerParameterProvider::default();
         parameters.server_version = rusqlite::version().to_owned();
 
@@ -308,18 +300,6 @@ impl PgWireServerHandlers for SqliteBackendFactory {
             Arc::new(DummyAuthSource),
             Arc::new(parameters),
         ))
-    }
-
-    fn copy_handler(&self) -> Arc<Self::CopyHandler> {
-        Arc::new(NoopCopyHandler)
-    }
-
-    fn cancel_handler(&self) -> Arc<Self::CancelHandler> {
-        Arc::new(NoopCancelHandler)
-    }
-
-    fn error_handler(&self) -> Arc<Self::ErrorHandler> {
-        Arc::new(NoopErrorHandler)
     }
 }
 

--- a/examples/transaction.rs
+++ b/examples/transaction.rs
@@ -3,14 +3,13 @@ use std::sync::Arc;
 
 use async_trait::async_trait;
 use futures::{stream, Sink, SinkExt};
-use pgwire::api::cancel::NoopCancelHandler;
+use pgwire::api::auth::StartupHandler;
 use tokio::net::TcpListener;
 
 use pgwire::api::auth::noop::NoopStartupHandler;
-use pgwire::api::copy::NoopCopyHandler;
-use pgwire::api::query::{PlaceholderExtendedQueryHandler, SimpleQueryHandler};
+use pgwire::api::query::SimpleQueryHandler;
 use pgwire::api::results::{DataRowEncoder, FieldFormat, FieldInfo, QueryResponse, Response, Tag};
-use pgwire::api::{ClientInfo, NoopErrorHandler, PgWireServerHandlers, Type};
+use pgwire::api::{ClientInfo, PgWireServerHandlers, Type};
 use pgwire::error::ErrorInfo;
 use pgwire::error::{PgWireError, PgWireResult};
 use pgwire::messages::response::NoticeResponse;
@@ -89,35 +88,12 @@ struct DummyProcessorFactory {
 }
 
 impl PgWireServerHandlers for DummyProcessorFactory {
-    type StartupHandler = DummyProcessor;
-    type SimpleQueryHandler = DummyProcessor;
-    type ExtendedQueryHandler = PlaceholderExtendedQueryHandler;
-    type CopyHandler = NoopCopyHandler;
-    type CancelHandler = NoopCancelHandler;
-    type ErrorHandler = NoopErrorHandler;
-
-    fn simple_query_handler(&self) -> Arc<Self::SimpleQueryHandler> {
+    fn simple_query_handler(&self) -> Arc<impl SimpleQueryHandler> {
         self.handler.clone()
     }
 
-    fn extended_query_handler(&self) -> Arc<Self::ExtendedQueryHandler> {
-        Arc::new(PlaceholderExtendedQueryHandler)
-    }
-
-    fn startup_handler(&self) -> Arc<Self::StartupHandler> {
+    fn startup_handler(&self) -> Arc<impl StartupHandler> {
         self.handler.clone()
-    }
-
-    fn copy_handler(&self) -> Arc<Self::CopyHandler> {
-        Arc::new(NoopCopyHandler)
-    }
-
-    fn cancel_handler(&self) -> Arc<Self::CancelHandler> {
-        Arc::new(NoopCancelHandler)
-    }
-
-    fn error_handler(&self) -> Arc<Self::ErrorHandler> {
-        Arc::new(NoopErrorHandler)
     }
 }
 

--- a/src/api/auth/noop.rs
+++ b/src/api/auth/noop.rs
@@ -58,3 +58,5 @@ where
         Ok(())
     }
 }
+
+impl NoopStartupHandler for crate::api::NoopHandler {}

--- a/src/api/cancel.rs
+++ b/src/api/cancel.rs
@@ -28,11 +28,8 @@ impl CancelHandler for DefaultCancelHandler {
     }
 }
 
-#[derive(Debug, new)]
-pub struct NoopCancelHandler;
-
 #[async_trait]
-impl CancelHandler for NoopCancelHandler {
+impl CancelHandler for super::NoopHandler {
     async fn on_cancel_request(&self, _cancel_request: CancelRequest) {}
 }
 

--- a/src/api/copy.rs
+++ b/src/api/copy.rs
@@ -18,19 +18,13 @@ pub trait CopyHandler: Send + Sync {
     where
         C: ClientInfo + Sink<PgWireBackendMessage> + Unpin + Send + Sync,
         C::Error: Debug,
-        PgWireError: From<<C as Sink<PgWireBackendMessage>>::Error>,
-    {
-        Ok(())
-    }
+        PgWireError: From<<C as Sink<PgWireBackendMessage>>::Error>;
 
     async fn on_copy_done<C>(&self, _client: &mut C, _done: CopyDone) -> PgWireResult<()>
     where
         C: ClientInfo + Sink<PgWireBackendMessage> + Unpin + Send + Sync,
         C::Error: Debug,
-        PgWireError: From<<C as Sink<PgWireBackendMessage>>::Error>,
-    {
-        Ok(())
-    }
+        PgWireError: From<<C as Sink<PgWireBackendMessage>>::Error>;
 
     async fn on_copy_fail<C>(&self, _client: &mut C, fail: CopyFail) -> PgWireError
     where
@@ -85,7 +79,23 @@ where
     Ok(())
 }
 
-#[derive(Clone, Copy, Debug, Default)]
-pub struct NoopCopyHandler;
+#[async_trait]
+impl CopyHandler for super::NoopHandler {
+    async fn on_copy_data<C>(&self, _client: &mut C, _copy_data: CopyData) -> PgWireResult<()>
+    where
+        C: ClientInfo + Sink<PgWireBackendMessage> + Unpin + Send + Sync,
+        C::Error: Debug,
+        PgWireError: From<<C as Sink<PgWireBackendMessage>>::Error>,
+    {
+        Ok(())
+    }
 
-impl CopyHandler for NoopCopyHandler {}
+    async fn on_copy_done<C>(&self, _client: &mut C, _done: CopyDone) -> PgWireResult<()>
+    where
+        C: ClientInfo + Sink<PgWireBackendMessage> + Unpin + Send + Sync,
+        C::Error: Debug,
+        PgWireError: From<<C as Sink<PgWireBackendMessage>>::Error>,
+    {
+        Ok(())
+    }
+}

--- a/src/api/mod.rs
+++ b/src/api/mod.rs
@@ -168,63 +168,58 @@ pub trait ErrorHandler: Send + Sync {
 }
 
 /// A noop implementation for `ErrorHandler`.
-pub struct NoopErrorHandler;
+#[derive(Debug)]
+pub struct NoopHandler;
 
-impl ErrorHandler for NoopErrorHandler {}
+impl ErrorHandler for NoopHandler {}
 
 pub trait PgWireServerHandlers {
-    type StartupHandler: auth::StartupHandler;
-    type SimpleQueryHandler: query::SimpleQueryHandler;
-    type ExtendedQueryHandler: query::ExtendedQueryHandler;
-    type CopyHandler: copy::CopyHandler;
-    type ErrorHandler: ErrorHandler;
-    type CancelHandler: cancel::CancelHandler;
+    fn simple_query_handler(&self) -> Arc<impl query::SimpleQueryHandler>;
 
-    fn simple_query_handler(&self) -> Arc<Self::SimpleQueryHandler>;
+    fn extended_query_handler(&self) -> Arc<impl query::ExtendedQueryHandler>;
 
-    fn extended_query_handler(&self) -> Arc<Self::ExtendedQueryHandler>;
+    fn startup_handler(&self) -> Arc<impl auth::StartupHandler> {
+        Arc::new(NoopHandler)
+    }
 
-    fn startup_handler(&self) -> Arc<Self::StartupHandler>;
+    fn copy_handler(&self) -> Arc<impl copy::CopyHandler> {
+        Arc::new(NoopHandler)
+    }
 
-    fn copy_handler(&self) -> Arc<Self::CopyHandler>;
+    fn error_handler(&self) -> Arc<impl ErrorHandler> {
+        Arc::new(NoopHandler)
+    }
 
-    fn error_handler(&self) -> Arc<Self::ErrorHandler>;
-
-    fn cancel_handler(&self) -> Arc<Self::CancelHandler>;
+    fn cancel_handler(&self) -> Arc<impl cancel::CancelHandler> {
+        Arc::new(NoopHandler)
+    }
 }
 
 impl<T> PgWireServerHandlers for Arc<T>
 where
     T: PgWireServerHandlers,
 {
-    type StartupHandler = T::StartupHandler;
-    type SimpleQueryHandler = T::SimpleQueryHandler;
-    type ExtendedQueryHandler = T::ExtendedQueryHandler;
-    type CopyHandler = T::CopyHandler;
-    type ErrorHandler = T::ErrorHandler;
-    type CancelHandler = T::CancelHandler;
-
-    fn simple_query_handler(&self) -> Arc<Self::SimpleQueryHandler> {
+    fn simple_query_handler(&self) -> Arc<impl query::SimpleQueryHandler> {
         (**self).simple_query_handler()
     }
 
-    fn extended_query_handler(&self) -> Arc<Self::ExtendedQueryHandler> {
+    fn extended_query_handler(&self) -> Arc<impl query::ExtendedQueryHandler> {
         (**self).extended_query_handler()
     }
 
-    fn startup_handler(&self) -> Arc<Self::StartupHandler> {
+    fn startup_handler(&self) -> Arc<impl auth::StartupHandler> {
         (**self).startup_handler()
     }
 
-    fn copy_handler(&self) -> Arc<Self::CopyHandler> {
+    fn copy_handler(&self) -> Arc<impl copy::CopyHandler> {
         (**self).copy_handler()
     }
 
-    fn error_handler(&self) -> Arc<Self::ErrorHandler> {
+    fn error_handler(&self) -> Arc<impl ErrorHandler> {
         (**self).error_handler()
     }
 
-    fn cancel_handler(&self) -> Arc<Self::CancelHandler> {
+    fn cancel_handler(&self) -> Arc<impl cancel::CancelHandler> {
         (**self).cancel_handler()
     }
 }

--- a/src/api/mod.rs
+++ b/src/api/mod.rs
@@ -174,9 +174,13 @@ pub struct NoopHandler;
 impl ErrorHandler for NoopHandler {}
 
 pub trait PgWireServerHandlers {
-    fn simple_query_handler(&self) -> Arc<impl query::SimpleQueryHandler>;
+    fn simple_query_handler(&self) -> Arc<impl query::SimpleQueryHandler> {
+        Arc::new(NoopHandler)
+    }
 
-    fn extended_query_handler(&self) -> Arc<impl query::ExtendedQueryHandler>;
+    fn extended_query_handler(&self) -> Arc<impl query::ExtendedQueryHandler> {
+        Arc::new(NoopHandler)
+    }
 
     fn startup_handler(&self) -> Arc<impl auth::StartupHandler> {
         Arc::new(NoopHandler)

--- a/src/api/query.rs
+++ b/src/api/query.rs
@@ -503,19 +503,13 @@ where
     Ok(())
 }
 
-/// A placeholder extended query handler. It panics when extended query messages
-/// received. This handler is for demo only, never use it in serious
-/// application.
-#[derive(Debug, Clone)]
-pub struct PlaceholderExtendedQueryHandler;
-
 #[async_trait]
-impl ExtendedQueryHandler for PlaceholderExtendedQueryHandler {
+impl ExtendedQueryHandler for super::NoopHandler {
     type Statement = String;
     type QueryParser = NoopQueryParser;
 
     fn query_parser(&self) -> Arc<Self::QueryParser> {
-        unimplemented!("Extended Query is not implemented on this server.")
+        Arc::new(NoopQueryParser)
     }
 
     async fn do_query<'a, C>(
@@ -527,7 +521,7 @@ impl ExtendedQueryHandler for PlaceholderExtendedQueryHandler {
     where
         C: ClientInfo + Unpin + Send + Sync,
     {
-        unimplemented!("Extended Query is not implemented on this server.")
+        Ok(Response::Execution(Tag::new("OK")))
     }
 
     async fn do_describe_statement<C>(
@@ -538,7 +532,7 @@ impl ExtendedQueryHandler for PlaceholderExtendedQueryHandler {
     where
         C: ClientInfo + Unpin + Send + Sync,
     {
-        unimplemented!("Extended Query is not implemented on this server.")
+        Ok(DescribeStatementResponse::no_data())
     }
 
     async fn do_describe_portal<C>(
@@ -549,6 +543,22 @@ impl ExtendedQueryHandler for PlaceholderExtendedQueryHandler {
     where
         C: ClientInfo + Unpin + Send + Sync,
     {
-        unimplemented!("Extended Query is not implemented on this server.")
+        Ok(DescribePortalResponse::no_data())
+    }
+}
+
+#[async_trait]
+impl SimpleQueryHandler for super::NoopHandler {
+    async fn do_query<'a, C>(
+        &self,
+        _client: &mut C,
+        _query: &str,
+    ) -> PgWireResult<Vec<Response<'a>>>
+    where
+        C: ClientInfo + ClientPortalStore + Sink<PgWireBackendMessage> + Unpin + Send + Sync,
+        C::Error: Debug,
+        PgWireError: From<<C as Sink<PgWireBackendMessage>>::Error>,
+    {
+        Ok(vec![Response::Execution(Tag::new("OK"))])
     }
 }

--- a/src/api/query.rs
+++ b/src/api/query.rs
@@ -14,13 +14,15 @@ use crate::api::results::{
     DescribePortalResponse, DescribeResponse, DescribeStatementResponse, QueryResponse, Response,
 };
 use crate::api::PgWireConnectionState;
-use crate::error::{PgWireError, PgWireResult};
+use crate::error::{ErrorInfo, PgWireError, PgWireResult};
 use crate::messages::data::{NoData, ParameterDescription};
 use crate::messages::extendedquery::{
     Bind, BindComplete, Close, CloseComplete, Describe, Execute, Flush, Parse, ParseComplete,
     Sync as PgSync, TARGET_TYPE_BYTE_PORTAL, TARGET_TYPE_BYTE_STATEMENT,
 };
-use crate::messages::response::{EmptyQueryResponse, ReadyForQuery, TransactionStatus};
+use crate::messages::response::{
+    EmptyQueryResponse, NoticeResponse, ReadyForQuery, TransactionStatus,
+};
 use crate::messages::simplequery::Query;
 use crate::messages::PgWireBackendMessage;
 
@@ -514,13 +516,24 @@ impl ExtendedQueryHandler for super::NoopHandler {
 
     async fn do_query<'a, C>(
         &self,
-        _client: &mut C,
+        client: &mut C,
         _portal: &Portal<Self::Statement>,
         _max_rows: usize,
     ) -> PgWireResult<Response<'a>>
     where
-        C: ClientInfo + Unpin + Send + Sync,
+        C: ClientInfo + Sink<PgWireBackendMessage> + Unpin + Send + Sync,
+        C::Error: Debug,
+        PgWireError: From<<C as Sink<PgWireBackendMessage>>::Error>,
     {
+        client
+            .send(PgWireBackendMessage::NoticeResponse(NoticeResponse::from(
+                ErrorInfo::new(
+                    "NOTICE".to_owned(),
+                    "01000".to_owned(),
+                    "This is a demo handler for extended query.".to_string(),
+                ),
+            )))
+            .await?;
         Ok(Response::Execution(Tag::new("OK")))
     }
 
@@ -549,16 +562,21 @@ impl ExtendedQueryHandler for super::NoopHandler {
 
 #[async_trait]
 impl SimpleQueryHandler for super::NoopHandler {
-    async fn do_query<'a, C>(
-        &self,
-        _client: &mut C,
-        _query: &str,
-    ) -> PgWireResult<Vec<Response<'a>>>
+    async fn do_query<'a, C>(&self, client: &mut C, _query: &str) -> PgWireResult<Vec<Response<'a>>>
     where
         C: ClientInfo + ClientPortalStore + Sink<PgWireBackendMessage> + Unpin + Send + Sync,
         C::Error: Debug,
         PgWireError: From<<C as Sink<PgWireBackendMessage>>::Error>,
     {
+        client
+            .send(PgWireBackendMessage::NoticeResponse(NoticeResponse::from(
+                ErrorInfo::new(
+                    "NOTICE".to_owned(),
+                    "01000".to_owned(),
+                    "This is a demo handler for simple query.".to_string(),
+                ),
+            )))
+            .await?;
         Ok(vec![Response::Execution(Tag::new("OK"))])
     }
 }


### PR DESCRIPTION
This patch is a breaking change but it's aimed to simplify the implementation of `PgWireServerHandlers` quite a bit. The new function signature uses `impl trait` style return value, and removed type definitions associated with the trait.

This allows us to set NoopHandler as default type and API won't break when we introduce new handlers.