### PR TITLE
fix: use bufstream for tls

### DIFF
--- a/src/tokio/server.rs
+++ b/src/tokio/server.rs
@@ -558,8 +558,10 @@ where
                     check_alpn_for_direct_ssl(&ssl_socket)?;
                 }
 
-                let mut socket =
-                    Framed::new(ssl_socket, PgWireMessageServerCodec::new(client_info));
+                let mut socket = Framed::new(
+                    BufStream::new(ssl_socket),
+                    PgWireMessageServerCodec::new(client_info),
+                );
 
                 do_process_socket(
                     &mut socket,


### PR DESCRIPTION
It's not critical to use bufstream for tls, but in order to keep code consistent I just made the switch