### PR TITLE
refactor: add support for PgWireFrontMessage to decode special messages

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ node_modules
 .DS_Store
 .direnv
 .envrc
+result

--- a/flake.nix
+++ b/flake.nix
@@ -45,6 +45,9 @@
             gnuplot ## for cargo bench
             pythonEnv
             postgresql
+            babashka
+            nodejs_24
+            go
           ];
 
           LD_LIBRARY_PATH = pkgs.lib.makeLibraryPath buildInputs;

--- a/flake.nix
+++ b/flake.nix
@@ -22,6 +22,7 @@
           duckdb.dev
           duckdb.lib
           sqlite.dev
+          openssl.out
         ];
       in
       {

--- a/src/error.rs
+++ b/src/error.rs
@@ -18,6 +18,8 @@ pub enum PgWireError {
     InvalidTargetType(u8),
     #[error("Invalid transaction status, received {0}")]
     InvalidTransactionStatus(u8),
+    #[error("Invalid ssl request message")]
+    InvalidSSLRequestMessage,
     #[error("Invalid startup message")]
     InvalidStartupMessage,
     #[error("Invalid authentication message code: {0}")]
@@ -239,6 +241,9 @@ impl From<PgWireError> for ErrorInfo {
                 ErrorInfo::new("FATAL".to_owned(), "08P01".to_owned(), error.to_string())
             }
             PgWireError::InvalidTransactionStatus(_) => {
+                ErrorInfo::new("FATAL".to_owned(), "08P01".to_owned(), error.to_string())
+            }
+            PgWireError::InvalidSSLRequestMessage => {
                 ErrorInfo::new("FATAL".to_owned(), "08P01".to_owned(), error.to_string())
             }
             PgWireError::InvalidStartupMessage => {

--- a/src/messages/mod.rs
+++ b/src/messages/mod.rs
@@ -443,15 +443,13 @@ mod test {
     use bytes::{Buf, BufMut, Bytes, BytesMut};
 
     macro_rules! roundtrip {
-        ($ins:ident, $st:ty) => {
+        ($ins:ident, $st:ty, $ctx:expr) => {
             let mut buffer = BytesMut::new();
             $ins.encode(&mut buffer).expect("encode packet");
 
             assert!(buffer.remaining() > 0);
 
-            let ctx = DecodeContext::new(ProtocolVersion::PROTOCOL3_0);
-
-            let item2 = <$st>::decode(&mut buffer, &ctx)
+            let item2 = <$st>::decode(&mut buffer, $ctx)
                 .expect("decode packet")
                 .expect("packet is none");
 
@@ -462,20 +460,34 @@ mod test {
 
     #[test]
     fn test_startup() {
+        let mut ctx = DecodeContext::new(ProtocolVersion::PROTOCOL3_0);
+
         let mut s = Startup::default();
         s.parameters.insert("user".to_owned(), "tomcat".to_owned());
+        roundtrip!(s, Startup, &ctx);
 
-        roundtrip!(s, Startup);
+        ctx.awaiting_ssl = false;
+        roundtrip!(s, Startup, &ctx);
     }
 
     #[test]
     fn test_cancel_request() {
+        let mut ctx = DecodeContext::new(ProtocolVersion::PROTOCOL3_2);
+
         let s = CancelRequest::new(100, SecretKey::Bytes(Bytes::from("server2008")));
-        roundtrip!(s, CancelRequest);
+        roundtrip!(s, CancelRequest, &ctx);
+
+        ctx.protocol_version = ProtocolVersion::PROTOCOL3_0;
+        let s = CancelRequest::new(100, SecretKey::I32(1900));
+        roundtrip!(s, CancelRequest, &ctx);
     }
 
     #[test]
     fn test_authentication() {
+        let mut ctx = DecodeContext::new(ProtocolVersion::PROTOCOL3_0);
+        ctx.awaiting_ssl = false;
+        ctx.awaiting_startup = false;
+
         let ss = vec![
             Authentication::Ok,
             Authentication::CleartextPassword,
@@ -484,67 +496,99 @@ mod test {
             Authentication::SASLFinal(Bytes::from("world")),
         ];
         for s in ss {
-            roundtrip!(s, Authentication);
+            roundtrip!(s, Authentication, &ctx);
         }
 
         let md5pass = Authentication::MD5Password(vec![b'p', b's', b't', b'g']);
-        roundtrip!(md5pass, Authentication);
+        roundtrip!(md5pass, Authentication, &ctx);
     }
 
     #[test]
     fn test_password() {
+        let mut ctx = DecodeContext::new(ProtocolVersion::PROTOCOL3_0);
+        ctx.awaiting_ssl = false;
+        ctx.awaiting_startup = false;
+
         let s = Password::new("pgwire".to_owned());
-        roundtrip!(s, Password);
+        roundtrip!(s, Password, &ctx);
     }
 
     #[test]
     fn test_parameter_status() {
+        let mut ctx = DecodeContext::new(ProtocolVersion::PROTOCOL3_0);
+        ctx.awaiting_ssl = false;
+        ctx.awaiting_startup = false;
+
         let pps = ParameterStatus::new("cli".to_owned(), "psql".to_owned());
-        roundtrip!(pps, ParameterStatus);
+        roundtrip!(pps, ParameterStatus, &ctx);
     }
 
     #[test]
     fn test_query() {
+        let mut ctx = DecodeContext::new(ProtocolVersion::PROTOCOL3_0);
+        ctx.awaiting_ssl = false;
+        ctx.awaiting_startup = false;
+
         let query = Query::new("SELECT 1".to_owned());
-        roundtrip!(query, Query);
+        roundtrip!(query, Query, &ctx);
     }
 
     #[test]
     fn test_command_complete() {
+        let mut ctx = DecodeContext::new(ProtocolVersion::PROTOCOL3_0);
+        ctx.awaiting_ssl = false;
+        ctx.awaiting_startup = false;
+
         let cc = CommandComplete::new("DELETE 5".to_owned());
-        roundtrip!(cc, CommandComplete);
+        roundtrip!(cc, CommandComplete, &ctx);
     }
 
     #[test]
     fn test_ready_for_query() {
+        let mut ctx = DecodeContext::new(ProtocolVersion::PROTOCOL3_0);
+        ctx.awaiting_ssl = false;
+        ctx.awaiting_startup = false;
+
         let r4q = ReadyForQuery::new(TransactionStatus::Idle);
-        roundtrip!(r4q, ReadyForQuery);
+        roundtrip!(r4q, ReadyForQuery, &ctx);
         let r4q = ReadyForQuery::new(TransactionStatus::Transaction);
-        roundtrip!(r4q, ReadyForQuery);
+        roundtrip!(r4q, ReadyForQuery, &ctx);
         let r4q = ReadyForQuery::new(TransactionStatus::Error);
-        roundtrip!(r4q, ReadyForQuery);
+        roundtrip!(r4q, ReadyForQuery, &ctx);
     }
 
     #[test]
     fn test_error_response() {
+        let mut ctx = DecodeContext::new(ProtocolVersion::PROTOCOL3_0);
+        ctx.awaiting_ssl = false;
+        ctx.awaiting_startup = false;
+
         let mut error = ErrorResponse::default();
         error.fields.push((b'R', "ERROR".to_owned()));
         error.fields.push((b'K', "cli".to_owned()));
 
-        roundtrip!(error, ErrorResponse);
+        roundtrip!(error, ErrorResponse, &ctx);
     }
 
     #[test]
     fn test_notice_response() {
+        let mut ctx = DecodeContext::new(ProtocolVersion::PROTOCOL3_0);
+        ctx.awaiting_ssl = false;
+        ctx.awaiting_startup = false;
+
         let mut error = NoticeResponse::default();
         error.fields.push((b'R', "NOTICE".to_owned()));
         error.fields.push((b'K', "cli".to_owned()));
 
-        roundtrip!(error, NoticeResponse);
+        roundtrip!(error, NoticeResponse, &ctx);
     }
 
     #[test]
     fn test_row_description() {
+        let mut ctx = DecodeContext::new(ProtocolVersion::PROTOCOL3_0);
+        ctx.awaiting_ssl = false;
+        ctx.awaiting_startup = false;
+
         let mut row_description = RowDescription::default();
 
         let mut f1 = FieldDescription::default();
@@ -567,11 +611,15 @@ mod test {
         f2.format_code = FORMAT_CODE_TEXT;
         row_description.fields.push(f2);
 
-        roundtrip!(row_description, RowDescription);
+        roundtrip!(row_description, RowDescription, &ctx);
     }
 
     #[test]
     fn test_data_row() {
+        let mut ctx = DecodeContext::new(ProtocolVersion::PROTOCOL3_0);
+        ctx.awaiting_ssl = false;
+        ctx.awaiting_startup = false;
+
         let mut row0 = DataRow::default();
         row0.data.put_i32(4);
         row0.data.put_slice("data".as_bytes());
@@ -579,52 +627,75 @@ mod test {
         row0.data.put_i32(1001);
         row0.data.put_i32(-1);
 
-        roundtrip!(row0, DataRow);
+        roundtrip!(row0, DataRow, &ctx);
     }
 
     #[test]
     fn test_terminate() {
+        let mut ctx = DecodeContext::new(ProtocolVersion::PROTOCOL3_0);
+        ctx.awaiting_ssl = false;
+        ctx.awaiting_startup = false;
+
         let terminate = Terminate::new();
-        roundtrip!(terminate, Terminate);
+        roundtrip!(terminate, Terminate, &ctx);
     }
 
     #[test]
     fn test_parse() {
+        let mut ctx = DecodeContext::new(ProtocolVersion::PROTOCOL3_0);
+        ctx.awaiting_ssl = false;
+        ctx.awaiting_startup = false;
+
         let parse = Parse::new(
             Some("find-user-by-id".to_owned()),
             "SELECT * FROM user WHERE id = ?".to_owned(),
             vec![1],
         );
-        roundtrip!(parse, Parse);
+        roundtrip!(parse, Parse, &ctx);
     }
 
     #[test]
     fn test_parse_65k() {
+        let mut ctx = DecodeContext::new(ProtocolVersion::PROTOCOL3_0);
+        ctx.awaiting_ssl = false;
+        ctx.awaiting_startup = false;
+
         let parse = Parse::new(
             Some("many-params".to_owned()),
             "it won't be parsed anyway".to_owned(),
             vec![25; u16::MAX as usize],
         );
-        roundtrip!(parse, Parse);
+        roundtrip!(parse, Parse, &ctx);
     }
 
     #[test]
     fn test_parse_complete() {
+        let mut ctx = DecodeContext::new(ProtocolVersion::PROTOCOL3_0);
+        ctx.awaiting_ssl = false;
+        ctx.awaiting_startup = false;
+
         let parse_complete = ParseComplete::new();
-        roundtrip!(parse_complete, ParseComplete);
+        roundtrip!(parse_complete, ParseComplete, &ctx);
     }
 
     #[test]
     fn test_close() {
+        let mut ctx = DecodeContext::new(ProtocolVersion::PROTOCOL3_0);
+        ctx.awaiting_ssl = false;
+        ctx.awaiting_startup = false;
+
         let close = Close::new(
             TARGET_TYPE_BYTE_STATEMENT,
             Some("find-user-by-id".to_owned()),
         );
-        roundtrip!(close, Close);
+        roundtrip!(close, Close, &ctx);
     }
 
     #[test]
     fn test_bind() {
+        let mut ctx = DecodeContext::new(ProtocolVersion::PROTOCOL3_0);
+        ctx.awaiting_ssl = false;
+        ctx.awaiting_startup = false;
         let bind = Bind::new(
             Some("find-user-by-id-0".to_owned()),
             Some("find-user-by-id".to_owned()),
@@ -632,11 +703,15 @@ mod test {
             vec![Some(Bytes::from_static(b"1234"))],
             vec![0],
         );
-        roundtrip!(bind, Bind);
+        roundtrip!(bind, Bind, &ctx);
     }
 
     #[test]
     fn test_bind_65k() {
+        let mut ctx = DecodeContext::new(ProtocolVersion::PROTOCOL3_0);
+        ctx.awaiting_ssl = false;
+        ctx.awaiting_startup = false;
+
         let bind = Bind::new(
             Some("lol".to_owned()),
             Some("kek".to_owned()),
@@ -644,56 +719,74 @@ mod test {
             vec![Some(Bytes::from_static(b"1234")); u16::MAX as usize],
             vec![0],
         );
-        roundtrip!(bind, Bind);
+        roundtrip!(bind, Bind, &ctx);
     }
 
     #[test]
     fn test_execute() {
+        let mut ctx = DecodeContext::new(ProtocolVersion::PROTOCOL3_0);
+        ctx.awaiting_ssl = false;
+        ctx.awaiting_startup = false;
+
         let exec = Execute::new(Some("find-user-by-id-0".to_owned()), 100);
-        roundtrip!(exec, Execute);
+        roundtrip!(exec, Execute, &ctx);
     }
 
     #[test]
     fn test_sslrequest() {
+        let ctx = DecodeContext::new(ProtocolVersion::PROTOCOL3_0);
+
         let sslreq = SslRequest::new();
-        roundtrip!(sslreq, SslRequest);
+        roundtrip!(sslreq, SslRequest, &ctx);
     }
 
     #[test]
     fn test_sslresponse() {
+        let ctx = DecodeContext::new(ProtocolVersion::PROTOCOL3_0);
+
         let sslaccept = SslResponse::Accept;
-        roundtrip!(sslaccept, SslResponse);
+        roundtrip!(sslaccept, SslResponse, &ctx);
         let sslrefuse = SslResponse::Refuse;
-        roundtrip!(sslrefuse, SslResponse);
+        roundtrip!(sslrefuse, SslResponse, &ctx);
     }
 
     #[test]
     fn test_saslresponse() {
+        let mut ctx = DecodeContext::new(ProtocolVersion::PROTOCOL3_0);
+        ctx.awaiting_ssl = false;
+        ctx.awaiting_startup = false;
+
         let saslinitialresp =
             SASLInitialResponse::new("SCRAM-SHA-256".to_owned(), Some(Bytes::from_static(b"abc")));
-        roundtrip!(saslinitialresp, SASLInitialResponse);
+        roundtrip!(saslinitialresp, SASLInitialResponse, &ctx);
 
         let saslresp = SASLResponse::new(Bytes::from_static(b"abc"));
-        roundtrip!(saslresp, SASLResponse);
+        roundtrip!(saslresp, SASLResponse, &ctx);
     }
 
     #[test]
     fn test_parameter_description() {
+        let mut ctx = DecodeContext::new(ProtocolVersion::PROTOCOL3_0);
+        ctx.awaiting_ssl = false;
+        ctx.awaiting_startup = false;
+
         let param_desc = ParameterDescription::new(vec![100, 200]);
-        roundtrip!(param_desc, ParameterDescription);
+        roundtrip!(param_desc, ParameterDescription, &ctx);
     }
 
     #[test]
     fn test_password_family() {
+        let mut ctx = DecodeContext::new(ProtocolVersion::PROTOCOL3_0);
+        ctx.awaiting_ssl = false;
+        ctx.awaiting_startup = false;
+
         let password = Password::new("tomcat".to_owned());
 
         let mut buffer = BytesMut::new();
         password.encode(&mut buffer).unwrap();
         assert!(buffer.remaining() > 0);
 
-        let decode_context = DecodeContext::new(ProtocolVersion::PROTOCOL3_0);
-
-        let item2 = PasswordMessageFamily::decode(&mut buffer, &decode_context)
+        let item2 = PasswordMessageFamily::decode(&mut buffer, &ctx)
             .unwrap()
             .unwrap();
         assert_eq!(buffer.remaining(), 0);
@@ -705,7 +798,7 @@ mod test {
         saslinitialresp.encode(&mut buffer).unwrap();
         assert!(buffer.remaining() > 0);
 
-        let item2 = PasswordMessageFamily::decode(&mut buffer, &decode_context)
+        let item2 = PasswordMessageFamily::decode(&mut buffer, &ctx)
             .unwrap()
             .unwrap();
         assert_eq!(buffer.remaining(), 0);
@@ -714,51 +807,79 @@ mod test {
 
     #[test]
     fn test_no_data() {
+        let mut ctx = DecodeContext::new(ProtocolVersion::PROTOCOL3_0);
+        ctx.awaiting_ssl = false;
+        ctx.awaiting_startup = false;
+
         let nodata = NoData::new();
-        roundtrip!(nodata, NoData);
+        roundtrip!(nodata, NoData, &ctx);
     }
 
     #[test]
     fn test_copy_data() {
+        let mut ctx = DecodeContext::new(ProtocolVersion::PROTOCOL3_0);
+        ctx.awaiting_ssl = false;
+        ctx.awaiting_startup = false;
+
         let copydata = CopyData::new(Bytes::from_static("tomcat".as_bytes()));
-        roundtrip!(copydata, CopyData);
+        roundtrip!(copydata, CopyData, &ctx);
     }
 
     #[test]
     fn test_copy_done() {
+        let mut ctx = DecodeContext::new(ProtocolVersion::PROTOCOL3_0);
+        ctx.awaiting_ssl = false;
+        ctx.awaiting_startup = false;
+
         let copydone = CopyDone::new();
-        roundtrip!(copydone, CopyDone);
+        roundtrip!(copydone, CopyDone, &ctx);
     }
 
     #[test]
     fn test_copy_fail() {
+        let mut ctx = DecodeContext::new(ProtocolVersion::PROTOCOL3_0);
+        ctx.awaiting_ssl = false;
+        ctx.awaiting_startup = false;
+
         let copyfail = CopyFail::new("copy failed".to_owned());
-        roundtrip!(copyfail, CopyFail);
+        roundtrip!(copyfail, CopyFail, &ctx);
     }
 
     #[test]
     fn test_copy_response() {
+        let mut ctx = DecodeContext::new(ProtocolVersion::PROTOCOL3_0);
+        ctx.awaiting_ssl = false;
+        ctx.awaiting_startup = false;
+
         let copyresponse = CopyInResponse::new(0, 3, vec![0, 0, 0]);
-        roundtrip!(copyresponse, CopyInResponse);
+        roundtrip!(copyresponse, CopyInResponse, &ctx);
 
         let copyresponse = CopyOutResponse::new(0, 3, vec![0, 0, 0]);
-        roundtrip!(copyresponse, CopyOutResponse);
+        roundtrip!(copyresponse, CopyOutResponse, &ctx);
 
         let copyresponse = CopyBothResponse::new(0, 3, vec![0, 0, 0]);
-        roundtrip!(copyresponse, CopyBothResponse);
+        roundtrip!(copyresponse, CopyBothResponse, &ctx);
     }
 
     #[test]
     fn test_notification_response() {
+        let mut ctx = DecodeContext::new(ProtocolVersion::PROTOCOL3_0);
+        ctx.awaiting_ssl = false;
+        ctx.awaiting_startup = false;
+
         let notification_response =
             NotificationResponse::new(10087, "channel".to_owned(), "payload".to_owned());
-        roundtrip!(notification_response, NotificationResponse);
+        roundtrip!(notification_response, NotificationResponse, &ctx);
     }
 
     #[test]
     fn test_negotiate_protocol_version() {
+        let mut ctx = DecodeContext::new(ProtocolVersion::PROTOCOL3_0);
+        ctx.awaiting_ssl = false;
+        ctx.awaiting_startup = false;
+
         let negotiate_protocol_version =
             NegotiateProtocolVersion::new(2, vec!["database".to_owned(), "user".to_owned()]);
-        roundtrip!(negotiate_protocol_version, NegotiateProtocolVersion);
+        roundtrip!(negotiate_protocol_version, NegotiateProtocolVersion, &ctx);
     }
 }

--- a/src/tokio/client.rs
+++ b/src/tokio/client.rs
@@ -42,9 +42,7 @@ impl Decoder for PgWireMessageClientCodec {
     type Error = PgWireError;
 
     fn decode(&mut self, src: &mut bytes::BytesMut) -> Result<Option<Self::Item>, Self::Error> {
-        let decode_context = DecodeContext {
-            protocol_version: self.protocol_version,
-        };
+        let decode_context = DecodeContext::default();
 
         //TODO: update protocol according to negotiation result
 
@@ -291,9 +289,9 @@ pub(crate) async fn ssl_handshake(
         } else {
             // postgres ssl handshake
             socket
-                .send(PgWireFrontendMessage::SslRequest(Some(
+                .send(PgWireFrontendMessage::SslRequest(
                     crate::messages::startup::SslRequest,
-                )))
+                ))
                 .await?;
 
             if let Some(Ok(PgWireBackendMessage::SslResponse(ssl_resp))) = socket.next().await {

--- a/src/tokio/server.rs
+++ b/src/tokio/server.rs
@@ -378,10 +378,6 @@ where
     CR: CancelHandler,
     E: ErrorHandler,
 {
-    // SslRequest is processed outside the decoder, so there we set state to
-    // AwaitingStartup by default
-    socket.set_state(PgWireConnectionState::AwaitingStartup);
-
     while let Some(Ok(msg)) = socket.next().await {
         let is_extended_query = match socket.state() {
             PgWireConnectionState::CopyInProgress(is_extended_query) => is_extended_query,

--- a/src/tokio/server.rs
+++ b/src/tokio/server.rs
@@ -378,6 +378,9 @@ where
     CR: CancelHandler,
     E: ErrorHandler,
 {
+    // for those steps without ssl negotiation
+    socket.set_state(PgWireConnectionState::AwaitingStartup);
+
     while let Some(Ok(msg)) = socket.next().await {
         let is_extended_query = match socket.state() {
             PgWireConnectionState::CopyInProgress(is_extended_query) => is_extended_query,


### PR DESCRIPTION
Previously, due to lack of connection state context, we are unable to fully decode Frontend messages in one decode function. Thanks to `DecodeContext` introduced in recent commits, it's now possible to provide state information and we can fully capable.