### PR TITLE
feat: GssEncRequest handshake

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,7 @@ this library.
 - Frontend-Backend interaction over TCP
   - [x] SSL Request and Response
     - [x] PostgreSQL 17 direct SSL negotiation
+  - [x] GSSAPI Request and Response: GSSAPI encryption is not supported
   - [x] Startup
     - [x] Protocol negotiation
     - [x] No authentication

--- a/src/error.rs
+++ b/src/error.rs
@@ -20,6 +20,8 @@ pub enum PgWireError {
     InvalidTransactionStatus(u8),
     #[error("Invalid ssl request message")]
     InvalidSSLRequestMessage,
+    #[error("Invalid gss encrypt request message")]
+    InvalidGssEncRequestMessage,
     #[error("Invalid startup message")]
     InvalidStartupMessage,
     #[error("Invalid authentication message code: {0}")]
@@ -244,6 +246,9 @@ impl From<PgWireError> for ErrorInfo {
                 ErrorInfo::new("FATAL".to_owned(), "08P01".to_owned(), error.to_string())
             }
             PgWireError::InvalidSSLRequestMessage => {
+                ErrorInfo::new("FATAL".to_owned(), "08P01".to_owned(), error.to_string())
+            }
+            PgWireError::InvalidGssEncRequestMessage => {
                 ErrorInfo::new("FATAL".to_owned(), "08P01".to_owned(), error.to_string())
             }
             PgWireError::InvalidStartupMessage => {

--- a/src/tokio/server.rs
+++ b/src/tokio/server.rs
@@ -328,42 +328,44 @@ async fn peek_for_sslrequest<ST>(
     socket: &mut Framed<TcpStream, PgWireMessageServerCodec<ST>>,
     ssl_supported: bool,
 ) -> Result<SslNegotiationType, io::Error> {
-    let tcp_socket = socket.get_ref();
-    if check_ssl_direct_negotiation(tcp_socket).await? {
+    if check_ssl_direct_negotiation(socket.get_ref()).await? {
         Ok(SslNegotiationType::Direct)
     } else {
-        let mut buf = [0u8; 8];
-        let n = tcp_socket.peek(&mut buf).await?;
+        loop {
+            let mut buf = [0u8; 8];
+            let n = socket.get_ref().peek(&mut buf).await?;
 
-        if n == buf.len() {
-            if SslRequest::is_ssl_request_packet(&buf) {
-                // consume SslRequest
-                let _ = socket.next().await;
-                // ssl request
-                if ssl_supported {
+            if n == buf.len() {
+                if SslRequest::is_ssl_request_packet(&buf) {
+                    // consume SslRequest
+                    let _ = socket.next().await;
+                    // ssl request
+                    if ssl_supported {
+                        socket
+                            .send(PgWireBackendMessage::SslResponse(SslResponse::Accept))
+                            .await?;
+                        return Ok(SslNegotiationType::Postgres);
+                    } else {
+                        socket
+                            .send(PgWireBackendMessage::SslResponse(SslResponse::Refuse))
+                            .await?;
+                        return Ok(SslNegotiationType::None);
+                    }
+                } else if GssEncRequest::is_gss_enc_request_packet(&buf) {
+                    let _ = socket.next().await;
                     socket
-                        .send(PgWireBackendMessage::SslResponse(SslResponse::Accept))
+                        .send(PgWireBackendMessage::GssEncResponse(GssEncResponse::Refuse))
                         .await?;
-                    Ok(SslNegotiationType::Postgres)
+                    // Continue to check for more requests (e.g., SSL request after GSSAPI refuse)
+                    continue;
                 } else {
-                    socket
-                        .send(PgWireBackendMessage::SslResponse(SslResponse::Refuse))
-                        .await?;
-                    Ok(SslNegotiationType::None)
+                    // startup or cancel
+                    return Ok(SslNegotiationType::None);
                 }
-            } else if GssEncRequest::is_gss_enc_request_packet(&buf) {
-                let _ = socket.next().await;
-                socket
-                    .send(PgWireBackendMessage::GssEncResponse(GssEncResponse::Refuse))
-                    .await?;
-                Ok(SslNegotiationType::None)
             } else {
-                // startup or cancel
-                Ok(SslNegotiationType::None)
+                // failed to peek, the connection may have gone
+                return Ok(SslNegotiationType::None);
             }
-        } else {
-            // failed to peek, the connection may have gone
-            Ok(SslNegotiationType::None)
         }
     }
 }


### PR DESCRIPTION
This patch adds support for GssEncRequest message codec and handshake support.

However, since we won't support GSSAPI encryption for now, the server will always reject handshake.