### PR TITLE
fix: resolve postgres date style issues

### DIFF
--- a/src/types/format/date_style.rs
+++ b/src/types/format/date_style.rs
@@ -84,6 +84,9 @@ impl DateStyle {
 
             (DateStyleDisplayStyle::ISO, _) => "%Y-%m-%d %H:%M:%S%.6f",
 
+            (DateStyleDisplayStyle::Postgres, Some(DateStyleOrder::DMY)) => {
+                "%a %e %b %H:%M:%S%.6f %Y"
+            }
             (DateStyleDisplayStyle::Postgres, _) => "%a %b %e %H:%M:%S%.6f %Y",
 
             (DateStyleDisplayStyle::German, _) => "%d.%m.%Y %H:%M:%S%.6f",
@@ -246,8 +249,8 @@ mod tests {
             (
                 "postgres",
                 Some("DMY"),
-                "%a %b %e %H:%M:%S%.6f %Y",
-                "%a %b %e %H:%M:%S%.6f %Y %Z",
+                "%a %e %b %H:%M:%S%.6f %Y",
+                "%a %e %b %H:%M:%S%.6f %Y %Z",
                 "%d-%m-%Y",
                 "%H:%M:%S%.6f %Z",
             ),
@@ -435,5 +438,24 @@ mod tests {
             .unwrap();
         let result = std::str::from_utf8(&out).unwrap();
         assert!(result.contains("14:30:45.123456"));
+    }
+
+    #[cfg(feature = "pg-type-chrono")]
+    #[test]
+    fn test_postgres_date_style_dmy_order() {
+        use crate::types::format::FormatOptions;
+
+        let dt = NaiveDate::from_ymd_opt(1997, 12, 17)
+            .unwrap()
+            .and_hms_micro_opt(7, 37, 16, 123000)
+            .unwrap();
+        let mut out = BytesMut::new();
+        let mut format_options = FormatOptions::default();
+        format_options.date_style = "postgres, DMY".to_string();
+
+        dt.to_sql_text(&Type::TIMESTAMP, &mut out, &format_options)
+            .unwrap();
+        let result = std::str::from_utf8(&out).unwrap();
+        assert_eq!(result, "Wed 17 Dec 07:37:16.123000 1997");
     }
 }


### PR DESCRIPTION
This patch fixes:

- add dmy order for postgres support
- remove the invalid space between seconds and micros