### PR TITLE
refactor: remove scram feature gate, discouple sasl and scram concept

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,8 +39,6 @@ jobs:
       run: cargo clippy --no-default-features --features server-api-ring -- -D warnings
     - name: Lint client api
       run: cargo clippy --features client-api-aws-lc-rs -- -D warnings
-    - name: Lint scram
-      run: cargo clippy --features scram -- -D warnings
 
   test:
     name: Test
@@ -62,11 +60,8 @@ jobs:
       run: cargo test --no-default-features
     - name: Run tests without tls
       run: cargo test --no-default-features --features server-api
-    - name: Run tests on additional scram+ring feature set
-      run: cargo test --no-default-features --features server-api-ring,scram
-    - name: Run tests on additional scram+aws-lc-rs feature set
-      if: runner.os != 'Windows'
-      run: cargo test --features scram
+    - name: Run tests on additional ring feature set
+      run: cargo test --no-default-features --features server-api-ring
     - name: Run tests for client api
       if: runner.os != 'Windows'
       run: cargo test --features client-api-aws-lc-rs
@@ -105,4 +100,3 @@ jobs:
     - run: cargo build --no-default-features
     - run: cargo build --no-default-features --features server-api
     - run: cargo build --no-default-features --features server-api-ring
-    - run: cargo build --features scram

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -53,8 +53,22 @@ percent-encoding = { version = "2.0", optional = true }
 
 [features]
 default = ["server-api-aws-lc-rs"]
