### PR TITLE
refactor: use arrow-pg for duckdb example

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -90,12 +90,16 @@ rustls-pki-types = { version = "1.10" }
 rusqlite = { version = "0.36.0", features = ["column_decltype"] }
 ## for duckdb example
 duckdb = { version = "1.0.0" }
+arrow-pg = "0.1"
 
 ## for loading custom cert files
 rustls-pemfile = "2.0"
 ## webpki-roots has mozilla's set of roots
 ## rustls-native-certs loads roots from current system
 gluesql = { version = "0.16", default-features = false, features = ["gluesql_memory_storage"] }
+
+[patch.crates-io]
+pgwire = { path = "." }
 
 [workspace]
 members = [


### PR DESCRIPTION
This patch reuse some code from `arrow-pg` for arrow data encoding in duckdb example.