### PR TITLE
Support for GSSENCMODE=prefer SSLMODE=require - falling back to ssl mode

### DIFF
--- a/src/tokio/server.rs
+++ b/src/tokio/server.rs
@@ -328,42 +328,44 @@ async fn peek_for_sslrequest<ST>(
     socket: &mut Framed<TcpStream, PgWireMessageServerCodec<ST>>,
     ssl_supported: bool,
 ) -> Result<SslNegotiationType, io::Error> {
-    let tcp_socket = socket.get_ref();
-    if check_ssl_direct_negotiation(tcp_socket).await? {
+    if check_ssl_direct_negotiation(socket.get_ref()).await? {
         Ok(SslNegotiationType::Direct)
     } else {
-        let mut buf = [0u8; 8];
-        let n = tcp_socket.peek(&mut buf).await?;
+        loop {
+            let mut buf = [0u8; 8];
+            let n = socket.get_ref().peek(&mut buf).await?;
 
-        if n == buf.len() {
-            if SslRequest::is_ssl_request_packet(&buf) {
-                // consume SslRequest
-                let _ = socket.next().await;
-                // ssl request
-                if ssl_supported {
+            if n == buf.len() {
+                if SslRequest::is_ssl_request_packet(&buf) {
+                    // consume SslRequest
+                    let _ = socket.next().await;
+                    // ssl request
+                    if ssl_supported {
+                        socket
+                            .send(PgWireBackendMessage::SslResponse(SslResponse::Accept))
+                            .await?;
+                        return Ok(SslNegotiationType::Postgres);
+                    } else {
+                        socket
+                            .send(PgWireBackendMessage::SslResponse(SslResponse::Refuse))
+                            .await?;
+                        return Ok(SslNegotiationType::None);
+                    }
+                } else if GssEncRequest::is_gss_enc_request_packet(&buf) {
+                    let _ = socket.next().await;
                     socket
-                        .send(PgWireBackendMessage::SslResponse(SslResponse::Accept))
+                        .send(PgWireBackendMessage::GssEncResponse(GssEncResponse::Refuse))
                         .await?;
-                    Ok(SslNegotiationType::Postgres)
+                    // Continue to check for more requests (e.g., SSL request after GSSAPI refuse)
+                    continue;
                 } else {
-                    socket
-                        .send(PgWireBackendMessage::SslResponse(SslResponse::Refuse))
-                        .await?;
-                    Ok(SslNegotiationType::None)
+                    // startup or cancel
+                    return Ok(SslNegotiationType::None);
                 }
-            } else if GssEncRequest::is_gss_enc_request_packet(&buf) {
-                let _ = socket.next().await;
-                socket
-                    .send(PgWireBackendMessage::GssEncResponse(GssEncResponse::Refuse))
-                    .await?;
-                Ok(SslNegotiationType::None)
             } else {
-                // startup or cancel
-                Ok(SslNegotiationType::None)
+                // failed to peek, the connection may have gone
+                return Ok(SslNegotiationType::None);
             }
-        } else {
-            // failed to peek, the connection may have gone
-            Ok(SslNegotiationType::None)
         }
     }
 }


### PR DESCRIPTION
This adds support for "GSSMODE=prefer SSLMODE=require" 

Currently this fails but it should actually fallback to ssl mode since gss is preferred

```
psql "host=127.0.0.1 port=5433 user=myuser gssencmode=prefer sslmode=require dbname=postgres"
psql: error: connection to server at "127.0.0.1", port 5433 failed: server closed the connection unexpectedly
	This probably means the server terminated abnormally
	before or while processing the request.
	
```

This PR adds a loop to check required modes so that it falls back to when gss is not available ssl mode. 

```
psql "host=127.0.0.1 port=5433 user=myuser gssencmode=prefer sslmode=require dbname=postgres"
psql (14.18 (Homebrew), server 16.6-pgwire-0.31.1)
WARNING: psql major version 14, server major version 16.
         Some psql features might not work.
SSL connection (protocol: TLSv1.3, cipher: TLS_AES_256_GCM_SHA384, bits: 256, compression: off)
Type "help" for help.

postgres=>
\q 
```

If gssencmode is require, it fails the connection (as it should)

```
psql "host=127.0.0.1 port=5433 user=myuser gssencmode=require sslmode=require dbname=postgres"

psql: error: connection to server at "127.0.0.1", port 5433 failed: server doesn't support GSSAPI encryption, but it was required
```

Just for completeness, this will fail the connection if we run it against example/server.rs (since sslmode is required)

```
psql "host=127.0.0.1 port=5433 user=myuser gssencmode=prefer sslmode=require dbname=postgres"

psql: error: connection to server at "127.0.0.1", port 5433 failed: server does not support SSL, but SSL was required
```
