### PR TITLE
feat: add startup timeout

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,7 +22,8 @@ tokio = { version = "1.19", features = [
     "net",
     "rt",
     "io-util",
-    "macros"
+    "macros",
+    "time"
 ], optional = true }
 tokio-util = { version = "0.7.3", features = ["codec", "io"], optional = true }
 tokio-rustls = { version = "0.26.2", optional = true, default-features = false, features = ["logging", "tls12"]}


### PR DESCRIPTION
Add timeout mechanism for startup process. Within 10 seconds (aligned with postgres), the client has to finish:

- encryption handshake
- tls handshake if possible
- startup and authentication

Otherwise we will drop the connection silently.
