### PR TITLE
feat: update pid generator to use counter

### DIFF
--- a/src/api/auth/cleartext.rs
+++ b/src/api/auth/cleartext.rs
@@ -27,7 +27,7 @@ impl<A, P> CleartextPasswordAuthStartupHandler<A, P> {
         Self {
             auth_source,
             parameter_provider,
-            pid_secret_key_generator: Arc::new(RandomPidSecretKeyGenerator),
+            pid_secret_key_generator: Arc::new(RandomPidSecretKeyGenerator::default()),
             connection_manager: None,
         }
     }

--- a/src/api/auth/md5pass.rs
+++ b/src/api/auth/md5pass.rs
@@ -29,7 +29,7 @@ impl<A, P> Md5PasswordAuthStartupHandler<A, P> {
         Md5PasswordAuthStartupHandler {
             auth_source,
             parameter_provider,
-            pid_secret_key_generator: Arc::new(RandomPidSecretKeyGenerator),
+            pid_secret_key_generator: Arc::new(RandomPidSecretKeyGenerator::default()),
             connection_manager: None,
             cached_password: Mutex::new(vec![]),
         }

--- a/src/api/auth/noop.rs
+++ b/src/api/auth/noop.rs
@@ -1,5 +1,6 @@
 use std::fmt::Debug;
 use std::sync::Arc;
+use std::sync::LazyLock;
 
 use async_trait::async_trait;
 use futures::sink::{Sink, SinkExt};
@@ -12,6 +13,9 @@ use crate::error::{PgWireError, PgWireResult};
 use crate::messages::response::{ReadyForQuery, TransactionStatus};
 use crate::messages::{PgWireBackendMessage, PgWireFrontendMessage};
 
+static DEFAULT_PID_GENERATOR: LazyLock<RandomPidSecretKeyGenerator> =
+    LazyLock::new(RandomPidSecretKeyGenerator::default);
+
 #[async_trait]
 /// A startup handler that performs no authentication.
 pub trait NoopStartupHandler: StartupHandler {
@@ -20,7 +24,7 @@ pub trait NoopStartupHandler: StartupHandler {
     }
 
     fn pid_secret_key_generator(&self) -> &dyn PidSecretKeyGenerator {
-        &RandomPidSecretKeyGenerator
+        &*DEFAULT_PID_GENERATOR
     }
 
     async fn post_startup<C>(

--- a/src/api/auth/sasl.rs
+++ b/src/api/auth/sasl.rs
@@ -73,7 +73,7 @@ impl<P> SASLAuthStartupHandler<P> {
     pub fn new(parameter_provider: Arc<P>) -> Self {
         SASLAuthStartupHandler {
             parameter_provider,
-            pid_secret_key_generator: Arc::new(RandomPidSecretKeyGenerator),
+            pid_secret_key_generator: Arc::new(RandomPidSecretKeyGenerator::default()),
             connection_manager: None,
             state: Mutex::new(SASLState::Initial),
             scram: None,

--- a/src/api/mod.rs
+++ b/src/api/mod.rs
@@ -3,6 +3,7 @@
 use std::any::{Any, TypeId};
 use std::collections::HashMap;
 use std::net::SocketAddr;
+use std::sync::atomic::{AtomicI32, Ordering};
 use std::sync::{Arc, RwLock};
 
 use bytes::Bytes;
@@ -321,17 +322,29 @@ pub trait PidSecretKeyGenerator: Send + Sync {
     fn generate(&self, client: &dyn ClientInfo) -> (i32, SecretKey);
 }
 
-/// Default implementation of [`PidSecretKeyGenerator`] that produces random
-/// values using the `rand` crate.
+/// Default implementation of [`PidSecretKeyGenerator`] that uses an atomic
+/// counter for PIDs and random values for secret keys via the `rand` crate.
 ///
 /// For protocol 3.0, generates a 4-byte `SecretKey::I32`. For protocol 3.2,
 /// generates a 32-byte `SecretKey::Bytes`.
-#[derive(Debug, Default)]
-pub struct RandomPidSecretKeyGenerator;
+const PID_INIT: i32 = 100_000;
+
+#[derive(Debug)]
+pub struct RandomPidSecretKeyGenerator {
+    next_pid: AtomicI32,
+}
+
+impl Default for RandomPidSecretKeyGenerator {
+    fn default() -> Self {
+        Self {
+            next_pid: AtomicI32::new(PID_INIT),
+        }
+    }
+}
 
 impl PidSecretKeyGenerator for RandomPidSecretKeyGenerator {
     fn generate(&self, client: &dyn ClientInfo) -> (i32, SecretKey) {
-        let pid = (rand::random::<u32>() >> 1) as i32;
+        let pid = self.next_pid.fetch_add(1, Ordering::Relaxed);
         let secret_key = match client.protocol_version() {
             ProtocolVersion::PROTOCOL3_0 => SecretKey::I32(rand::random::<i32>()),
             ProtocolVersion::PROTOCOL3_2 => {


### PR DESCRIPTION
This patch updates our default builtin pid generator to use a counter instead of purely random, to avoid potential collision.