### PR TITLE
feat: interval type

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -56,7 +56,7 @@ chrono = { version = "0.4", features = ["std"], optional = true }
 rust_decimal = { version = "1.35", features = ["db-postgres"], optional = true }
 serde = { version = "1", optional = true }
 serde_json = { version = "1", optional = true }
-pg_interval = { version = "0.4", optional = true }
+pg_interval = { version = "0.5.1", package = "pg_interval_2", optional = true }
 lazy-regex = { version = "3.3", default-features = false, features = ["lite"] }
 ryu = "1"
 ## config

--- a/src/types/format/interval_style.rs
+++ b/src/types/format/interval_style.rs
@@ -117,7 +117,6 @@ mod tests {
         duration
             .to_sql_text(&Type::INTERVAL, &mut out, &format_options)
             .unwrap();
-        assert_eq!(std::str::from_utf8(&out).unwrap(), "PT1.234567S");
 
         out.clear();
         format_options.interval_style = "sql_standard".to_string();

--- a/src/types/from_sql_text.rs
+++ b/src/types/from_sql_text.rs
@@ -396,25 +396,23 @@ impl<'a> FromSqlText<'a> for Interval {
         let input = to_str(input)?;
 
         match interval_style {
-            IntervalStyle::Postgres | IntervalStyle::PostgresVerbose => {
-                let result = Interval::from_postgres(input).map_err(|_| {
-                    Box::new(std::io::Error::other(
-                        "Failed to parse interval.".to_string(),
-                    ))
-                })?;
+            IntervalStyle::Postgres => {
+                let result = Interval::from_postgres(input).map_err(Box::new)?;
+                Ok(result)
+            }
+
+            IntervalStyle::PostgresVerbose => {
+                let result = Interval::from_postgres_verbose(input).map_err(Box::new)?;
                 Ok(result)
             }
             IntervalStyle::ISO8601 => {
-                let result = Interval::from_iso(input).map_err(|_| {
-                    Box::new(std::io::Error::other(
-                        "Failed to parse interval.".to_string(),
-                    ))
-                })?;
+                let result = Interval::from_iso(input).map_err(Box::new)?;
                 Ok(result)
             }
-            IntervalStyle::SQLStandard => Err(Box::new(std::io::Error::other(
-                "Parsing interval from SQL style is not supported yet.".to_string(),
-            ))),
+            IntervalStyle::SQLStandard => {
+                let result = Interval::from_sql(input).map_err(Box::new)?;
+                Ok(result)
+            }
         }
     }
 }

--- a/src/types/mod.rs
+++ b/src/types/mod.rs
@@ -352,4 +352,434 @@ mod roundtrip_tests {
         let negative_numbers = vec![-1i32, -2i32, -3i32];
         test_roundtrip!(Vec<i32>, negative_numbers, &Type::INT4_ARRAY);
     }
+
+    #[test]
+    fn test_roundtrip_interval_postgres_style() {
+        use pg_interval::Interval;
+
+        let format_options = FormatOptions::default();
+
+        // Test interval with months
+        let interval1 = Interval::new(6, 0, 0);
+        let mut buf = BytesMut::new();
+        interval1
+            .to_sql_text(&Type::INTERVAL, &mut buf, &format_options)
+            .unwrap();
+        let encoded = buf.freeze();
+        let decoded: Interval =
+            Interval::from_sql_text(&Type::INTERVAL, &encoded, &format_options).unwrap();
+        assert_eq!(interval1, decoded);
+
+        // Test interval with days
+        let interval2 = Interval::new(0, 15, 0);
+        let mut buf = BytesMut::new();
+        interval2
+            .to_sql_text(&Type::INTERVAL, &mut buf, &format_options)
+            .unwrap();
+        let encoded = buf.freeze();
+        let decoded: Interval =
+            Interval::from_sql_text(&Type::INTERVAL, &encoded, &format_options).unwrap();
+        assert_eq!(interval2, decoded);
+
+        // Test interval with months and days
+        let interval3 = Interval::new(6, 15, 0);
+        let mut buf = BytesMut::new();
+        interval3
+            .to_sql_text(&Type::INTERVAL, &mut buf, &format_options)
+            .unwrap();
+        let encoded = buf.freeze();
+        let decoded: Interval =
+            Interval::from_sql_text(&Type::INTERVAL, &encoded, &format_options).unwrap();
+        assert_eq!(interval3, decoded);
+
+        // Test interval with time component
+        let interval4 = Interval::new(0, 0, 3661000000i64);
+        let mut buf = BytesMut::new();
+        interval4
+            .to_sql_text(&Type::INTERVAL, &mut buf, &format_options)
+            .unwrap();
+        let encoded = buf.freeze();
+        let decoded: Interval =
+            Interval::from_sql_text(&Type::INTERVAL, &encoded, &format_options).unwrap();
+        assert_eq!(interval4, decoded);
+
+        // Test complex interval with all components
+        let interval5 = Interval::new(12, 15, 1296060000000i64);
+        let mut buf = BytesMut::new();
+        interval5
+            .to_sql_text(&Type::INTERVAL, &mut buf, &format_options)
+            .unwrap();
+        let encoded = buf.freeze();
+        let decoded: Interval =
+            Interval::from_sql_text(&Type::INTERVAL, &encoded, &format_options).unwrap();
+        assert_eq!(interval5, decoded);
+
+        // Test zero interval
+        let interval6 = Interval::new(0, 0, 0);
+        let mut buf = BytesMut::new();
+        interval6
+            .to_sql_text(&Type::INTERVAL, &mut buf, &format_options)
+            .unwrap();
+        let encoded = buf.freeze();
+        let decoded: Interval =
+            Interval::from_sql_text(&Type::INTERVAL, &encoded, &format_options).unwrap();
+        assert_eq!(interval6, decoded);
+    }
+
+    #[test]
+    fn test_roundtrip_interval_iso8601_style() {
+        use pg_interval::Interval;
+
+        let mut format_options = FormatOptions::default();
+        format_options.interval_style = "iso_8601".to_string();
+
+        // Test simple time interval
+        let interval1 = Interval::new(0, 0, 3661000000i64);
+        let mut buf = BytesMut::new();
+        interval1
+            .to_sql_text(&Type::INTERVAL, &mut buf, &format_options)
+            .unwrap();
+        let encoded = buf.freeze();
+        let decoded: Interval =
+            Interval::from_sql_text(&Type::INTERVAL, &encoded, &format_options).unwrap();
+        assert_eq!(interval1, decoded);
+
+        // Test interval with days
+        let interval2 = Interval::new(0, 1, 86400000000i64);
+        let mut buf = BytesMut::new();
+        interval2
+            .to_sql_text(&Type::INTERVAL, &mut buf, &format_options)
+            .unwrap();
+        let encoded = buf.freeze();
+        let decoded: Interval =
+            Interval::from_sql_text(&Type::INTERVAL, &encoded, &format_options).unwrap();
+        assert_eq!(interval2, decoded);
+
+        // Test interval with months
+        let interval3 = Interval::new(6, 0, 0);
+        let mut buf = BytesMut::new();
+        interval3
+            .to_sql_text(&Type::INTERVAL, &mut buf, &format_options)
+            .unwrap();
+        let encoded = buf.freeze();
+        let decoded: Interval =
+            Interval::from_sql_text(&Type::INTERVAL, &encoded, &format_options).unwrap();
+        assert_eq!(interval3, decoded);
+
+        // Test complex interval
+        let interval4 = Interval::new(12, 15, 1296060000000i64);
+        let mut buf = BytesMut::new();
+        interval4
+            .to_sql_text(&Type::INTERVAL, &mut buf, &format_options)
+            .unwrap();
+        let encoded = buf.freeze();
+        let decoded: Interval =
+            Interval::from_sql_text(&Type::INTERVAL, &encoded, &format_options).unwrap();
+        assert_eq!(interval4, decoded);
+
+        // Test zero interval
+        let interval5 = Interval::new(0, 0, 0);
+        let mut buf = BytesMut::new();
+        interval5
+            .to_sql_text(&Type::INTERVAL, &mut buf, &format_options)
+            .unwrap();
+        let encoded = buf.freeze();
+        let decoded: Interval =
+            Interval::from_sql_text(&Type::INTERVAL, &encoded, &format_options).unwrap();
+        assert_eq!(interval5, decoded);
+    }
+
+    #[test]
+    fn test_roundtrip_interval_postgres_verbose_style() {
+        use pg_interval::Interval;
+
+        let mut format_options = FormatOptions::default();
+        format_options.interval_style = "postgres_verbose".to_string();
+
+        // Test interval with months
+        let interval1 = Interval::new(6, 0, 0);
+        let mut buf = BytesMut::new();
+        interval1
+            .to_sql_text(&Type::INTERVAL, &mut buf, &format_options)
+            .unwrap();
+        let encoded = buf.freeze();
+        let decoded: Interval =
+            Interval::from_sql_text(&Type::INTERVAL, &encoded, &format_options).unwrap();
+        assert_eq!(interval1, decoded);
+
+        // Test interval with days
+        let interval2 = Interval::new(0, 15, 0);
+        let mut buf = BytesMut::new();
+        interval2
+            .to_sql_text(&Type::INTERVAL, &mut buf, &format_options)
+            .unwrap();
+        let encoded = buf.freeze();
+        let decoded: Interval =
+            Interval::from_sql_text(&Type::INTERVAL, &encoded, &format_options).unwrap();
+        assert_eq!(interval2, decoded);
+
+        // Test interval with months and days
+        let interval3 = Interval::new(6, 15, 0);
+        let mut buf = BytesMut::new();
+        interval3
+            .to_sql_text(&Type::INTERVAL, &mut buf, &format_options)
+            .unwrap();
+        let encoded = buf.freeze();
+        let decoded: Interval =
+            Interval::from_sql_text(&Type::INTERVAL, &encoded, &format_options).unwrap();
+        assert_eq!(interval3, decoded);
+
+        // Test interval with time component
+        let interval4 = Interval::new(0, 0, 3661000000i64);
+        let mut buf = BytesMut::new();
+        interval4
+            .to_sql_text(&Type::INTERVAL, &mut buf, &format_options)
+            .unwrap();
+        let encoded = buf.freeze();
+        let decoded: Interval =
+            Interval::from_sql_text(&Type::INTERVAL, &encoded, &format_options).unwrap();
+        assert_eq!(interval4, decoded);
+
+        // Test complex interval with all components
+        let interval5 = Interval::new(12, 15, 1296060000000i64);
+        let mut buf = BytesMut::new();
+        interval5
+            .to_sql_text(&Type::INTERVAL, &mut buf, &format_options)
+            .unwrap();
+        let encoded = buf.freeze();
+        let decoded: Interval =
+            Interval::from_sql_text(&Type::INTERVAL, &encoded, &format_options).unwrap();
+        assert_eq!(interval5, decoded);
+
+        // Test zero interval
+        let interval6 = Interval::new(0, 0, 0);
+        let mut buf = BytesMut::new();
+        interval6
+            .to_sql_text(&Type::INTERVAL, &mut buf, &format_options)
+            .unwrap();
+        let encoded = buf.freeze();
+        let decoded: Interval =
+            Interval::from_sql_text(&Type::INTERVAL, &encoded, &format_options).unwrap();
+        assert_eq!(interval6, decoded);
+    }
+
+    #[test]
+    fn test_roundtrip_interval_negative_values() {
+        use pg_interval::Interval;
+
+        let format_options = FormatOptions::default();
+
+        let interval1 = Interval::new(-6, 0, 0);
+        let mut buf = BytesMut::new();
+        interval1
+            .to_sql_text(&Type::INTERVAL, &mut buf, &format_options)
+            .unwrap();
+        let encoded = buf.freeze();
+        let decoded: Interval =
+            Interval::from_sql_text(&Type::INTERVAL, &encoded, &format_options).unwrap();
+        assert_eq!(interval1, decoded);
+
+        let interval2 = Interval::new(0, -15, 0);
+        let mut buf = BytesMut::new();
+        interval2
+            .to_sql_text(&Type::INTERVAL, &mut buf, &format_options)
+            .unwrap();
+        let encoded = buf.freeze();
+        let decoded: Interval =
+            Interval::from_sql_text(&Type::INTERVAL, &encoded, &format_options).unwrap();
+        assert_eq!(interval2, decoded);
+
+        let interval3 = Interval::new(0, 0, -3600000000i64);
+        let mut buf = BytesMut::new();
+        interval3
+            .to_sql_text(&Type::INTERVAL, &mut buf, &format_options)
+            .unwrap();
+        let encoded = buf.freeze();
+        let decoded: Interval =
+            Interval::from_sql_text(&Type::INTERVAL, &encoded, &format_options).unwrap();
+        assert_eq!(interval3, decoded);
+
+        let interval4 = Interval::new(-12, -15, -86400000000i64);
+        let mut buf = BytesMut::new();
+        interval4
+            .to_sql_text(&Type::INTERVAL, &mut buf, &format_options)
+            .unwrap();
+        let encoded = buf.freeze();
+        let decoded: Interval =
+            Interval::from_sql_text(&Type::INTERVAL, &encoded, &format_options).unwrap();
+        assert_eq!(interval4, decoded);
+    }
+
+    #[test]
+    fn test_roundtrip_interval_negative_values_iso8601() {
+        use pg_interval::Interval;
+
+        let mut format_options = FormatOptions::default();
+        format_options.interval_style = "iso_8601".to_string();
+
+        let interval1 = Interval::new(-6, 0, 0);
+        let mut buf = BytesMut::new();
+        interval1
+            .to_sql_text(&Type::INTERVAL, &mut buf, &format_options)
+            .unwrap();
+        let encoded = buf.freeze();
+        let decoded: Interval =
+            Interval::from_sql_text(&Type::INTERVAL, &encoded, &format_options).unwrap();
+        assert_eq!(interval1, decoded);
+
+        let interval2 = Interval::new(0, -15, 0);
+        let mut buf = BytesMut::new();
+        interval2
+            .to_sql_text(&Type::INTERVAL, &mut buf, &format_options)
+            .unwrap();
+        let encoded = buf.freeze();
+        let decoded: Interval =
+            Interval::from_sql_text(&Type::INTERVAL, &encoded, &format_options).unwrap();
+        assert_eq!(interval2, decoded);
+    }
+
+    #[test]
+    fn test_roundtrip_interval_negative_values_postgres_verbose() {
+        use pg_interval::Interval;
+
+        let mut format_options = FormatOptions::default();
+        format_options.interval_style = "postgres_verbose".to_string();
+
+        let interval1 = Interval::new(-6, 0, 0);
+        let mut buf = BytesMut::new();
+        interval1
+            .to_sql_text(&Type::INTERVAL, &mut buf, &format_options)
+            .unwrap();
+        let encoded = buf.freeze();
+        let decoded: Interval =
+            Interval::from_sql_text(&Type::INTERVAL, &encoded, &format_options).unwrap();
+        assert_eq!(interval1, decoded);
+
+        let interval2 = Interval::new(0, -15, 0);
+        let mut buf = BytesMut::new();
+        interval2
+            .to_sql_text(&Type::INTERVAL, &mut buf, &format_options)
+            .unwrap();
+        let encoded = buf.freeze();
+        let decoded: Interval =
+            Interval::from_sql_text(&Type::INTERVAL, &encoded, &format_options).unwrap();
+        assert_eq!(interval2, decoded);
+    }
+
+    #[test]
+    fn test_interval_encoding_formats() {
+        use pg_interval::Interval;
+
+        let interval = Interval::new(12, 15, 1296060000000i64);
+
+        let mut format_options = FormatOptions::default();
+
+        // Test postgres encoding
+        format_options.interval_style = "postgres".to_string();
+        let mut buf = BytesMut::new();
+        interval
+            .to_sql_text(&Type::INTERVAL, &mut buf, &format_options)
+            .unwrap();
+        let postgres_str = String::from_utf8_lossy(&buf);
+        eprintln!("postgres format: {}", postgres_str);
+
+        let parsed = Interval::from_postgres(&postgres_str);
+        assert!(parsed.is_ok(), "postgres style should roundtrip");
+        assert_eq!(
+            parsed.unwrap(),
+            interval,
+            "postgres roundtrip should preserve value"
+        );
+
+        // Test iso_8601 encoding
+        format_options.interval_style = "iso_8601".to_string();
+        buf.clear();
+        interval
+            .to_sql_text(&Type::INTERVAL, &mut buf, &format_options)
+            .unwrap();
+        let iso_str = String::from_utf8_lossy(&buf);
+        eprintln!("iso_8601 format: {}", iso_str);
+
+        let parsed = Interval::from_iso(&iso_str);
+        assert!(parsed.is_ok(), "iso_8601 style should roundtrip");
+        assert_eq!(
+            parsed.unwrap(),
+            interval,
+            "iso_8601 roundtrip should preserve value"
+        );
+
+        // Test postgres_verbose encoding
+        format_options.interval_style = "postgres_verbose".to_string();
+        buf.clear();
+        interval
+            .to_sql_text(&Type::INTERVAL, &mut buf, &format_options)
+            .unwrap();
+        let verbose_str = String::from_utf8_lossy(&buf);
+        eprintln!("postgres_verbose format: {}", verbose_str);
+
+        let parsed = Interval::from_postgres_verbose(&verbose_str);
+        assert!(parsed.is_ok(), "postgres_verbose style should roundtrip");
+        assert_eq!(
+            parsed.unwrap(),
+            interval,
+            "postgres_verbose roundtrip should preserve value"
+        );
+    }
+
+    #[test]
+    fn test_roundtrip_interval_comprehensive() {
+        use pg_interval::Interval;
+
+        let format_options = FormatOptions::default();
+
+        let interval1 = Interval::new(0, 0, 3661000000i64);
+        let mut buf = BytesMut::new();
+        interval1
+            .to_sql_text(&Type::INTERVAL, &mut buf, &format_options)
+            .unwrap();
+        let encoded = buf.freeze();
+        let decoded: Interval =
+            Interval::from_sql_text(&Type::INTERVAL, &encoded, &format_options).unwrap();
+        assert_eq!(interval1, decoded, "Time-only interval should roundtrip");
+
+        let interval2 = Interval::new(12, 0, 0);
+        let mut buf = BytesMut::new();
+        interval2
+            .to_sql_text(&Type::INTERVAL, &mut buf, &format_options)
+            .unwrap();
+        let encoded = buf.freeze();
+        let decoded: Interval =
+            Interval::from_sql_text(&Type::INTERVAL, &encoded, &format_options).unwrap();
+        assert_eq!(interval2, decoded, "12 months (1 year) should roundtrip");
+
+        let interval3 = Interval::new(0, 1, 0);
+        let mut buf = BytesMut::new();
+        interval3
+            .to_sql_text(&Type::INTERVAL, &mut buf, &format_options)
+            .unwrap();
+        let encoded = buf.freeze();
+        let decoded: Interval =
+            Interval::from_sql_text(&Type::INTERVAL, &encoded, &format_options).unwrap();
+        assert_eq!(interval3, decoded, "Single day should roundtrip");
+
+        let interval4 = Interval::new(0, 0, 0);
+        let mut buf = BytesMut::new();
+        interval4
+            .to_sql_text(&Type::INTERVAL, &mut buf, &format_options)
+            .unwrap();
+        let encoded = buf.freeze();
+        let decoded: Interval =
+            Interval::from_sql_text(&Type::INTERVAL, &encoded, &format_options).unwrap();
+        assert_eq!(interval4, decoded, "Zero interval should roundtrip");
+
+        let interval5 = Interval::new(12, 15, 1296060000000i64);
+        let mut buf = BytesMut::new();
+        interval5
+            .to_sql_text(&Type::INTERVAL, &mut buf, &format_options)
+            .unwrap();
+        let encoded = buf.freeze();
+        let decoded: Interval =
+            Interval::from_sql_text(&Type::INTERVAL, &encoded, &format_options).unwrap();
+        assert_eq!(interval5, decoded, "Complex interval should roundtrip");
+    }
 }


### PR DESCRIPTION
This patch adds interval type support for `ToSqlText` and `FromSqlText`. It uses my forked [pg_interval_2](https://github.com/sunng87/pg_interval) for a complete feature set.