### PR TITLE
chore: add version constraint for bigdecimal/gluesql

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -135,6 +135,7 @@ rustls-pemfile = "2.0"
 gluesql = { version = "0.18", default-features = false, features = [
   "gluesql_memory_storage",
 ] }
+bigdecimal = { version = ">=0.4.5, <0.4.10" }
 
 ## oauth
 jsonwebtoken = { version = "10", features = ["aws_lc_rs"] }


### PR DESCRIPTION
Remove the constraint until upstream updated: https://github.com/gluesql/gluesql/issues/1866