### PR TITLE
fix: generate header after query also in do_describe_ in DuckDB example

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -89,7 +89,7 @@ tokio = { version = "1.19", features = ["rt-multi-thread", "net", "macros", "tim
 rustls-pki-types = { version = "1.10" }
 rusqlite = { version = "0.36.0", features = ["column_decltype"] }
 ## for duckdb example
-duckdb = { version = "1.0.0" }
+duckdb = { version = "1", features = ["bundled"] }
 
 ## for loading custom cert files
 rustls-pemfile = "2.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -89,7 +89,7 @@ tokio = { version = "1.19", features = ["rt-multi-thread", "net", "macros", "tim
 rustls-pki-types = { version = "1.10" }
 rusqlite = { version = "0.36.0", features = ["column_decltype"] }
 ## for duckdb example
-duckdb = { version = "1", features = ["bundled"] }
+duckdb = { version = "1"}
 
 ## for loading custom cert files
 rustls-pemfile = "2.0"


### PR DESCRIPTION
Continues #271 
I'm executing the statement before describing it also in `do_describe_statement()` and `do_describe_portal()`.
I'm also allowing for more queries to be considered for `query()` rather than `execute()`.

`SELECT 1;`
```bash
pgbench "host=localhost port=5432 password=pencil" --no-vacuum -f pgbench/select.sql -c 100 -t 100 --protocol simple
# tps = 2651.462995 (without initial connection time)


pgbench "host=localhost port=5432 password=pencil" --no-vacuum -f pgbench/select.sql -c 100 -t 100 --protocol extended
# tps = 2415.428242 (without initial connection time)
```


`SELECT 1, version() FROM 'hf://datasets/ibm/duorc/ParaphraseRC/*.parquet' LIMIT 3;`
```bash
pgbench "host=localhost port=5432 password=pencil" --no-vacuum -f pgbench/select.sql -c 3 -t 3 --protocol simple
# tps = 0.766688 (without initial connection time)


pgbench "host=localhost port=5432 password=pencil" --no-vacuum -f pgbench/select.sql -c 3 -t 3 --protocol extended
# tps = 1.063646 (without initial connection time)
```

