### PR TITLE
refactor: accept generic stream in QueryResponse::new

### DIFF
--- a/examples/bench.rs
+++ b/examples/bench.rs
@@ -54,7 +54,7 @@ impl SimpleQueryHandler for DummyProcessor {
 
         Ok(vec![Response::Query(QueryResponse::new(
             schema,
-            Box::pin(data_row_stream),
+            data_row_stream,
         ))])
     }
 }

--- a/examples/common/mod.rs
+++ b/examples/common/mod.rs
@@ -65,7 +65,7 @@ impl SimpleQueryHandler for DummyProcessor {
 
             Ok(vec![Response::Query(QueryResponse::new(
                 schema,
-                Box::pin(data_row_stream),
+                data_row_stream,
             ))])
         } else {
             Ok(vec![Response::Execution(Tag::new("OK").with_rows(1))])

--- a/examples/duckdb.rs
+++ b/examples/duckdb.rs
@@ -68,7 +68,7 @@ impl SimpleQueryHandler for DuckDBBackend {
                 .collect::<Vec<_>>();
             Ok(vec![Response::Query(QueryResponse::new(
                 header,
-                Box::pin(stream::iter(data.into_iter())),
+                stream::iter(data.into_iter()),
             ))])
         } else {
             conn.execute(query, params![])
@@ -188,7 +188,7 @@ impl ExtendedQueryHandler for DuckDBBackend {
 
             Ok(Response::Query(QueryResponse::new(
                 header,
-                Box::pin(stream::iter(data)),
+                stream::iter(data),
             )))
         } else {
             stmt.execute::<&[&dyn duckdb::ToSql]>(params_ref.as_ref())

--- a/examples/gluesql.rs
+++ b/examples/gluesql.rs
@@ -6,9 +6,7 @@ use gluesql::prelude::*;
 use tokio::net::TcpListener;
 
 use pgwire::api::query::SimpleQueryHandler;
-use pgwire::api::results::{
-    DataRowEncoder, FieldFormat, FieldInfo, QueryResponse, Response, SendableRowStream, Tag,
-};
+use pgwire::api::results::{DataRowEncoder, FieldFormat, FieldInfo, QueryResponse, Response, Tag};
 use pgwire::api::{ClientInfo, PgWireServerHandlers, Type};
 use pgwire::error::{PgWireError, PgWireResult};
 use pgwire::tokio::process_socket;
@@ -129,7 +127,7 @@ impl SimpleQueryHandler for GluesqlProcessor {
 
                             Ok(Response::Query(QueryResponse::new(
                                 fields,
-                                Box::pin(stream::iter(results)) as SendableRowStream,
+                                stream::iter(results),
                             )))
                         }
                         Payload::Insert(rows) => Ok(Response::Execution(

--- a/examples/sqlite.rs
+++ b/examples/sqlite.rs
@@ -59,10 +59,7 @@ impl SimpleQueryHandler for SqliteBackend {
             stmt.query(())
                 .map(|rows| {
                     let s = encode_row_data(rows, header.clone());
-                    vec![Response::Query(QueryResponse::new(
-                        header,
-                        Box::pin(s) as SendableRowStream,
-                    ))]
+                    vec![Response::Query(QueryResponse::new(header, s))]
                 })
                 .map_err(|e| PgWireError::ApiError(Box::new(e)))
         } else {
@@ -223,7 +220,7 @@ impl ExtendedQueryHandler for SqliteBackend {
             stmt.query::<&[&dyn rusqlite::ToSql]>(params_ref.as_ref())
                 .map(|rows| {
                     let s = encode_row_data(rows, header.clone());
-                    Response::Query(QueryResponse::new(header, Box::pin(s) as SendableRowStream))
+                    Response::Query(QueryResponse::new(header, s))
                 })
                 .map_err(|e| PgWireError::ApiError(Box::new(e)))
         } else {

--- a/examples/transaction.rs
+++ b/examples/transaction.rs
@@ -8,9 +8,7 @@ use tokio::net::TcpListener;
 
 use pgwire::api::auth::noop::NoopStartupHandler;
 use pgwire::api::query::SimpleQueryHandler;
-use pgwire::api::results::{
-    DataRowEncoder, FieldFormat, FieldInfo, QueryResponse, Response, SendableRowStream, Tag,
-};
+use pgwire::api::results::{DataRowEncoder, FieldFormat, FieldInfo, QueryResponse, Response, Tag};
 use pgwire::api::{ClientInfo, PgWireServerHandlers, Type};
 use pgwire::error::{ErrorInfo, PgWireError, PgWireResult};
 use pgwire::messages::response::NoticeResponse;
@@ -71,10 +69,7 @@ impl SimpleQueryHandler for DummyProcessor {
                     encoder.finish()
                 };
                 let data_row_stream = stream::iter(vec![row]);
-                Response::Query(QueryResponse::new(
-                    schema,
-                    Box::pin(data_row_stream) as SendableRowStream,
-                ))
+                Response::Query(QueryResponse::new(schema, data_row_stream))
             }
             _ => Response::Error(Box::new(ErrorInfo::new(
                 "FATAL".to_string(),

--- a/src/api/results.rs
+++ b/src/api/results.rs
@@ -165,11 +165,14 @@ impl Debug for QueryResponse {
 impl QueryResponse {
     /// Create `QueryResponse` from column schemas and stream of data row.
     /// Sets "SELECT" as the command tag.
-    pub fn new(field_defs: Arc<Vec<FieldInfo>>, row_stream: SendableRowStream) -> QueryResponse {
+    pub fn new<S>(field_defs: Arc<Vec<FieldInfo>>, row_stream: S) -> QueryResponse
+    where
+        S: Stream<Item = PgWireResult<DataRow>> + Send + 'static,
+    {
         QueryResponse {
             command_tag: "SELECT".to_owned(),
             row_schema: field_defs,
-            data_rows: Mutex::new(row_stream),
+            data_rows: Mutex::new(Box::pin(row_stream)),
         }
     }
 


### PR DESCRIPTION
Call `Box::pin` in `QueryReponse::new` so user won't need to call it.

Partially in #305 