### PR TITLE
feat: from/to sql text for json/serde types

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -44,19 +44,18 @@ aws-lc-rs = { version = "1.7", optional = true }
 stringprep = { version = "0.1.2", optional = true }
 x509-certificate = { version = "0.25", optional = true }
 ## types
-postgres-types = { version = "0.2", features = [
-  "with-chrono-0_4",
-  "array-impls",
-], optional = true }
+postgres-types = { version = "0.2", features = ["array-impls"], optional = true }
 chrono = { version = "0.4", features = ["std"], optional = true }
 rust_decimal = { version = "1.35", features = ["db-postgres"], optional = true }
+serde = { version = "1", optional = true }
+serde_json = { version = "1", optional = true }
 lazy-regex = { version = "3.3", default-features = false, features = ["lite"] }
 ## config
 percent-encoding = { version = "2.0", optional = true }
 
 [features]
 default = ["server-api-aws-lc-rs", "pg_ext_types"]
-pg_ext_types = ["pg_type_chrono", "pg_type_rust_decimal"]
+pg_ext_types = ["pg_type_chrono", "pg_type_rust_decimal", "pg_type_serde_json"]
 _ring = [
   "dep:ring",
   "tokio-rustls/ring",
@@ -96,8 +95,9 @@ client-api = [
 ]
 client-api-ring = ["client-api", "_ring", "dep:rustls-pki-types"]
 client-api-aws-lc-rs = ["client-api", "_aws-lc-rs", "dep:rustls-pki-types"]
-pg_type_chrono = ["dep:chrono"]
+pg_type_chrono = ["dep:chrono", "postgres-types/with-chrono-0_4"]
 pg_type_rust_decimal = ["dep:rust_decimal"]
+pg_type_serde_json = ["dep:serde", "dep:serde_json", "postgres-types/with-serde_json-1"]
 _sqlite = []
 _bundled = ["rusqlite/bundled"]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -55,7 +55,8 @@ lazy-regex = { version = "3.3", default-features = false, features = ["lite"] }
 percent-encoding = { version = "2.0", optional = true }
 
 [features]
-default = ["server-api-aws-lc-rs"]
+default = ["server-api-aws-lc-rs", "pg_ext_types"]
+pg_ext_types = ["pg_type_chrono", "pg_type_rust_decimal"]
 _ring = [
   "dep:ring",
   "tokio-rustls/ring",
@@ -81,8 +82,6 @@ server-api = [
   "dep:md5",
   "dep:hex",
   "dep:postgres-types",
-  "dep:chrono",
-  "dep:rust_decimal",
 ]
 server-api-ring = ["server-api", "_ring"]
 server-api-aws-lc-rs = ["server-api", "_aws-lc-rs"]
@@ -97,6 +96,8 @@ client-api = [
 ]
 client-api-ring = ["client-api", "_ring", "dep:rustls-pki-types"]
 client-api-aws-lc-rs = ["client-api", "_aws-lc-rs", "dep:rustls-pki-types"]
+pg_type_chrono = ["dep:chrono"]
+pg_type_rust_decimal = ["dep:rust_decimal"]
 _sqlite = []
 _bundled = ["rusqlite/bundled"]
 

--- a/src/api/client/result.rs
+++ b/src/api/client/result.rs
@@ -43,7 +43,7 @@ impl DataRowDecoder<'_> {
     /// Get value from data row
     pub fn next_value<T>(&mut self) -> PgWireClientResult<Option<T>>
     where
-        T: FromSqlOwned + FromSqlText,
+        T: FromSqlOwned + for<'a> FromSqlText<'a>,
     {
         if let Some(field_info) = self.fields.get(self.read_index) {
             // advance read index

--- a/src/api/results.rs
+++ b/src/api/results.rs
@@ -373,7 +373,6 @@ pub enum Response {
 
 #[cfg(test)]
 mod test {
-    use std::time::SystemTime;
 
     use super::*;
 
@@ -391,7 +390,10 @@ mod test {
     }
 
     #[test]
+    #[cfg(feature = "pg_type_chrono")]
     fn test_data_row_encoder() {
+        use std::time::SystemTime;
+
         let schema = Arc::new(vec![
             FieldInfo::new("id".into(), None, None, Type::INT4, FieldFormat::Text),
             FieldInfo::new("name".into(), None, None, Type::VARCHAR, FieldFormat::Text),

--- a/src/types/from_sql_text.rs
+++ b/src/types/from_sql_text.rs
@@ -1,9 +1,12 @@
 use std::error::Error;
 use std::fmt;
+#[cfg(feature = "pg_type_chrono")]
 use std::time::{Duration, SystemTime, UNIX_EPOCH};
 
+#[cfg(feature = "pg_type_chrono")]
 use chrono::{DateTime, FixedOffset, NaiveDate, NaiveDateTime, NaiveTime, Offset, Utc};
-use postgres_types::{Type, WrongType};
+use postgres_types::Type;
+#[cfg(feature = "pg_type_rust_decimal")]
 use rust_decimal::Decimal;
 
 pub trait FromSqlText: fmt::Debug {
@@ -64,6 +67,7 @@ impl_from_sql_text!(f32);
 impl_from_sql_text!(f64);
 impl_from_sql_text!(char);
 
+#[cfg(feature = "pg_type_rust_decimal")]
 impl FromSqlText for Decimal {
     fn from_sql_text(_ty: &Type, input: &[u8]) -> Result<Self, Box<dyn Error + Sync + Send>>
     where
@@ -86,6 +90,7 @@ impl FromSqlText for Vec<u8> {
     }
 }
 
+#[cfg(feature = "pg_type_chrono")]
 impl FromSqlText for SystemTime {
     fn from_sql_text(_ty: &Type, value: &[u8]) -> Result<Self, Box<dyn Error + Sync + Send>>
     where
@@ -99,6 +104,7 @@ impl FromSqlText for SystemTime {
     }
 }
 
+#[cfg(feature = "pg_type_chrono")]
 impl FromSqlText for DateTime<FixedOffset> {
     fn from_sql_text(ty: &Type, value: &[u8]) -> Result<Self, Box<dyn Error + Sync + Send>>
     where
@@ -121,11 +127,14 @@ impl FromSqlText for DateTime<FixedOffset> {
                 let datetime = NaiveDateTime::parse_from_str(to_str(value)?, fmt)?;
                 Ok(DateTime::from_naive_utc_and_offset(datetime, Utc.fix()))
             }
-            _ => Err(Box::new(WrongType::new::<DateTime<Utc>>(ty.clone()))),
+            _ => Err(Box::new(postgres_types::WrongType::new::<DateTime<Utc>>(
+                ty.clone(),
+            ))),
         }
     }
 }
 
+#[cfg(feature = "pg_type_chrono")]
 impl FromSqlText for NaiveDate {
     fn from_sql_text(_ty: &Type, value: &[u8]) -> Result<Self, Box<dyn Error + Sync + Send>>
     where
@@ -136,6 +145,7 @@ impl FromSqlText for NaiveDate {
     }
 }
 
+#[cfg(feature = "pg_type_chrono")]
 impl FromSqlText for NaiveTime {
     fn from_sql_text(_ty: &Type, value: &[u8]) -> Result<Self, Box<dyn Error + Sync + Send>>
     where
@@ -146,6 +156,7 @@ impl FromSqlText for NaiveTime {
     }
 }
 
+#[cfg(feature = "pg_type_chrono")]
 impl FromSqlText for NaiveDateTime {
     fn from_sql_text(_ty: &Type, value: &[u8]) -> Result<Self, Box<dyn Error + Sync + Send>>
     where


### PR DESCRIPTION
Fixes #320 

This patch introduces ToSqlText/FromSqlText for serde types and serde_json::Value.

This patch also reorganized features for various extension types. Extension types will be disabled when you include pgwire with `no-default-features`