### PR TITLE
Expose a few functions from tokio::server

### DIFF
--- a/src/tokio/server.rs
+++ b/src/tokio/server.rs
@@ -564,20 +564,8 @@ where
                 | PgWireConnectionState::AuthenticationInProgress
         ) {
             tokio::select! {
-                _ = &mut startup_timeout => {
-                    if matches!(
-                        socket.state(),
-                        PgWireConnectionState::AwaitingStartup
-                        | PgWireConnectionState::AuthenticationInProgress
-                    ) {
-                        None
-                    } else {
-                        continue;
-                    }
-                },
-                msg = socket.next() => {
-                    msg
-                },
+                _ = &mut startup_timeout => None,
+                msg = socket.next() => msg,
             }
         } else {
             socket.next().await


### PR DESCRIPTION
Reviewed well with `git diff --color-moved=zebra --color-moved-ws=ignore-space-change`.

The first commit splits out parts of `process_socket` into a new function `negotiate_tls`, which calls `peek_for_sslrequest` and handles setting up the TLS connection. It then exposes `negotiate_tls`, `process_message`, and `process_error` as public.

The second commit inlines `do_process_socket` into `process_socket`, since it no longer needs to be generic over the type of the socket - that's now in the `MaybeTls` enum.