### PR TITLE
feat: packet length check

### DIFF
--- a/src/error.rs
+++ b/src/error.rs
@@ -14,6 +14,8 @@ pub enum PgWireError {
     InvalidSecretKey,
     #[error("Invalid message recevied, received {0}")]
     InvalidMessageType(u8),
+    #[error("Invalid message length, expected max {0}, actual: {1}")]
+    MessageTooLarge(usize, usize),
     #[error("Invalid target type, received {0}")]
     InvalidTargetType(u8),
     #[error("Invalid transaction status, received {0}")]
@@ -238,6 +240,9 @@ impl From<PgWireError> for ErrorInfo {
                 ErrorInfo::new("FATAL".to_owned(), "08P01".to_owned(), error.to_string())
             }
             PgWireError::InvalidTargetType(_) => {
+                ErrorInfo::new("FATAL".to_owned(), "08P01".to_owned(), error.to_string())
+            }
+            PgWireError::MessageTooLarge(..) => {
                 ErrorInfo::new("FATAL".to_owned(), "08P01".to_owned(), error.to_string())
             }
             PgWireError::InvalidTransactionStatus(_) => {

--- a/src/messages/copy.rs
+++ b/src/messages/copy.rs
@@ -19,6 +19,11 @@ impl Message for CopyData {
         Some(MESSAGE_TYPE_BYTE_COPY_DATA)
     }
 
+    #[inline]
+    fn max_message_length() -> usize {
+        super::LARGE_PACKET_SIZE_LIMIT
+    }
+
     fn message_length(&self) -> usize {
         4 + self.data.len()
     }
@@ -104,6 +109,11 @@ impl Message for CopyInResponse {
         Some(MESSAGE_TYPE_BYTE_COPY_IN_RESPONSE)
     }
 
+    #[inline]
+    fn max_message_length() -> usize {
+        super::SMALL_BACKEND_PACKET_SIZE_LIMIT
+    }
+
     fn message_length(&self) -> usize {
         4 + 1 + 2 + self.column_formats.len() * 2
     }
@@ -145,6 +155,11 @@ impl Message for CopyOutResponse {
         Some(MESSAGE_TYPE_BYTE_COPY_OUT_RESPONSE)
     }
 
+    #[inline]
+    fn max_message_length() -> usize {
+        super::SMALL_BACKEND_PACKET_SIZE_LIMIT
+    }
+
     fn message_length(&self) -> usize {
         4 + 1 + 2 + self.column_formats.len() * 2
     }
@@ -184,6 +199,11 @@ impl Message for CopyBothResponse {
     #[inline]
     fn message_type() -> Option<u8> {
         Some(MESSAGE_TYPE_BYTE_COPY_BOTH_RESPONSE)
+    }
+
+    #[inline]
+    fn max_message_length() -> usize {
+        super::SMALL_BACKEND_PACKET_SIZE_LIMIT
     }
 
     fn message_length(&self) -> usize {

--- a/src/messages/data.rs
+++ b/src/messages/data.rs
@@ -36,8 +36,14 @@ pub struct RowDescription {
 pub const MESSAGE_TYPE_BYTE_ROW_DESCRITION: u8 = b'T';
 
 impl Message for RowDescription {
+    #[inline]
     fn message_type() -> Option<u8> {
         Some(MESSAGE_TYPE_BYTE_ROW_DESCRITION)
+    }
+
+    #[inline]
+    fn max_message_length() -> usize {
+        super::LONG_BACKEND_PACKET_SIZE_LIMIT
     }
 
     fn message_length(&self) -> usize {
@@ -98,8 +104,14 @@ pub struct ParameterDescription {
 pub const MESSAGE_TYPE_BYTE_PARAMETER_DESCRITION: u8 = b't';
 
 impl Message for ParameterDescription {
+    #[inline]
     fn message_type() -> Option<u8> {
         Some(MESSAGE_TYPE_BYTE_PARAMETER_DESCRITION)
+    }
+
+    #[inline]
+    fn max_message_length() -> usize {
+        super::SMALL_BACKEND_PACKET_SIZE_LIMIT
     }
 
     fn message_length(&self) -> usize {
@@ -149,6 +161,11 @@ impl Message for DataRow {
         Some(MESSAGE_TYPE_BYTE_DATA_ROW)
     }
 
+    #[inline]
+    fn max_message_length() -> usize {
+        super::LONG_BACKEND_PACKET_SIZE_LIMIT
+    }
+
     fn message_length(&self) -> usize {
         4 + 2 + self.data.len()
     }
@@ -182,6 +199,11 @@ impl Message for NoData {
     #[inline]
     fn message_type() -> Option<u8> {
         Some(MESSAGE_TYPE_BYTE_NO_DATA)
+    }
+
+    #[inline]
+    fn max_message_length() -> usize {
+        super::SMALL_BACKEND_PACKET_SIZE_LIMIT
     }
 
     fn message_length(&self) -> usize {

--- a/src/messages/extendedquery.rs
+++ b/src/messages/extendedquery.rs
@@ -20,6 +20,11 @@ impl Message for Parse {
         Some(MESSAGE_TYPE_BYTE_PARSE)
     }
 
+    #[inline]
+    fn max_message_length() -> usize {
+        super::LARGE_PACKET_SIZE_LIMIT
+    }
+
     fn message_length(&self) -> usize {
         4 + codec::option_string_len(&self.name) // name
             + (1 + self.query.len()) // query
@@ -71,6 +76,11 @@ impl Message for ParseComplete {
     #[inline]
     fn message_type() -> Option<u8> {
         Some(MESSAGE_TYPE_BYTE_PARSE_COMPLETE)
+    }
+
+    #[inline]
+    fn max_message_length() -> usize {
+        super::SMALL_BACKEND_PACKET_SIZE_LIMIT
     }
 
     #[inline]
@@ -148,6 +158,11 @@ impl Message for CloseComplete {
     }
 
     #[inline]
+    fn max_message_length() -> usize {
+        super::SMALL_BACKEND_PACKET_SIZE_LIMIT
+    }
+
+    #[inline]
     fn message_length(&self) -> usize {
         4
     }
@@ -187,6 +202,11 @@ impl Message for Bind {
     #[inline]
     fn message_type() -> Option<u8> {
         Some(MESSAGE_TYPE_BYTE_BIND)
+    }
+
+    #[inline]
+    fn max_message_length() -> usize {
+        super::LARGE_PACKET_SIZE_LIMIT
     }
 
     fn message_length(&self) -> usize {
@@ -283,6 +303,11 @@ impl Message for BindComplete {
     #[inline]
     fn message_type() -> Option<u8> {
         Some(MESSAGE_TYPE_BYTE_BIND_COMPLETE)
+    }
+
+    #[inline]
+    fn max_message_length() -> usize {
+        super::SMALL_BACKEND_PACKET_SIZE_LIMIT
     }
 
     #[inline]
@@ -453,6 +478,11 @@ impl Message for PortalSuspended {
     #[inline]
     fn message_type() -> Option<u8> {
         Some(MESSAGE_TYPE_BYTE_PORTAL_SUSPENDED)
+    }
+
+    #[inline]
+    fn max_message_length() -> usize {
+        super::SMALL_BACKEND_PACKET_SIZE_LIMIT
     }
 
     #[inline]

--- a/src/messages/mod.rs
+++ b/src/messages/mod.rs
@@ -215,7 +215,7 @@ impl PgWireFrontendMessage {
             match first_byte {
                 // Password, SASLInitialResponse, SASLResponse can only be
                 // decoded under certain context
-                startup::MESSAGE_TYPE_BYTE_PASWORD_MESSAGE_FAMILY => {
+                startup::MESSAGE_TYPE_BYTE_PASSWORD_MESSAGE_FAMILY => {
                     startup::PasswordMessageFamily::decode(buf, ctx)
                         .map(|v| v.map(Self::PasswordMessageFamily))
                 }

--- a/src/messages/mod.rs
+++ b/src/messages/mod.rs
@@ -509,6 +509,13 @@ mod test {
 
         ctx.awaiting_ssl = false;
         roundtrip!(s, Startup, &ctx);
+
+        let mut s_too_large = Startup::default();
+        s_too_large
+            .parameters
+            .insert("user".to_owned(), "a".repeat(10000));
+        let mut buffer = BytesMut::new();
+        assert!(s_too_large.encode(&mut buffer).is_err());
     }
 
     #[test]
@@ -582,6 +589,10 @@ mod test {
 
         let cc = CommandComplete::new("DELETE 5".to_owned());
         roundtrip!(cc, CommandComplete, &ctx);
+
+        let cc = CommandComplete::new("DELETE 5".repeat(10_000));
+        let mut buffer = BytesMut::new();
+        assert!(cc.encode(&mut buffer).is_err());
     }
 
     #[test]

--- a/src/messages/response.rs
+++ b/src/messages/response.rs
@@ -19,6 +19,11 @@ impl Message for CommandComplete {
         Some(MESSAGE_TYPE_BYTE_COMMAND_COMPLETE)
     }
 
+    #[inline]
+    fn max_message_length() -> usize {
+        super::SMALL_BACKEND_PACKET_SIZE_LIMIT
+    }
+
     fn message_length(&self) -> usize {
         5 + self.tag.len()
     }
@@ -45,6 +50,11 @@ pub const MESSAGE_TYPE_BYTE_EMPTY_QUERY_RESPONSE: u8 = b'I';
 impl Message for EmptyQueryResponse {
     fn message_type() -> Option<u8> {
         Some(MESSAGE_TYPE_BYTE_EMPTY_QUERY_RESPONSE)
+    }
+
+    #[inline]
+    fn max_message_length() -> usize {
+        super::SMALL_BACKEND_PACKET_SIZE_LIMIT
     }
 
     fn message_length(&self) -> usize {
@@ -91,6 +101,11 @@ impl Message for ReadyForQuery {
     }
 
     #[inline]
+    fn max_message_length() -> usize {
+        super::SMALL_BACKEND_PACKET_SIZE_LIMIT
+    }
+
+    #[inline]
     fn message_length(&self) -> usize {
         5
     }
@@ -132,6 +147,11 @@ impl Message for ErrorResponse {
     #[inline]
     fn message_type() -> Option<u8> {
         Some(MESSAGE_TYPE_BYTE_ERROR_RESPONSE)
+    }
+
+    #[inline]
+    fn max_message_length() -> usize {
+        super::LONG_BACKEND_PACKET_SIZE_LIMIT
     }
 
     fn message_length(&self) -> usize {
@@ -177,6 +197,11 @@ impl Message for NoticeResponse {
     #[inline]
     fn message_type() -> Option<u8> {
         Some(MESSAGE_TYPE_BYTE_NOTICE_RESPONSE)
+    }
+
+    #[inline]
+    fn max_message_length() -> usize {
+        super::LONG_BACKEND_PACKET_SIZE_LIMIT
     }
 
     fn message_length(&self) -> usize {
@@ -284,6 +309,11 @@ impl Message for NotificationResponse {
     #[inline]
     fn message_type() -> Option<u8> {
         Some(MESSAGE_TYPE_BYTE_NOTIFICATION_RESPONSE)
+    }
+
+    #[inline]
+    fn max_message_length() -> usize {
+        super::LONG_BACKEND_PACKET_SIZE_LIMIT
     }
 
     fn message_length(&self) -> usize {

--- a/src/messages/simplequery.rs
+++ b/src/messages/simplequery.rs
@@ -24,6 +24,11 @@ impl Message for Query {
         5 + self.query.len()
     }
 
+    #[inline]
+    fn max_message_length() -> usize {
+        super::LARGE_PACKET_SIZE_LIMIT
+    }
+
     fn encode_body(&self, buf: &mut BytesMut) -> PgWireResult<()> {
         codec::put_cstring(buf, &self.query);
 


### PR DESCRIPTION
This patch adds a limit of packet length according to postgres' own implementation:

- small frontend message is no larger than 10_000
- large frontend message has a limit of 0x3fffffff - 1
- small backend message is no larger than 30_000
- large backend message has no size limit