### PR TITLE
Fix Windows compilation errors in client config

### DIFF
--- a/src/api/client/config.rs
+++ b/src/api/client/config.rs
@@ -90,6 +90,7 @@ impl Host {
     pub(crate) fn get_hostname(&self) -> Option<String> {
         match self {
             Host::Tcp(host) => Some(host.clone()),
+            #[cfg(unix)]
             Host::Unix(_) => None,
         }
     }
@@ -1092,7 +1093,7 @@ impl<'a> UrlParser<'a> {
     }
 
     #[cfg(not(unix))]
-    fn host_param(&mut self, s: &str) -> Result<(), Error> {
+    fn host_param(&mut self, s: &str) -> Result<(), PgWireClientError> {
         let s = self.decode(s)?;
         self.config.param("host", &s)
     }


### PR DESCRIPTION
This PR fixes two small compile errors on windows in the client config. It appears that these two things are the only thing breaking windows builds.

1. The `Host::Unix(_)` match arm in `get_hostname()` was not gated with `#[cfg(unix)]`, but the `Host::Unix` variant itself is conditionally compiled only on Unix. This caused E0599.

2. The `#[cfg(not(unix))]` version of `host_param()` used `Error` as the return type instead of `PgWireClientError`, causing E0412.

## Changes

- Added `#[cfg(unix)]` attribute to the `Host::Unix(_)` match arm in `Host::get_hostname()`
- Changed return type from `Error` to `PgWireClientError` in the non-unix `host_param()` function

## Testing
- [x] I have verified that the new code compiles.