### PR TITLE
feat: cleanup portals on sync

### DIFF
--- a/src/api/query.rs
+++ b/src/api/query.rs
@@ -385,10 +385,14 @@ pub trait ExtendedQueryHandler: Send + Sync {
     /// `READY_FOR_QUERY` response to client
     async fn on_sync<C>(&self, client: &mut C, _message: PgSync) -> PgWireResult<()>
     where
-        C: ClientInfo + Sink<PgWireBackendMessage> + Unpin + Send + Sync,
+        C: ClientInfo + ClientPortalStore + Sink<PgWireBackendMessage> + Unpin + Send + Sync,
+        C::PortalStore: PortalStore<Statement = Self::Statement>,
         C::Error: Debug,
         PgWireError: From<<C as Sink<PgWireBackendMessage>>::Error>,
     {
+        // cleanup all portals
+        client.portal_store().clear_portals();
+
         client
             .send(PgWireBackendMessage::ReadyForQuery(ReadyForQuery::new(
                 client.transaction_status(),

--- a/src/api/store.rs
+++ b/src/api/store.rs
@@ -17,6 +17,8 @@ pub trait PortalStore: Send + Sync {
 
     fn rm_portal(&self, name: &str);
 
+    fn clear_portals(&self);
+
     fn get_portal(&self, name: &str) -> Option<Arc<Portal<Self::Statement>>>;
 }
 
@@ -54,6 +56,11 @@ impl<S: Clone + Send + Sync> PortalStore for MemPortalStore<S> {
     fn rm_portal(&self, name: &str) {
         let mut guard = self.portals.write().unwrap();
         guard.remove(name);
+    }
+
+    fn clear_portals(&self) {
+        let mut guard = self.portals.write().unwrap();
+        guard.clear();
     }
 
     fn get_portal(&self, name: &str) -> Option<Arc<Portal<Self::Statement>>> {


### PR DESCRIPTION
This patch aligns with postgres behavior to cleanup all portals of current connection on `SYNC`.