### PR TITLE
Expose SNI (tls server name indication)

### DIFF
--- a/src/api/mod.rs
+++ b/src/api/mod.rs
@@ -65,6 +65,8 @@ pub trait ClientInfo {
 
     fn metadata_mut(&mut self) -> &mut HashMap<String, String>;
 
+    fn sni_server_name(&self) -> Option<&str>;
+
     #[cfg(any(feature = "_ring", feature = "_aws-lc-rs"))]
     fn client_certificates<'a>(&self) -> Option<&[CertificateDer<'a>]>;
 }
@@ -89,6 +91,7 @@ pub struct DefaultClient<S> {
     pub state: PgWireConnectionState,
     pub transaction_status: TransactionStatus,
     pub metadata: HashMap<String, String>,
+    pub sni_server_name: Option<String>,
     pub portal_store: store::MemPortalStore<S>,
 }
 
@@ -141,6 +144,10 @@ impl<S> ClientInfo for DefaultClient<S> {
         self.transaction_status = new_status
     }
 
+    fn sni_server_name(&self) -> Option<&str> {
+        self.sni_server_name.as_deref()
+    }
+
     #[cfg(any(feature = "_ring", feature = "_aws-lc-rs"))]
     fn client_certificates<'a>(&self) -> Option<&[CertificateDer<'a>]> {
         None
@@ -157,6 +164,7 @@ impl<S> DefaultClient<S> {
             state: PgWireConnectionState::default(),
             transaction_status: TransactionStatus::Idle,
             metadata: HashMap::new(),
+            sni_server_name: None,
             portal_store: store::MemPortalStore::new(),
         }
     }


### PR DESCRIPTION
We expose server_name from rustls to client metadata with this PR.

This is helpful in some cases. If one is using pgwire for loadbalancing/routing amongst servers, can decide with server_name. Also I think it can be helpful for some sanity checks, if one is trying to connect via scanning ip addresses etc. server can just close the connection as something is going fishy.

I tried to come up with some unit tests (tried a few ways, in the end this works in macos and linux but I'm open to suggestions ) 

Also tested manually. I have a branch that is checking this server_name in riffq, it works with simply when tls is enabled [1]

Simply connecting with when tls is enabled psql after version 12 sends the SNI.  
```
psql "host=example.com port=5444"
```
In ssl=verify-full or ssl=require etc. it also works. 

When tls is enabled but if client doesn't send sni it also sets server_name as None (or when connecting with ip)
```
 psql "host=example.com port=5444 sslmode=prefer sslsni=0"
```

Let me know what you think.

[1] https://github.com/ybrs/riffq/pull/105