-_ring = ["dep:ring", "tokio-rustls/ring", "dep:rustls-pki-types"]
-_aws-lc-rs = ["dep:aws-lc-rs", "tokio-rustls/aws-lc-rs", "dep:rustls-pki-types"]
+_ring = [
+  "dep:ring",
+  "tokio-rustls/ring",
+  "dep:rustls-pki-types",
+  "dep:base64",
+  "dep:stringprep",
+  "dep:x509-certificate",
+]
+_aws-lc-rs = [
+  "dep:aws-lc-rs",
+  "tokio-rustls/aws-lc-rs",
+  "dep:rustls-pki-types",
+  "dep:base64",
+  "dep:stringprep",
+  "dep:x509-certificate"
+]
 server-api = [
     "dep:tokio",
     "dep:tokio-util",
@@ -80,7 +94,6 @@ client-api = [
 ]
 client-api-ring = ["client-api", "_ring", "dep:rustls-pki-types"]
 client-api-aws-lc-rs = ["client-api", "_aws-lc-rs", "dep:rustls-pki-types"]
-scram = ["dep:base64", "dep:stringprep", "dep:x509-certificate"]
 _duckdb = []
 _sqlite = []
 _bundled = ["duckdb/bundled", "rusqlite/bundled"]
@@ -139,7 +152,7 @@ required-features = ["server-api-aws-lc-rs"]
 
 [[example]]
 name = "scram"
-required-features = ["server-api-aws-lc-rs", "scram"]
+required-features = ["server-api-aws-lc-rs"]
 
 [[example]]
 name = "transaction"

--- a/examples/duckdb.rs
+++ b/examples/duckdb.rs
@@ -26,6 +26,7 @@ pub struct DuckDBBackend {
     query_parser: Arc<NoopQueryParser>,
 }
 
+#[derive(Debug)]
 struct DummyAuthSource;
 
 #[async_trait]

--- a/examples/scram.rs
+++ b/examples/scram.rs
@@ -10,7 +10,7 @@ use tokio::net::TcpListener;
 use tokio_rustls::rustls::ServerConfig;
 use tokio_rustls::TlsAcceptor;
 
-use pgwire::api::auth::sasl::scram::gen_salted_password;
+use pgwire::api::auth::sasl::scram::{gen_salted_password, ScramAuth};
 use pgwire::api::auth::sasl::SASLAuthStartupHandler;
 use pgwire::api::auth::{
     AuthSource, DefaultServerParameterProvider, LoginInfo, Password, StartupHandler,
@@ -25,6 +25,7 @@ pub fn random_salt() -> Vec<u8> {
 
 const ITERATIONS: usize = 4096;
 
+#[derive(Debug)]
 struct DummyAuthDB;
 
 #[async_trait]
@@ -62,14 +63,13 @@ struct DummyProcessorFactory {
 
 impl PgWireServerHandlers for DummyProcessorFactory {
     fn startup_handler(&self) -> Arc<impl StartupHandler> {
-        let mut authenticator = SASLAuthStartupHandler::new(
-            Arc::new(DummyAuthDB),
-            Arc::new(DefaultServerParameterProvider::default()),
-        );
-        authenticator.set_iterations(ITERATIONS);
-        authenticator
-            .configure_certificate(self.cert.as_ref())
-            .unwrap();
+        let mut scram = ScramAuth::new(Arc::new(DummyAuthDB));
+        scram.set_iterations(ITERATIONS);
+        scram.configure_certificate(self.cert.as_ref()).unwrap();
+
+        let authenticator =
+            SASLAuthStartupHandler::new(Arc::new(DefaultServerParameterProvider::default()))
+                .with_scram(scram);
 
         Arc::new(authenticator)
     }

--- a/examples/scram.rs
+++ b/examples/scram.rs
@@ -10,7 +10,8 @@ use tokio::net::TcpListener;
 use tokio_rustls::rustls::ServerConfig;
 use tokio_rustls::TlsAcceptor;
 
-use pgwire::api::auth::scram::{gen_salted_password, SASLScramAuthStartupHandler};
+use pgwire::api::auth::sasl::scram::gen_salted_password;
+use pgwire::api::auth::sasl::SASLAuthStartupHandler;
 use pgwire::api::auth::{
     AuthSource, DefaultServerParameterProvider, LoginInfo, Password, StartupHandler,
 };
@@ -61,7 +62,7 @@ struct DummyProcessorFactory {
 
 impl PgWireServerHandlers for DummyProcessorFactory {
     fn startup_handler(&self) -> Arc<impl StartupHandler> {
-        let mut authenticator = SASLScramAuthStartupHandler::new(
+        let mut authenticator = SASLAuthStartupHandler::new(
             Arc::new(DummyAuthDB),
             Arc::new(DefaultServerParameterProvider::default()),
         );

--- a/examples/sqlite.rs
+++ b/examples/sqlite.rs
@@ -28,6 +28,7 @@ pub struct SqliteBackend {
     query_parser: Arc<NoopQueryParser>,
 }
 
+#[derive(Debug)]
 struct DummyAuthSource;
 
 #[async_trait]

--- a/src/api/auth/mod.rs
+++ b/src/api/auth/mod.rs
@@ -22,7 +22,7 @@ pub trait StartupHandler: Send + Sync {
         message: PgWireFrontendMessage,
     ) -> PgWireResult<()>
     where
-        C: ClientInfo + Sink<PgWireBackendMessage> + Unpin + Send,
+        C: ClientInfo + Sink<PgWireBackendMessage> + Unpin + Send + Sync,
         C::Error: Debug,
         PgWireError: From<<C as Sink<PgWireBackendMessage>>::Error>;
 }

--- a/src/api/auth/mod.rs
+++ b/src/api/auth/mod.rs
@@ -141,7 +141,7 @@ impl LoginInfo<'_> {
 /// authentication, salt is not required, while in md5pass, a 4-byte salt is
 /// needed.
 #[async_trait]
-pub trait AuthSource: Send + Sync {
+pub trait AuthSource: Send + Sync + Debug {
     /// Get password from the `AuthSource`.
     ///
     /// `Password` has a an optional salt field when it's hashed.

--- a/src/api/auth/mod.rs
+++ b/src/api/auth/mod.rs
@@ -252,5 +252,5 @@ where
 pub mod cleartext;
 pub mod md5pass;
 pub mod noop;
-#[cfg(feature = "scram")]
-pub mod scram;
+#[cfg(any(feature = "_aws-lc-rs", feature = "_ring"))]
+pub mod sasl;

--- a/src/api/auth/sasl.rs
+++ b/src/api/auth/sasl.rs
@@ -1,0 +1,168 @@
+use std::fmt::Debug;
+use std::sync::Arc;
+
+use async_trait::async_trait;
+use base64::engine::general_purpose::STANDARD;
+use base64::Engine;
+use futures::{Sink, SinkExt};
+use tokio::sync::Mutex;
+
+use crate::api::auth::{AuthSource, Password};
+use crate::api::{ClientInfo, PgWireConnectionState};
+use crate::error::{PgWireError, PgWireResult};
+use crate::messages::startup::{Authentication, PasswordMessageFamily};
+use crate::messages::{PgWireBackendMessage, PgWireFrontendMessage};
+
+use super::{ServerParameterProvider, StartupHandler};
+
+pub mod scram;
+
+#[derive(Debug)]
+pub enum SASLState {
+    Initial,
+    // scram authentication method selected
+    ScramClientFirstReceived,
+    // cached password, channel_binding and partial auth-message
+    ScramServerFirstSent(Password, String, String),
+    // finished
+    Finished,
+}
+
+impl SASLState {
+    fn is_scram(&self) -> bool {
+        matches!(
+            self,
+            SASLState::ScramClientFirstReceived | SASLState::ScramServerFirstSent(_, _, _)
+        )
+    }
+}
+
+#[derive(Debug)]
+pub struct SASLAuthStartupHandler<A, P> {
+    parameter_provider: Arc<P>,
+    /// state of the SASL auth
+    state: Mutex<SASLState>,
+    /// scram configuration
+    scram: scram::ScramAuth<A>,
+}
+
+impl<A, P> SASLAuthStartupHandler<A, P> {
+    const SCRAM_SHA_256: &str = "SCRAM-SHA-256";
+    const SCRAM_SHA_256_PLUS: &str = "SCRAM-SHA-256-PLUS";
+
+    fn supported_mechanisms(&self) -> Vec<String> {
+        if self.scram.server_cert_sig.is_some() {
+            vec![
+                Self::SCRAM_SHA_256.to_owned(),
+                Self::SCRAM_SHA_256_PLUS.to_owned(),
+            ]
+        } else {
+            vec![Self::SCRAM_SHA_256.to_owned()]
+        }
+    }
+}
+
+#[async_trait]
+impl<A: AuthSource, P: ServerParameterProvider> StartupHandler for SASLAuthStartupHandler<A, P> {
+    async fn on_startup<C>(
+        &self,
+        client: &mut C,
+        message: PgWireFrontendMessage,
+    ) -> PgWireResult<()>
+    where
+        C: ClientInfo + Sink<PgWireBackendMessage> + Unpin + Send + Sync,
+        C::Error: Debug,
+        PgWireError: From<<C as Sink<PgWireBackendMessage>>::Error>,
+    {
+        match message {
+            PgWireFrontendMessage::Startup(ref startup) => {
+                super::protocol_negotiation(client, startup).await?;
+                super::save_startup_parameters_to_metadata(client, startup);
+                client.set_state(PgWireConnectionState::AuthenticationInProgress);
+                let supported_mechanisms = self.supported_mechanisms();
+                client
+                    .send(PgWireBackendMessage::Authentication(Authentication::SASL(
+                        supported_mechanisms,
+                    )))
+                    .await?;
+            }
+            PgWireFrontendMessage::PasswordMessageFamily(mut msg) => {
+                let mut state = self.state.lock().await;
+                if let SASLState::Initial = *state {
+                    let sasl_initial_response = msg.into_sasl_initial_response()?;
+                    let selected_mechanism = sasl_initial_response.auth_method.as_str();
+
+                    if [Self::SCRAM_SHA_256, Self::SCRAM_SHA_256_PLUS].contains(&selected_mechanism)
+                    {
+                        *state = SASLState::ScramClientFirstReceived;
+                    } else {
+                        return Err(PgWireError::UnsupportedSASLAuthMethod(
+                            selected_mechanism.to_string(),
+                        ));
+                    }
+
+                    msg = PasswordMessageFamily::SASLInitialResponse(sasl_initial_response);
+                } else {
+                    let sasl_response = msg.into_sasl_response()?;
+                    msg = PasswordMessageFamily::SASLResponse(sasl_response);
+                }
+
+                // SCRAM authentication
+                if state.is_scram() {
+                    let (resp, new_state) = self
+                        .scram
+                        .process_scram_message(client, msg, &state)
+                        .await?;
+                    client
+                        .send(PgWireBackendMessage::Authentication(resp))
+                        .await?;
+                    *state = new_state;
+                }
+
+                if matches!(*state, SASLState::Finished) {
+                    super::finish_authentication(client, self.parameter_provider.as_ref()).await?;
+                }
+            }
+            _ => {}
+        }
+
+        Ok(())
+    }
+}
+
+impl<A, P> SASLAuthStartupHandler<A, P> {
+    pub fn new(auth_db: Arc<A>, parameter_provider: Arc<P>) -> Self {
+        SASLAuthStartupHandler {
+            parameter_provider,
+            state: Mutex::new(SASLState::Initial),
+            scram: scram::ScramAuth {
+                auth_db,
+                server_cert_sig: None,
+                iterations: 4096,
+            },
+        }
+    }
+
+    /// enable channel binding (SCRAM-SHA-256-PLUS) by configuring server
+    /// certificate.
+    ///
+    /// Original pem data is required here. We will decode pem and use the first
+    /// certificate as server certificate.
+    pub fn configure_certificate(&mut self, certs_pem: &[u8]) -> PgWireResult<()> {
+        let sig = scram::compute_cert_signature(certs_pem)?;
+        self.scram.server_cert_sig = Some(Arc::new(STANDARD.encode(sig)));
+        Ok(())
+    }
+
+    /// Set password hash iteration count, according to SCRAM RFC, a minimal of
+    /// 4096 is required.
+    ///
+    /// Note that this implementation does not hash password, it just tells
+    /// client to hash with this iteration count. You have to implement password
+    /// hashing in your `AuthSource` implementation, either after fetching
+    /// cleartext password, or before storing hashed password. And this number
+    /// should be identical to your `AuthSource` implementation.
+    pub fn set_iterations(&mut self, iterations: usize) {
+        self.scram.iterations = iterations;
+    }
+}

--- a/src/api/auth/sasl/scram.rs
+++ b/src/api/auth/sasl/scram.rs
@@ -4,80 +4,31 @@ use std::num::NonZeroU32;
 use std::ops::BitXor;
 use std::sync::Arc;
 
-use async_trait::async_trait;
 use base64::engine::general_purpose::STANDARD;
 use base64::Engine;
 use bytes::Bytes;
-use futures::{Sink, SinkExt};
-use tokio::sync::Mutex;
 use x509_certificate::certificate::CapturedX509Certificate;
 use x509_certificate::SignatureAlgorithm;
+
+use crate::api::auth::{AuthSource, LoginInfo};
+use crate::api::ClientInfo;
+use crate::error::{PgWireError, PgWireResult};
+use crate::messages::startup::{Authentication, PasswordMessageFamily};
+
+use super::SASLState;
 
 #[cfg(feature = "_aws-lc-rs")]
 use aws_lc_rs::{digest, hmac, pbkdf2};
 #[cfg(feature = "_ring")]
 use ring::{digest, hmac, pbkdf2};
 
-use crate::api::auth::{AuthSource, LoginInfo, Password};
-use crate::api::{ClientInfo, PgWireConnectionState};
-use crate::error::{PgWireError, PgWireResult};
-use crate::messages::startup::{Authentication, PasswordMessageFamily};
-use crate::messages::{PgWireBackendMessage, PgWireFrontendMessage};
-
-use super::{ServerParameterProvider, StartupHandler};
-
-#[derive(Debug)]
-pub enum SASLState {
-    Initial,
-    // scram authentication method selected
-    ScramClientFirstReceived,
-    // cached password, channel_binding and partial auth-message
-    ScramServerFirstSent(Password, String, String),
-    // finished
-    Finished,
-}
-
-impl SASLState {
-    fn is_scram(&self) -> bool {
-        matches!(
-            self,
-            SASLState::ScramClientFirstReceived | SASLState::ScramServerFirstSent(_, _, _)
-        )
-    }
-}
-
 #[derive(Debug)]
 pub struct ScramAuth<A> {
-    auth_db: Arc<A>,
+    pub(crate) auth_db: Arc<A>,
     /// base64 encoded certificate signature for tls-server-end-point channel binding
-    server_cert_sig: Option<Arc<String>>,
+    pub(crate) server_cert_sig: Option<Arc<String>>,
     /// iterations
-    iterations: usize,
-}
-
-#[derive(Debug)]
-pub struct SASLAuthStartupHandler<A, P> {
-    parameter_provider: Arc<P>,
-    /// state of the SASL auth
-    state: Mutex<SASLState>,
-    /// scram configuration
-    scram: ScramAuth<A>,
-}
-
-impl<A, P> SASLAuthStartupHandler<A, P> {
-    const SCRAM_SHA_256: &str = "SCRAM-SHA-256";
-    const SCRAM_SHA_256_PLUS: &str = "SCRAM-SHA-256-PLUS";
-
-    fn supported_mechanisms(&self) -> Vec<String> {
-        if self.scram.server_cert_sig.is_some() {
-            vec![
-                Self::SCRAM_SHA_256.to_owned(),
-                Self::SCRAM_SHA_256_PLUS.to_owned(),
-            ]
-        } else {
-            vec![Self::SCRAM_SHA_256.to_owned()]
-        }
-    }
+    pub(crate) iterations: usize,
 }
 
 /// Compute salted password from raw password as defined in
@@ -118,7 +69,7 @@ impl<A: AuthSource> ScramAuth<A> {
     }
 
     /// Process incoming message and return response, new state
-    async fn process_scram_message<C>(
+    pub async fn process_scram_message<C>(
         &self,
         client: &C,
         msg: PasswordMessageFamily,
@@ -209,113 +160,8 @@ impl<A: AuthSource> ScramAuth<A> {
                     ))
                 }
             }
-            _ => {
-                todo!("unexpected state")
-            }
+            _ => Err(PgWireError::InvalidSASLState),
         }
-    }
-}
-
-#[async_trait]
-impl<A: AuthSource, P: ServerParameterProvider> StartupHandler for SASLAuthStartupHandler<A, P> {
-    async fn on_startup<C>(
-        &self,
-        client: &mut C,
-        message: PgWireFrontendMessage,
-    ) -> PgWireResult<()>
-    where
-        C: ClientInfo + Sink<PgWireBackendMessage> + Unpin + Send + Sync,
-        C::Error: Debug,
-        PgWireError: From<<C as Sink<PgWireBackendMessage>>::Error>,
-    {
-        match message {
-            PgWireFrontendMessage::Startup(ref startup) => {
-                super::protocol_negotiation(client, startup).await?;
-                super::save_startup_parameters_to_metadata(client, startup);
-                client.set_state(PgWireConnectionState::AuthenticationInProgress);
-                let supported_mechanisms = self.supported_mechanisms();
-                client
-                    .send(PgWireBackendMessage::Authentication(Authentication::SASL(
-                        supported_mechanisms,
-                    )))
-                    .await?;
-            }
-            PgWireFrontendMessage::PasswordMessageFamily(mut msg) => {
-                let mut state = self.state.lock().await;
-                if let SASLState::Initial = *state {
-                    let sasl_initial_response = msg.into_sasl_initial_response()?;
-                    let selected_mechanism = sasl_initial_response.auth_method.as_str();
-
-                    if [Self::SCRAM_SHA_256, Self::SCRAM_SHA_256_PLUS].contains(&selected_mechanism)
-                    {
-                        *state = SASLState::ScramClientFirstReceived;
-                    } else {
-                        todo!("unexpected method")
-                    }
-
-                    msg = PasswordMessageFamily::SASLInitialResponse(sasl_initial_response);
-                } else {
-                    let sasl_response = msg.into_sasl_response()?;
-                    msg = PasswordMessageFamily::SASLResponse(sasl_response);
-                }
-
-                // SCRAM authentication
-                if state.is_scram() {
-                    let (resp, new_state) = self
-                        .scram
-                        .process_scram_message(client, msg, &state)
-                        .await?;
-                    client
-                        .send(PgWireBackendMessage::Authentication(resp))
-                        .await?;
-                    *state = new_state;
-                }
-
-                if matches!(*state, SASLState::Finished) {
-                    super::finish_authentication(client, self.parameter_provider.as_ref()).await?;
-                }
-            }
-            _ => {}
-        }
-
-        Ok(())
-    }
-}
-
-impl<A, P> SASLAuthStartupHandler<A, P> {
-    pub fn new(auth_db: Arc<A>, parameter_provider: Arc<P>) -> Self {
-        SASLAuthStartupHandler {
-            parameter_provider,
-            state: Mutex::new(SASLState::Initial),
-            scram: ScramAuth {
-                auth_db,
-                server_cert_sig: None,
-                iterations: 4096,
-            },
-        }
-    }
-
-    /// enable channel binding (SCRAM-SHA-256-PLUS) by configuring server
-    /// certificate.
-    ///
-    /// Original pem data is required here. We will decode pem and use the first
-    /// certificate as server certificate.
-    pub fn configure_certificate(&mut self, certs_pem: &[u8]) -> PgWireResult<()> {
-        let sig = compute_cert_signature(certs_pem)?;
-        self.scram.server_cert_sig = Some(Arc::new(STANDARD.encode(sig)));
-        Ok(())
-    }
-
-    /// Set password hash iteration count, according to SCRAM RFC, a minimal of
-    /// 4096 is required.
-    ///
-    /// Note that this implementation does not hash password, it just tells
-    /// client to hash with this iteration count. You have to implement password
-    /// hashing in your `AuthSource` implementation, either after fetching
-    /// cleartext password, or before storing hashed password. And this number
-    /// should be identical to your `AuthSource` implementation.
-    pub fn set_iterations(&mut self, iterations: usize) {
-        self.scram.iterations = iterations;
     }
 }
 
@@ -483,7 +329,7 @@ fn xor(lhs: &[u8], rhs: &[u8]) -> Vec<u8> {
 /// 2. use the certificate's algorithm if it's neither md5 or sha-1
 /// 3. if the certificate has 0 or more than 1 signature algorithm, the
 ///    behaviour is undefined at the time.
-fn compute_cert_signature(cert: &[u8]) -> PgWireResult<Vec<u8>> {
+pub(super) fn compute_cert_signature(cert: &[u8]) -> PgWireResult<Vec<u8>> {
     let certs = CapturedX509Certificate::from_pem_multiple(cert)
         .map_err(|e| PgWireError::ApiError(Box::new(e)))?;
     let x509 = &certs[0];

--- a/src/error.rs
+++ b/src/error.rs
@@ -30,6 +30,10 @@ pub enum PgWireError {
     InvalidAuthenticationMessageCode(i32),
     #[error("Invalid password message type, failed to coerce")]
     FailedToCoercePasswordMessage,
+    #[error("Invalid SASL state")]
+    InvalidSASLState,
+    #[error("Unsupported SASL authentication method {0}")]
+    UnsupportedSASLAuthMethod(String),
     #[error(transparent)]
     IoError(#[from] std::io::Error),
     #[error("Portal not found for name: {0}")]
@@ -266,6 +270,12 @@ impl From<PgWireError> for ErrorInfo {
             }
             PgWireError::FailedToCoercePasswordMessage => {
                 ErrorInfo::new("FATAL".to_owned(), "XX000".to_owned(), error.to_string())
+            }
+            PgWireError::InvalidSASLState => {
+                ErrorInfo::new("FATAL".to_owned(), "XX000".to_owned(), error.to_string())
+            }
+            PgWireError::UnsupportedSASLAuthMethod(_) => {
+                ErrorInfo::new("FATAL".to_owned(), "08P01".to_owned(), error.to_string())
             }
             PgWireError::IoError(_) => {
                 ErrorInfo::new("FATAL".to_owned(), "58030".to_owned(), error.to_string())

--- a/src/error.rs
+++ b/src/error.rs
@@ -28,6 +28,8 @@ pub enum PgWireError {
     InvalidStartupMessage,
     #[error("Invalid authentication message code: {0}")]
     InvalidAuthenticationMessageCode(i32),
+    #[error("Invalid password message type, failed to coerce")]
+    FailedToCoercePasswordMessage,
     #[error(transparent)]
     IoError(#[from] std::io::Error),
     #[error("Portal not found for name: {0}")]
@@ -261,6 +263,9 @@ impl From<PgWireError> for ErrorInfo {
             }
             PgWireError::InvalidAuthenticationMessageCode(_) => {
                 ErrorInfo::new("FATAL".to_owned(), "08P01".to_owned(), error.to_string())
+            }
+            PgWireError::FailedToCoercePasswordMessage => {
+                ErrorInfo::new("FATAL".to_owned(), "XX000".to_owned(), error.to_string())
             }
             PgWireError::IoError(_) => {
                 ErrorInfo::new("FATAL".to_owned(), "58030".to_owned(), error.to_string())

--- a/src/messages/startup.rs
+++ b/src/messages/startup.rs
@@ -287,53 +287,38 @@ impl Message for PasswordMessageFamily {
 
 impl PasswordMessageFamily {
     /// Coerce the raw message into `Password`
-    ///
-    /// # Panics
-    ///
-    /// Panic when the message is already coerced into concrete type.
     pub fn into_password(self) -> PgWireResult<Password> {
-        if let PasswordMessageFamily::Raw(mut body) = self {
-            let len = body.len() + 4;
-            Password::decode_body(&mut body, len, &DecodeContext::default())
-        } else {
-            unreachable!(
-                "Do not coerce password message when it has a concrete type {:?}",
-                self
-            )
+        match self {
+            PasswordMessageFamily::Raw(mut body) => {
+                let len = body.len() + 4;
+                Password::decode_body(&mut body, len, &DecodeContext::default())
+            }
+            PasswordMessageFamily::Password(pass) => Ok(pass),
+            _ => Err(PgWireError::FailedToCoercePasswordMessage),
         }
     }
 
     /// Coerce the raw message into `SASLInitialResponse`
-    ///
-    /// # Panics
-    ///
-    /// Panic when the message is already coerced into concrete type.
     pub fn into_sasl_initial_response(self) -> PgWireResult<SASLInitialResponse> {
-        if let PasswordMessageFamily::Raw(mut body) = self {
-            let len = body.len() + 4;
-            SASLInitialResponse::decode_body(&mut body, len, &DecodeContext::default())
-        } else {
-            unreachable!(
-                "Do not coerce password message when it has a concrete type {:?}",
-                self
-            )
+        match self {
+            PasswordMessageFamily::Raw(mut body) => {
+                let len = body.len() + 4;
+                SASLInitialResponse::decode_body(&mut body, len, &DecodeContext::default())
+            }
+            PasswordMessageFamily::SASLInitialResponse(msg) => Ok(msg),
+            _ => Err(PgWireError::FailedToCoercePasswordMessage),
         }
     }
 
     /// Coerce the raw message into `SASLResponse`
-    ///
-    /// # Panics
-    ///
-    /// Panic when the message is already coerced into concrete type.
     pub fn into_sasl_response(self) -> PgWireResult<SASLResponse> {
-        if let PasswordMessageFamily::Raw(mut body) = self {
-            let len = body.len() + 4;
-            SASLResponse::decode_body(&mut body, len, &DecodeContext::default())
-        } else {
-            unreachable!(
-                "Do not coerce password message when it has a concrete type {:?}",
-                self
-            )
+        match self {
+            PasswordMessageFamily::Raw(mut body) => {
+                let len = body.len() + 4;
+                SASLResponse::decode_body(&mut body, len, &DecodeContext::default())
+            }
+            PasswordMessageFamily::SASLResponse(msg) => Ok(msg),
+            _ => Err(PgWireError::FailedToCoercePasswordMessage),
         }
     }
 }

--- a/tests-integration/test-server/Cargo.toml
+++ b/tests-integration/test-server/Cargo.toml
@@ -7,7 +7,7 @@ publish = false
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-pgwire = { path = "../../", features = ["scram"] }
+pgwire = { path = "../../" }
 async-trait = "0.1"
 futures = "0.3"
 tokio = { version = "1", features = ["full"] }


### PR DESCRIPTION
This is a refactor step before we can have #298 in our SASL framework.

- decoupled concept of SASL and scram: SASL is an authentication framework, renamed `SASLScramAuthStartupHandler` to `SASLAuthStartupHandler`
- made scram enabled with ring or aws-lc-rs presents
- add `Sync` marker to `client` in `StartupHandler`
- removed panic behaviour for `PasswordMessageFamily`

