### PR TITLE
feat: use protocol 3.2 by default, and downgrade to 3.0 if client requests

### DIFF
--- a/examples/common/mod.rs
+++ b/examples/common/mod.rs
@@ -1,17 +1,41 @@
+use std::fmt::Debug;
 use std::sync::Arc;
 
 use async_trait::async_trait;
-use futures::{stream, StreamExt};
+use futures::{stream, Sink, StreamExt};
 
 use pgwire::api::auth::noop::NoopStartupHandler;
 use pgwire::api::query::SimpleQueryHandler;
 use pgwire::api::results::{DataRowEncoder, FieldFormat, FieldInfo, QueryResponse, Response, Tag};
 use pgwire::api::{ClientInfo, Type};
-use pgwire::error::PgWireResult;
+use pgwire::error::{PgWireError, PgWireResult};
+use pgwire::messages::{PgWireBackendMessage, PgWireFrontendMessage};
 
 pub struct DummyProcessor;
 
-impl NoopStartupHandler for DummyProcessor {}
+#[async_trait]
+impl NoopStartupHandler for DummyProcessor {
+    async fn post_startup<C>(
+        &self,
+        client: &mut C,
+        _message: PgWireFrontendMessage,
+    ) -> PgWireResult<()>
+    where
+        C: ClientInfo + Sink<PgWireBackendMessage> + Unpin + Send,
+        C::Error: Debug,
+        PgWireError: From<<C as Sink<PgWireBackendMessage>>::Error>,
+    {
+        println!(
+            "Client connected:\n- Socket Address: {}\n- TLS: {}\n- Protocol Version: {:?}\n- Process id/SecretKey: {:?}\n -- Metadata: {:?}",
+            client.socket_addr(),
+            client.is_secure(),
+            client.protocol_version(),
+            client.pid_and_secret_key(),
+            client.metadata(),
+        );
+        Ok(())
+    }
+}
 
 #[async_trait]
 impl SimpleQueryHandler for DummyProcessor {

--- a/examples/common/mod.rs
+++ b/examples/common/mod.rs
@@ -26,7 +26,7 @@ impl NoopStartupHandler for DummyProcessor {
         PgWireError: From<<C as Sink<PgWireBackendMessage>>::Error>,
     {
         println!(
-            "Client connected:\n- Socket Address: {}\n- TLS: {}\n- Protocol Version: {:?}\n- Process id/SecretKey: {:?}\n -- Metadata: {:?}",
+            "Client connected:\n- Socket Address: {}\n- TLS: {}\n- Protocol Version: {:?}\n- ProcessID/SecretKey: {:?}\n- Metadata: {:?}",
             client.socket_addr(),
             client.is_secure(),
             client.protocol_version(),

--- a/src/api/auth/cleartext.rs
+++ b/src/api/auth/cleartext.rs
@@ -4,8 +4,8 @@ use async_trait::async_trait;
 use futures::sink::{Sink, SinkExt};
 
 use super::{
-    AuthSource, ClientInfo, LoginInfo, PgWireConnectionState, ServerParameterProvider,
-    StartupHandler,
+    protocol_negotiation, AuthSource, ClientInfo, LoginInfo, PgWireConnectionState,
+    ServerParameterProvider, StartupHandler,
 };
 use crate::error::{PgWireError, PgWireResult};
 use crate::messages::startup::Authentication;
@@ -33,13 +33,15 @@ impl<V: AuthSource, P: ServerParameterProvider> StartupHandler
     {
         match message {
             PgWireFrontendMessage::Startup(ref startup) => {
-                super::save_startup_parameters_to_metadata(client, startup);
-                client.set_state(PgWireConnectionState::AuthenticationInProgress);
-                client
-                    .send(PgWireBackendMessage::Authentication(
-                        Authentication::CleartextPassword,
-                    ))
-                    .await?;
+                if protocol_negotiation(client, startup).await? {
+                    super::save_startup_parameters_to_metadata(client, startup);
+                    client.set_state(PgWireConnectionState::AuthenticationInProgress);
+                    client
+                        .send(PgWireBackendMessage::Authentication(
+                            Authentication::CleartextPassword,
+                        ))
+                        .await?;
+                }
             }
             PgWireFrontendMessage::PasswordMessageFamily(pwd) => {
                 let pwd = pwd.into_password()?;

--- a/src/api/auth/md5pass.rs
+++ b/src/api/auth/md5pass.rs
@@ -6,8 +6,8 @@ use futures::sink::{Sink, SinkExt};
 use tokio::sync::Mutex;
 
 use super::{
-    AuthSource, ClientInfo, LoginInfo, PgWireConnectionState, ServerParameterProvider,
-    StartupHandler,
+    protocol_negotiation, AuthSource, ClientInfo, LoginInfo, PgWireConnectionState,
+    ServerParameterProvider, StartupHandler,
 };
 use crate::error::{PgWireError, PgWireResult};
 use crate::messages::startup::Authentication;
@@ -45,27 +45,29 @@ impl<A: AuthSource, P: ServerParameterProvider> StartupHandler
     {
         match message {
             PgWireFrontendMessage::Startup(ref startup) => {
-                super::save_startup_parameters_to_metadata(client, startup);
-                client.set_state(PgWireConnectionState::AuthenticationInProgress);
+                if protocol_negotiation(client, startup).await? {
+                    super::save_startup_parameters_to_metadata(client, startup);
+                    client.set_state(PgWireConnectionState::AuthenticationInProgress);
 
-                let login_info = LoginInfo::from_client_info(client);
-                let salt_and_pass = self.auth_source.get_password(&login_info).await?;
+                    let login_info = LoginInfo::from_client_info(client);
+                    let salt_and_pass = self.auth_source.get_password(&login_info).await?;
 
-                let salt = salt_and_pass
-                    .salt
-                    .as_ref()
-                    .expect("Salt is required for Md5Password authentication");
+                    let salt = salt_and_pass
+                        .salt
+                        .as_ref()
+                        .expect("Salt is required for Md5Password authentication");
 
-                self.cached_password
-                    .lock()
-                    .await
-                    .clone_from(&salt_and_pass.password);
+                    self.cached_password
+                        .lock()
+                        .await
+                        .clone_from(&salt_and_pass.password);
 
-                client
-                    .send(PgWireBackendMessage::Authentication(
-                        Authentication::MD5Password(salt.clone()),
-                    ))
-                    .await?;
+                    client
+                        .send(PgWireBackendMessage::Authentication(
+                            Authentication::MD5Password(salt.clone()),
+                        ))
+                        .await?;
+                }
             }
             PgWireFrontendMessage::PasswordMessageFamily(pwd) => {
                 let pwd = pwd.into_password()?;

--- a/src/api/auth/scram.rs
+++ b/src/api/auth/scram.rs
@@ -24,7 +24,7 @@ use crate::error::{PgWireError, PgWireResult};
 use crate::messages::startup::Authentication;
 use crate::messages::{PgWireBackendMessage, PgWireFrontendMessage};
 
-use super::{ServerParameterProvider, StartupHandler};
+use super::{protocol_negotiation, ServerParameterProvider, StartupHandler};
 
 #[derive(Debug)]
 pub enum ScramState {
@@ -99,18 +99,20 @@ impl<A: AuthSource, P: ServerParameterProvider> StartupHandler
     {
         match message {
             PgWireFrontendMessage::Startup(ref startup) => {
-                super::save_startup_parameters_to_metadata(client, startup);
-                client.set_state(PgWireConnectionState::AuthenticationInProgress);
-                let supported_mechanisms = if self.server_cert_sig.is_some() {
-                    vec!["SCRAM-SHA-256".to_owned(), "SCRAM-SHA-256-PLUS".to_owned()]
-                } else {
-                    vec!["SCRAM-SHA-256".to_owned()]
-                };
-                client
-                    .send(PgWireBackendMessage::Authentication(Authentication::SASL(
-                        supported_mechanisms,
-                    )))
-                    .await?;
+                if protocol_negotiation(client, startup).await? {
+                    super::save_startup_parameters_to_metadata(client, startup);
+                    client.set_state(PgWireConnectionState::AuthenticationInProgress);
+                    let supported_mechanisms = if self.server_cert_sig.is_some() {
+                        vec!["SCRAM-SHA-256".to_owned(), "SCRAM-SHA-256-PLUS".to_owned()]
+                    } else {
+                        vec!["SCRAM-SHA-256".to_owned()]
+                    };
+                    client
+                        .send(PgWireBackendMessage::Authentication(Authentication::SASL(
+                            supported_mechanisms,
+                        )))
+                        .await?;
+                }
             }
             PgWireFrontendMessage::PasswordMessageFamily(msg) => {
                 let salt_and_salted_pass = {

--- a/src/api/mod.rs
+++ b/src/api/mod.rs
@@ -152,7 +152,7 @@ impl<S> DefaultClient<S> {
         DefaultClient {
             socket_addr,
             is_secure,
-            protocol_version: ProtocolVersion::UNKNOWN,
+            protocol_version: ProtocolVersion::PROTOCOL3_2,
             pid_secret_key: (0, SecretKey::default()),
             state: PgWireConnectionState::default(),
             transaction_status: TransactionStatus::Idle,

--- a/src/api/mod.rs
+++ b/src/api/mod.rs
@@ -152,7 +152,7 @@ impl<S> DefaultClient<S> {
         DefaultClient {
             socket_addr,
             is_secure,
-            protocol_version: ProtocolVersion::PROTOCOL3_2,
+            protocol_version: ProtocolVersion::default(),
             pid_secret_key: (0, SecretKey::default()),
             state: PgWireConnectionState::default(),
             transaction_status: TransactionStatus::Idle,

--- a/src/messages/mod.rs
+++ b/src/messages/mod.rs
@@ -11,17 +11,27 @@ use crate::error::{PgWireError, PgWireResult};
 
 #[derive(Default, Debug, PartialEq, Eq, Clone, Copy)]
 pub enum ProtocolVersion {
-    #[default]
-    UNKNOWN,
     PROTOCOL3_0,
+    #[default]
     PROTOCOL3_2,
 }
 
 impl ProtocolVersion {
     pub fn version_number(&self) -> (u16, u16) {
         match &self {
-            Self::UNKNOWN | Self::PROTOCOL3_0 => (3, 0),
+            Self::PROTOCOL3_0 => (3, 0),
             Self::PROTOCOL3_2 => (3, 2),
+        }
+    }
+
+    /// Get ProtocolVersion from (major, minor) version tuple
+    ///
+    /// Return none if protocol is not supported.
+    pub fn from_version_number(major: u16, minor: u16) -> Option<Self> {
+        match (major, minor) {
+            (3, 0) => Some(Self::PROTOCOL3_0),
+            (3, 2) => Some(Self::PROTOCOL3_2),
+            _ => None,
         }
     }
 }

--- a/src/messages/startup.rs
+++ b/src/messages/startup.rs
@@ -467,7 +467,6 @@ impl Message for BackendKeyData {
         let secret_key = match ctx.protocol_version {
             ProtocolVersion::PROTOCOL3_0 => SecretKey::I32(buf.get_i32()),
             ProtocolVersion::PROTOCOL3_2 => SecretKey::Bytes(buf.split_to(msg_len - 8).freeze()),
-            _ => unreachable!("Protocol Version must be known for BackendKeyData"),
         };
 
         Ok(BackendKeyData { pid, secret_key })


### PR DESCRIPTION
In this patch I removed `UNKNOWN` from `ProtocolVersion`. There won't be a unknown state. The server will always use `3.2` protocol version be default, and if client requests an alternative version the server knows about, it will downgrade to it. Otherwise, the server will start its protocol negotiation process hoping the client to know about it. This will be implemented in next patch.