### PR TITLE
refactor: store unfinished data stream in portal

### DIFF
--- a/src/api/mod.rs
+++ b/src/api/mod.rs
@@ -72,11 +72,8 @@ pub trait ClientInfo {
 /// Client Portal Store
 pub trait ClientPortalStore {
     type PortalStore;
-    type PortalSuspendedResult;
 
     fn portal_store(&self) -> &Self::PortalStore;
-
-    fn portal_suspended_result(&self) -> &Self::PortalSuspendedResult;
 }
 
 pub const METADATA_USER: &str = "user";
@@ -93,7 +90,6 @@ pub struct DefaultClient<S> {
     pub transaction_status: TransactionStatus,
     pub metadata: HashMap<String, String>,
     pub portal_store: store::MemPortalStore<S>,
-    pub suspended_portal_results: store::MemPortalSuspendedResult,
 }
 
 impl<S> ClientInfo for DefaultClient<S> {
@@ -162,21 +158,15 @@ impl<S> DefaultClient<S> {
             transaction_status: TransactionStatus::Idle,
             metadata: HashMap::new(),
             portal_store: store::MemPortalStore::new(),
-            suspended_portal_results: store::MemPortalSuspendedResult::new(),
         }
     }
 }
 
 impl<S> ClientPortalStore for DefaultClient<S> {
     type PortalStore = store::MemPortalStore<S>;
-    type PortalSuspendedResult = store::MemPortalSuspendedResult;
 
     fn portal_store(&self) -> &Self::PortalStore {
         &self.portal_store
-    }
-
-    fn portal_suspended_result(&self) -> &Self::PortalSuspendedResult {
-        &self.suspended_portal_results
     }
 }
 

--- a/src/api/portal.rs
+++ b/src/api/portal.rs
@@ -5,7 +5,7 @@ use bytes::Bytes;
 use postgres_types::FromSqlOwned;
 use tokio::sync::Mutex;
 
-use crate::api::results::SendableRowStream;
+use crate::api::results::QueryResponse;
 use crate::api::Type;
 use crate::error::{PgWireError, PgWireResult};
 use crate::messages::data::FORMAT_CODE_BINARY;
@@ -28,23 +28,13 @@ pub struct Portal<S> {
     pub state: Arc<Mutex<PortalExecutionState>>,
 }
 
-#[derive(Default)]
+#[derive(Default, Debug)]
 pub enum PortalExecutionState {
     #[default]
     Initial,
     // tag and data stream
-    Suspended((String, SendableRowStream)),
+    Suspended(QueryResponse),
     Finished,
-}
-
-impl Debug for PortalExecutionState {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        match self {
-            PortalExecutionState::Initial => write!(f, "Initial"),
-            PortalExecutionState::Finished => write!(f, "Finished"),
-            PortalExecutionState::Suspended(_) => write!(f, "Suspended"),
-        }
-    }
 }
 
 #[derive(Debug, Clone, Default)]

--- a/src/api/results.rs
+++ b/src/api/results.rs
@@ -191,12 +191,8 @@ impl QueryResponse {
     }
 
     /// Get access to data rows stream
-    pub fn data_rows(&self) -> &SendableRowStream {
-        &self.data_rows
-    }
-
-    pub fn take_data_rows(self) -> SendableRowStream {
-        self.data_rows
+    pub fn data_rows(&mut self) -> &mut SendableRowStream {
+        &mut self.data_rows
     }
 }
 

--- a/src/api/store.rs
+++ b/src/api/store.rs
@@ -2,7 +2,6 @@ use std::collections::BTreeMap;
 use std::sync::{Arc, RwLock};
 
 use super::portal::Portal;
-use super::results::QueryResponse;
 use super::stmt::StoredStatement;
 
 pub trait PortalStore: Send + Sync {
@@ -60,29 +59,5 @@ impl<S: Clone + Send + Sync> PortalStore for MemPortalStore<S> {
     fn get_portal(&self, name: &str) -> Option<Arc<Portal<Self::Statement>>> {
         let guard = self.portals.read().unwrap();
         guard.get(name).cloned()
-    }
-}
-
-pub trait PortalSuspendedResult {
-    fn put_result(&self, name: &str, result: QueryResponse);
-
-    fn take_result(&self, name: &str) -> Option<QueryResponse>;
-}
-
-#[derive(Debug, Default, new)]
-pub struct MemPortalSuspendedResult {
-    #[new(default)]
-    results: RwLock<BTreeMap<String, QueryResponse>>,
-}
-
-impl PortalSuspendedResult for MemPortalSuspendedResult {
-    fn put_result(&self, name: &str, result: QueryResponse) {
-        let mut guard = self.results.write().unwrap();
-        guard.insert(name.to_owned(), result);
-    }
-
-    fn take_result(&self, name: &str) -> Option<QueryResponse> {
-        let mut guard = self.results.write().unwrap();
-        guard.remove(name)
     }
 }

--- a/src/tokio/server.rs
+++ b/src/tokio/server.rs
@@ -141,14 +141,9 @@ impl<T: 'static, S> ClientInfo for Framed<T, PgWireMessageServerCodec<S>> {
 
 impl<T, S> ClientPortalStore for Framed<T, PgWireMessageServerCodec<S>> {
     type PortalStore = <DefaultClient<S> as ClientPortalStore>::PortalStore;
-    type PortalSuspendedResult = <DefaultClient<S> as ClientPortalStore>::PortalSuspendedResult;
 
     fn portal_store(&self) -> &Self::PortalStore {
         self.codec().client_info.portal_store()
-    }
-
-    fn portal_suspended_result(&self) -> &Self::PortalSuspendedResult {
-        self.codec().client_info.portal_suspended_result()
     }
 }
 


### PR DESCRIPTION
This patch removes `PortalSuspendedResults` introduced in #303 and use portal itself to hold a state for it. It keeps tracking portal state with: 

- `Initial`: unexecuted portal
- `Suspended`: portal partially fetched
- `Finished`: portal completely fetched

This also removes mutex from the stream in `QueryResponse`. The stream will be moved accordingly as execution state advances.

Partially for #305 

@xhwhis 