### PR TITLE
Add Debug to Response enum

### DIFF
--- a/src/api/results.rs
+++ b/src/api/results.rs
@@ -359,6 +359,7 @@ pub struct CopyResponse {
 /// * CopyIn: response for a copy-in request
 /// * CopyOut: response for a copy-out request
 /// * CopuBoth: response for a copy-both request
+#[derive(Debug)]
 pub enum Response {
     EmptyQuery,
     Query(QueryResponse),


### PR DESCRIPTION
Add a derived Debug implementation to Response for ease of debugging in applications that use pgwire.