### PR TITLE
feat(server): #346 drop unnamed portals immediately after execution

### DIFF
--- a/src/api/query.rs
+++ b/src/api/query.rs
@@ -308,6 +308,10 @@ pub trait ExtendedQueryHandler: Send + Sync {
                 client.set_transaction_status(transaction_status);
             };
 
+            if portal_name == DEFAULT_NAME {
+                client.portal_store().rm_portal(portal_name);
+            }
+
             Ok(())
         } else {
             Err(PgWireError::PortalNotFound(portal_name.to_owned()))


### PR DESCRIPTION
Removes portals that have the default name after execution is complete.