### PR TITLE
fix: correct message length check

### DIFF
--- a/src/messages/cancel.rs
+++ b/src/messages/cancel.rs
@@ -56,7 +56,7 @@ impl Message for CancelRequest {
     fn decode(buf: &mut bytes::BytesMut, ctx: &DecodeContext) -> PgWireResult<Option<Self>> {
         if buf.remaining() >= startup::MINIMUM_STARTUP_MESSAGE_LEN {
             if Self::is_cancel_request_packet(buf) {
-                codec::decode_packet(buf, 0, |buf, full_len| {
+                codec::decode_packet(buf, 0, Self::max_message_length(), |buf, full_len| {
                     Self::decode_body(buf, full_len, ctx)
                 })
             } else {
@@ -74,13 +74,6 @@ impl Message for CancelRequest {
     ) -> PgWireResult<Self> {
         if msg_len < Self::MINIMUM_CANCEL_REQUEST_MESSAGE_LEN {
             return Err(PgWireError::InvalidCancelRequest);
-        }
-
-        if msg_len > Self::max_message_length() {
-            return Err(PgWireError::MessageTooLarge(
-                msg_len,
-                Self::max_message_length(),
-            ));
         }
 
         // skip cancel code

--- a/src/messages/mod.rs
+++ b/src/messages/mod.rs
@@ -110,14 +110,7 @@ pub trait Message: Sized {
     fn decode(buf: &mut BytesMut, ctx: &DecodeContext) -> PgWireResult<Option<Self>> {
         let offset = Self::message_type().is_some().into();
 
-        codec::decode_packet(buf, offset, |buf, full_len| {
-            if full_len > Self::max_message_length() {
-                return Err(PgWireError::MessageTooLarge(
-                    full_len,
-                    Self::max_message_length(),
-                ));
-            }
-
+        codec::decode_packet(buf, offset, Self::max_message_length(), |buf, full_len| {
             Self::decode_body(buf, full_len, ctx)
         })
     }

--- a/src/messages/startup.rs
+++ b/src/messages/startup.rs
@@ -73,7 +73,7 @@ impl Message for Startup {
     }
 
     fn decode(buf: &mut BytesMut, ctx: &DecodeContext) -> PgWireResult<Option<Self>> {
-        codec::decode_packet(buf, 0, |buf, full_len| {
+        codec::decode_packet(buf, 0, Self::max_message_length(), |buf, full_len| {
             Self::decode_body(buf, full_len, ctx)
         })
     }
@@ -85,13 +85,6 @@ impl Message for Startup {
         // with reading protocol numbers.
         if msg_len <= MINIMUM_STARTUP_MESSAGE_LEN {
             return Err(PgWireError::InvalidStartupMessage);
-        }
-
-        if msg_len > Self::max_message_length() {
-            return Err(PgWireError::MessageTooLarge(
-                msg_len,
-                Self::max_message_length(),
-            ));
         }
 
         // parse


### PR DESCRIPTION
We can still get blocked by messages with invalid size in previous implementation. This patch should fixed this issue. We will valid message length before checking available bytes.