### PR TITLE
feat: add cursor support for portal 

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -201,5 +201,9 @@ name = "cancel"
 required-features = ["server-api-aws-lc-rs"]
 
 [[example]]
+name = "cursor"
+required-features = ["server-api-aws-lc-rs"]
+
+[[example]]
 name = "client"
 required-features = ["client-api"]

--- a/examples/common/mod.rs
+++ b/examples/common/mod.rs
@@ -82,10 +82,12 @@ impl SimpleQueryHandler for DummyProcessor {
     }
 }
 
+#[allow(dead_code)]
 pub struct DummyProcessorFactory {
     pub handler: Arc<DummyProcessor>,
 }
 
+#[allow(dead_code)]
 impl DummyProcessorFactory {
     pub fn new() -> DummyProcessorFactory {
         Self {

--- a/examples/cursor.rs
+++ b/examples/cursor.rs
@@ -1,0 +1,265 @@
+use std::sync::Arc;
+
+use async_trait::async_trait;
+use futures::{Sink, SinkExt, StreamExt, stream};
+use tokio::net::TcpListener;
+
+use pgwire::api::auth::StartupHandler;
+use pgwire::api::auth::noop::NoopStartupHandler;
+use pgwire::api::portal::Portal;
+use pgwire::api::query::SimpleQueryHandler;
+use pgwire::api::results::{DataRowEncoder, FieldFormat, FieldInfo, QueryResponse, Response, Tag};
+use pgwire::api::store::{MemPortalStore, PortalStore};
+use pgwire::api::{ClientInfo, ClientPortalStore, PgWireServerHandlers, Type};
+use pgwire::error::{ErrorInfo, PgWireError, PgWireResult};
+use pgwire::messages::response::NoticeResponse;
+use pgwire::messages::{PgWireBackendMessage, PgWireFrontendMessage};
+use pgwire::tokio::process_socket;
+
+mod common;
+
+type Statement = String;
+
+struct CursorBackend;
+
+fn make_row_data() -> (Arc<Vec<FieldInfo>>, Vec<(i32, &'static str)>) {
+    let schema = Arc::new(vec![
+        FieldInfo::new("id".into(), None, None, Type::INT4, FieldFormat::Text),
+        FieldInfo::new("name".into(), None, None, Type::VARCHAR, FieldFormat::Text),
+    ]);
+    let data = vec![
+        (1, "Alice"),
+        (2, "Bob"),
+        (3, "Charlie"),
+        (4, "Diana"),
+        (5, "Eve"),
+        (6, "Frank"),
+        (7, "Grace"),
+        (8, "Hank"),
+        (9, "Ivy"),
+        (10, "Jack"),
+    ];
+    (schema, data)
+}
+
+enum CursorCommand {
+    Declare { name: String, inner_query: String },
+    Fetch { name: String, count: usize },
+    Close { name: String },
+}
+
+fn parse_cursor_command(query: &str) -> Option<CursorCommand> {
+    let upper = query.to_uppercase();
+    if upper.starts_with("DECLARE") {
+        let rest = &query["DECLARE".len()..].trim_start();
+        let parts: Vec<&str> = rest.splitn(2, "FOR").collect();
+        if parts.len() == 2 {
+            Some(CursorCommand::Declare {
+                name: parts[0].trim().to_string(),
+                inner_query: parts[1].trim().to_string(),
+            })
+        } else {
+            None
+        }
+    } else if upper.starts_with("FETCH") {
+        let rest = &query["FETCH".len()..].trim_start();
+        let parts: Vec<&str> = rest.splitn(2, "FROM").collect();
+        if parts.len() == 2 {
+            Some(CursorCommand::Fetch {
+                count: parts[0].trim().parse().unwrap_or(1),
+                name: parts[1].trim().trim_end_matches(';').trim().to_string(),
+            })
+        } else {
+            None
+        }
+    } else if upper.starts_with("CLOSE") {
+        let rest = &query["CLOSE".len()..].trim_start();
+        Some(CursorCommand::Close {
+            name: rest.trim().trim_end_matches(';').trim().to_string(),
+        })
+    } else {
+        None
+    }
+}
+
+fn encode_row_data(
+    data: Vec<(i32, &'static str)>,
+    schema: Arc<Vec<FieldInfo>>,
+) -> impl futures::Stream<Item = PgWireResult<pgwire::messages::data::DataRow>> + use<> {
+    let mut encoder = DataRowEncoder::new(schema);
+    stream::iter(data).map(move |(id, name)| {
+        encoder.encode_field(&id)?;
+        encoder.encode_field(&name)?;
+        Ok(encoder.take_row())
+    })
+}
+
+#[async_trait]
+impl NoopStartupHandler for CursorBackend {
+    async fn post_startup<C>(
+        &self,
+        client: &mut C,
+        _message: PgWireFrontendMessage,
+    ) -> PgWireResult<()>
+    where
+        C: ClientInfo + Sink<PgWireBackendMessage> + Unpin + Send,
+        C::Error: std::fmt::Debug,
+        PgWireError: From<<C as Sink<PgWireBackendMessage>>::Error>,
+    {
+        println!("Client connected: {}", client.socket_addr());
+
+        let notice = NoticeResponse::from(ErrorInfo::new(
+            "INFO".into(),
+            "00000".into(),
+            "Cursor example server. Supported statements:\n  \
+             DECLARE <name> FOR SELECT ...\n  \
+             FETCH <n> FROM <name>\n  \
+             CLOSE <name>\n  \
+             SELECT ..."
+                .into(),
+        ));
+        client
+            .send(PgWireBackendMessage::NoticeResponse(notice))
+            .await?;
+
+        Ok(())
+    }
+}
+
+#[async_trait]
+impl SimpleQueryHandler for CursorBackend {
+    async fn do_query<C>(&self, client: &mut C, query: &str) -> PgWireResult<Vec<Response>>
+    where
+        C: ClientInfo + ClientPortalStore + Unpin + Send + Sync,
+        C::PortalStore: PortalStore,
+    {
+        println!("Query: {:?}", query);
+
+        let portal_store = client
+            .portal_store()
+            .as_any()
+            .downcast_ref::<MemPortalStore<Statement>>()
+            .expect("expected MemPortalStore<String>");
+
+        if let Some(cmd) = parse_cursor_command(query) {
+            match cmd {
+                CursorCommand::Declare { name, inner_query } => {
+                    handle_declare(portal_store, &name, &inner_query)
+                }
+                CursorCommand::Fetch { name, count } => {
+                    handle_fetch(portal_store, &name, count).await
+                }
+                CursorCommand::Close { name } => handle_close(portal_store, &name),
+            }
+        } else if query.to_uppercase().starts_with("SELECT") {
+            let (schema, data) = make_row_data();
+            let row_stream = encode_row_data(data, schema.clone());
+            Ok(vec![Response::Query(QueryResponse::new(
+                schema, row_stream,
+            ))])
+        } else {
+            Ok(vec![Response::Execution(Tag::new("OK").with_rows(1))])
+        }
+    }
+}
+
+fn handle_declare(
+    portal_store: &MemPortalStore<Statement>,
+    cursor_name: &str,
+    inner_query: &str,
+) -> PgWireResult<Vec<Response>> {
+    println!("DECLARE cursor '{}' FOR {}", cursor_name, inner_query);
+
+    if !inner_query.to_uppercase().starts_with("SELECT") {
+        return Err(PgWireError::UserError(Box::new(ErrorInfo::new(
+            "ERROR".to_owned(),
+            "42809".to_owned(),
+            "DECLARE CURSOR can only be used with SELECT queries".to_string(),
+        ))));
+    }
+
+    let (schema, data) = make_row_data();
+    let row_stream = encode_row_data(data, schema.clone());
+
+    let response = QueryResponse::new(schema, row_stream);
+    let portal = Portal::new_cursor(cursor_name.to_string(), response);
+    portal_store.put_portal(Arc::new(portal));
+
+    Ok(vec![Response::Execution(Tag::new("DECLARE CURSOR"))])
+}
+
+async fn handle_fetch(
+    portal_store: &MemPortalStore<Statement>,
+    cursor_name: &str,
+    count: usize,
+) -> PgWireResult<Vec<Response>> {
+    println!("FETCH {} FROM {}", count, cursor_name);
+
+    let Some(portal) = portal_store.get_portal(cursor_name) else {
+        return Err(PgWireError::UserError(Box::new(ErrorInfo::new(
+            "ERROR".to_owned(),
+            "34000".to_owned(),
+            format!("cursor \"{}\" does not exist", cursor_name),
+        ))));
+    };
+
+    let fetch_result = portal.fetch(count).await?;
+    println!(
+        "  -> Fetched {} rows, has_more: {}",
+        fetch_result.rows.len(),
+        fetch_result.suspended
+    );
+
+    let schema = fetch_result.row_schema;
+    let row_stream = stream::iter(fetch_result.rows.into_iter().map(Ok));
+    Ok(vec![Response::Query(QueryResponse::new(
+        schema, row_stream,
+    ))])
+}
+
+fn handle_close(
+    portal_store: &MemPortalStore<Statement>,
+    cursor_name: &str,
+) -> PgWireResult<Vec<Response>> {
+    println!("CLOSE {}", cursor_name);
+    portal_store.rm_portal(cursor_name);
+    Ok(vec![Response::Execution(Tag::new("CLOSE CURSOR"))])
+}
+
+struct CursorBackendFactory {
+    handler: Arc<CursorBackend>,
+}
+
+impl PgWireServerHandlers for CursorBackendFactory {
+    fn simple_query_handler(&self) -> Arc<impl SimpleQueryHandler> {
+        self.handler.clone()
+    }
+
+    fn startup_handler(&self) -> Arc<impl StartupHandler> {
+        self.handler.clone()
+    }
+}
+
+#[tokio::main]
+pub async fn main() {
+    let factory = Arc::new(CursorBackendFactory {
+        handler: Arc::new(CursorBackend),
+    });
+
+    let server_addr = "127.0.0.1:5432";
+    let listener = TcpListener::bind(server_addr).await.unwrap();
+    println!("Listening to {}", server_addr);
+    println!();
+    println!("Try these commands with psql:");
+    println!("  DECLARE my_cursor FOR SELECT * FROM users;");
+    println!("  FETCH 3 FROM my_cursor;");
+    println!("  FETCH 3 FROM my_cursor;");
+    println!("  FETCH 3 FROM my_cursor;");
+    println!("  FETCH 3 FROM my_cursor;");
+    println!("  CLOSE my_cursor;");
+    loop {
+        let incoming_socket = listener.accept().await.unwrap();
+        let factory_ref = factory.clone();
+        tokio::spawn(async move { process_socket(incoming_socket.0, None, factory_ref).await });
+    }
+}

--- a/examples/cursor.rs
+++ b/examples/cursor.rs
@@ -1,3 +1,4 @@
+use std::ops::Deref;
 use std::sync::Arc;
 
 use async_trait::async_trait;
@@ -9,6 +10,7 @@ use pgwire::api::auth::noop::NoopStartupHandler;
 use pgwire::api::portal::Portal;
 use pgwire::api::query::SimpleQueryHandler;
 use pgwire::api::results::{DataRowEncoder, FieldFormat, FieldInfo, QueryResponse, Response, Tag};
+use pgwire::api::stmt::StoredStatement;
 use pgwire::api::store::{MemPortalStore, PortalStore};
 use pgwire::api::{ClientInfo, ClientPortalStore, PgWireServerHandlers, Type};
 use pgwire::error::{ErrorInfo, PgWireError, PgWireResult};
@@ -92,6 +94,22 @@ fn encode_row_data(
         encoder.encode_field(&name)?;
         Ok(encoder.take_row())
     })
+}
+
+/// Demo stub: validates that the query starts with SELECT, then returns
+/// hardcoded data. A real implementation would parse and execute the query.
+fn execute_inner_query(inner_query: &str) -> PgWireResult<QueryResponse> {
+    if !inner_query.to_uppercase().starts_with("SELECT") {
+        return Err(PgWireError::UserError(Box::new(ErrorInfo::new(
+            "ERROR".to_owned(),
+            "42809".to_owned(),
+            "DECLARE CURSOR can only be used with SELECT queries".to_string(),
+        ))));
+    }
+
+    let (schema, data) = make_row_data();
+    let row_stream = encode_row_data(data, schema.clone());
+    Ok(QueryResponse::new(schema, row_stream))
 }
 
 #[async_trait]
@@ -178,11 +196,8 @@ fn handle_declare(
         ))));
     }
 
-    let (schema, data) = make_row_data();
-    let row_stream = encode_row_data(data, schema.clone());
-
-    let response = QueryResponse::new(schema, row_stream);
-    let portal = Portal::new_cursor(cursor_name.to_string(), response);
+    let statement = StoredStatement::new(cursor_name.to_string(), inner_query.to_string(), vec![]);
+    let portal = Portal::new_cursor(cursor_name.to_string(), Arc::new(statement));
     portal_store.put_portal(Arc::new(portal));
 
     Ok(vec![Response::Execution(Tag::new("DECLARE CURSOR"))])
@@ -202,6 +217,18 @@ async fn handle_fetch(
             format!("cursor \"{}\" does not exist", cursor_name),
         ))));
     };
+
+    // Lazy execution: if the cursor hasn't been started yet, execute the
+    // stored statement now and transition to Suspended.
+    if matches!(
+        portal.state().lock().await.deref(),
+        pgwire::api::portal::PortalExecutionState::Initial
+    ) {
+        let inner_query = &portal.statement.statement;
+        println!("  -> Lazy execution of: {}", inner_query);
+        let response = execute_inner_query(inner_query)?;
+        portal.start(response).await;
+    }
 
     let fetch_result = portal.fetch(count).await?;
     println!(

--- a/src/api/portal.rs
+++ b/src/api/portal.rs
@@ -1,14 +1,16 @@
 use std::fmt::Debug;
+use std::ops::DerefMut;
 use std::sync::Arc;
 
 use bytes::Bytes;
+use futures::stream::StreamExt;
 use postgres_types::FromSqlOwned;
 use tokio::sync::Mutex;
 
 use crate::api::Type;
-use crate::api::results::QueryResponse;
+use crate::api::results::{FieldInfo, QueryResponse};
 use crate::error::{PgWireError, PgWireResult};
-use crate::messages::data::FORMAT_CODE_BINARY;
+use crate::messages::data::{DataRow, FORMAT_CODE_BINARY};
 use crate::messages::extendedquery::Bind;
 use crate::types::FromSqlText;
 use crate::types::format::FormatOptions;
@@ -38,6 +40,15 @@ pub enum PortalExecutionState {
     // tag and data stream
     Suspended(QueryResponse),
     Finished,
+}
+
+/// Result of fetching rows from a portal in `Suspended` state.
+#[derive(Debug)]
+pub struct FetchResult {
+    pub command_tag: String,
+    pub rows: Vec<DataRow>,
+    pub row_schema: Arc<Vec<FieldInfo>>,
+    pub suspended: bool,
 }
 
 /// Column format specification for parameters or result columns.
@@ -157,6 +168,65 @@ impl<S: Clone> Portal<S> {
     /// Get a handle to the portal's execution state.
     pub fn state(&self) -> Arc<Mutex<PortalExecutionState>> {
         self.state.clone()
+    }
+
+    /// Fetch up to `max_rows` from a portal's suspended state.
+    ///
+    /// Returns a [`FetchResult`] containing the rows, the row schema, and
+    /// whether the portal is still suspended (has more rows). When the
+    /// underlying stream is exhausted, the portal transitions to `Finished`.
+    /// When `max_rows` is 0, all remaining rows are fetched.
+    ///
+    /// Returns an error if the portal is in `Initial` state or if the stream
+    /// yields an error.
+    pub async fn fetch(&self, max_rows: usize) -> PgWireResult<FetchResult> {
+        let mut state = self.state.lock().await;
+
+        match state.deref_mut() {
+            PortalExecutionState::Initial => Err(PgWireError::IoError(std::io::Error::new(
+                std::io::ErrorKind::Other,
+                "Cannot fetch from portal in Initial state",
+            ))),
+            PortalExecutionState::Finished => Ok(FetchResult {
+                command_tag: String::new(),
+                rows: vec![],
+                row_schema: Arc::new(vec![]),
+                suspended: false,
+            }),
+            PortalExecutionState::Suspended(response) => {
+                let command_tag = response.command_tag().to_owned();
+                let row_schema = response.row_schema();
+                let data_rows = response.data_rows();
+
+                let mut rows = Vec::with_capacity(if max_rows == 0 { 256 } else { max_rows });
+                let mut suspended = true;
+                while max_rows == 0 || rows.len() < max_rows {
+                    if let Some(row) = data_rows.next().await {
+                        rows.push(row?);
+                    } else {
+                        suspended = false;
+                        break;
+                    }
+                }
+
+                if suspended {
+                    Ok(FetchResult {
+                        command_tag,
+                        rows,
+                        row_schema,
+                        suspended: true,
+                    })
+                } else {
+                    *state = PortalExecutionState::Finished;
+                    Ok(FetchResult {
+                        command_tag,
+                        rows,
+                        row_schema,
+                        suspended: false,
+                    })
+                }
+            }
+        }
     }
 }
 

--- a/src/api/portal.rs
+++ b/src/api/portal.rs
@@ -209,9 +209,7 @@ impl<S: Clone> Portal<S> {
         let mut state = self.state.lock().await;
 
         match state.deref_mut() {
-            PortalExecutionState::Initial => Err(PgWireError::IoError(std::io::Error::other(
-                "Cannot fetch from portal in Initial state, call start() first",
-            ))),
+            PortalExecutionState::Initial => Err(PgWireError::PortalNotStarted),
             PortalExecutionState::Finished => Ok(FetchResult {
                 command_tag: String::new(),
                 rows: vec![],

--- a/src/api/portal.rs
+++ b/src/api/portal.rs
@@ -160,6 +160,24 @@ impl<S: Clone> Portal<S> {
     }
 }
 
+impl<S: Default> Portal<S> {
+    /// Create a cursor-oriented portal directly from a query response.
+    ///
+    /// The portal starts in `Suspended` state, ready for `Execute` with
+    /// `max_rows` to fetch batches. No `StoredStatement` is needed — a
+    /// default placeholder is used internally.
+    pub fn new_cursor(name: String, response: QueryResponse) -> Self {
+        Portal {
+            name,
+            statement: Arc::new(StoredStatement::default()),
+            parameter_format: Format::UnifiedText,
+            parameters: vec![],
+            result_column_format: Format::UnifiedText,
+            state: Arc::new(Mutex::new(PortalExecutionState::Suspended(response))),
+        }
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use postgres_types::FromSql;

--- a/src/api/portal.rs
+++ b/src/api/portal.rs
@@ -125,6 +125,22 @@ impl<S: Clone> Portal<S> {
         })
     }
 
+    /// Create a cursor-oriented portal with a stored statement.
+    ///
+    /// The portal starts in `Initial` state. The first call to [`fetch()`](Self::fetch)
+    /// after [`start()`](Self::start) will begin returning rows.
+    /// Use [`start()`](Self::start) to provide a `QueryResponse` before fetching.
+    pub fn new_cursor(name: String, statement: Arc<StoredStatement<S>>) -> Self {
+        Portal {
+            name,
+            statement,
+            parameter_format: Format::UnifiedText,
+            parameters: vec![],
+            result_column_format: Format::UnifiedText,
+            state: Arc::new(Mutex::new(PortalExecutionState::Initial)),
+        }
+    }
+
     /// Get number of parameters
     pub fn parameter_len(&self) -> usize {
         self.parameters.len()
@@ -170,6 +186,16 @@ impl<S: Clone> Portal<S> {
         self.state.clone()
     }
 
+    /// Transition the portal from `Initial` to `Suspended` with the given
+    /// query response.
+    ///
+    /// This is called by the query handler after executing the portal's
+    /// statement, before calling [`fetch()`](Self::fetch) to retrieve rows.
+    pub async fn start(&self, response: QueryResponse) {
+        let mut state = self.state.lock().await;
+        *state = PortalExecutionState::Suspended(response);
+    }
+
     /// Fetch up to `max_rows` from a portal's suspended state.
     ///
     /// Returns a [`FetchResult`] containing the rows, the row schema, and
@@ -177,15 +203,14 @@ impl<S: Clone> Portal<S> {
     /// underlying stream is exhausted, the portal transitions to `Finished`.
     /// When `max_rows` is 0, all remaining rows are fetched.
     ///
-    /// Returns an error if the portal is in `Initial` state or if the stream
-    /// yields an error.
+    /// Returns an error if the portal is in `Initial` state (call
+    /// [`start()`](Self::start) first) or if the stream yields an error.
     pub async fn fetch(&self, max_rows: usize) -> PgWireResult<FetchResult> {
         let mut state = self.state.lock().await;
 
         match state.deref_mut() {
-            PortalExecutionState::Initial => Err(PgWireError::IoError(std::io::Error::new(
-                std::io::ErrorKind::Other,
-                "Cannot fetch from portal in Initial state",
+            PortalExecutionState::Initial => Err(PgWireError::IoError(std::io::Error::other(
+                "Cannot fetch from portal in Initial state, call start() first",
             ))),
             PortalExecutionState::Finished => Ok(FetchResult {
                 command_tag: String::new(),
@@ -226,24 +251,6 @@ impl<S: Clone> Portal<S> {
                     })
                 }
             }
-        }
-    }
-}
-
-impl<S: Default> Portal<S> {
-    /// Create a cursor-oriented portal directly from a query response.
-    ///
-    /// The portal starts in `Suspended` state, ready for `Execute` with
-    /// `max_rows` to fetch batches. No `StoredStatement` is needed — a
-    /// default placeholder is used internally.
-    pub fn new_cursor(name: String, response: QueryResponse) -> Self {
-        Portal {
-            name,
-            statement: Arc::new(StoredStatement::default()),
-            parameter_format: Format::UnifiedText,
-            parameters: vec![],
-            result_column_format: Format::UnifiedText,
-            state: Arc::new(Mutex::new(PortalExecutionState::Suspended(response))),
         }
     }
 }

--- a/src/api/query.rs
+++ b/src/api/query.rs
@@ -438,7 +438,7 @@ pub trait ExtendedQueryHandler: Send + Sync {
         PgWireError: From<<C as Sink<PgWireBackendMessage>>::Error>,
     {
         // cleanup all portals
-        client.portal_store().clear_portals();
+        client.portal_store().rm_portal(DEFAULT_NAME);
 
         client
             .send(PgWireBackendMessage::ReadyForQuery(ReadyForQuery::new(

--- a/src/api/query.rs
+++ b/src/api/query.rs
@@ -1,6 +1,6 @@
 use std::cmp::max;
 use std::fmt::Debug;
-use std::ops::DerefMut;
+use std::ops::Deref;
 use std::sync::Arc;
 
 use async_trait::async_trait;
@@ -264,96 +264,105 @@ pub trait ExtendedQueryHandler: Send + Sync {
         let portal_name = message.name.as_deref().unwrap_or(DEFAULT_NAME);
         let max_rows = message.max_rows as usize;
 
-        if let Some(portal) = client.portal_store().get_portal(portal_name) {
-            let portal_state_lock = portal.state();
-            let mut portal_state = portal_state_lock.lock().await;
-            match portal_state.deref_mut() {
-                PortalExecutionState::Initial => {
-                    let cancel_rx = get_cancel_receiver(client).await;
-                    let resp = if let Some(cancel_rx) = cancel_rx {
-                        match select(self.do_query(client, portal.as_ref(), max_rows), cancel_rx)
-                            .await
-                        {
-                            Either::Left((result, _)) => result,
-                            Either::Right(_) => Err(PgWireError::QueryCanceled),
-                        }
-                    } else {
-                        self.do_query(client, portal.as_ref(), max_rows).await
-                    }?;
-                    match resp {
-                        Response::EmptyQuery => {
-                            client
-                                .feed(PgWireBackendMessage::EmptyQueryResponse(EmptyQueryResponse))
-                                .await?;
-                        }
-                        Response::Query(mut results) => {
-                            if max_rows > 0 {
-                                if send_partial_query_response(client, &mut results, max_rows)
-                                    .await?
-                                {
-                                    *portal_state = PortalExecutionState::Suspended(results);
-                                } else {
-                                    *portal_state = PortalExecutionState::Finished;
-                                }
-                            } else {
-                                send_query_response(client, results, false).await?;
-                            }
-                        }
-                        Response::Execution(tag) => {
-                            send_execution_response(client, tag).await?;
-                        }
-                        Response::TransactionStart(tag) => {
-                            send_execution_response(client, tag).await?;
-                            transaction_status = transaction_status.to_in_transaction_state();
-                        }
-                        Response::TransactionEnd(tag) => {
-                            send_execution_response(client, tag).await?;
-                            transaction_status = transaction_status.to_idle_state();
-                        }
-                        Response::Error(err) => {
-                            client
-                                .send(PgWireBackendMessage::ErrorResponse((*err).into()))
-                                .await?;
-                            transaction_status = transaction_status.to_error_state();
-                        }
-                        Response::CopyIn(result) => {
-                            client.set_state(PgWireConnectionState::CopyInProgress(true));
-                            copy::send_copy_in_response(client, result).await?;
-                        }
-                        Response::CopyOut(result) => {
-                            copy::send_copy_out_response(client, result).await?;
-                        }
-                        Response::CopyBoth(result) => {
-                            client.set_state(PgWireConnectionState::CopyInProgress(true));
-                            copy::send_copy_both_response(client, result).await?;
-                        }
-                    }
+        let Some(portal) = client.portal_store().get_portal(portal_name) else {
+            return Err(PgWireError::PortalNotFound(portal_name.to_owned()));
+        };
+        // Execute query if the portal hasn't been started yet
+        let needs_fetch = if matches!(
+            portal.state().lock().await.deref(),
+            PortalExecutionState::Initial
+        ) {
+            let cancel_rx = get_cancel_receiver(client).await;
+            let resp = if let Some(cancel_rx) = cancel_rx {
+                match select(self.do_query(client, portal.as_ref(), max_rows), cancel_rx).await {
+                    Either::Left((result, _)) => result,
+                    Either::Right(_) => Err(PgWireError::QueryCanceled),
                 }
-                PortalExecutionState::Suspended(results) => {
-                    let has_more = send_partial_query_response(client, results, max_rows).await?;
-                    if !has_more {
-                        *portal_state = PortalExecutionState::Finished;
-                    }
+            } else {
+                self.do_query(client, portal.as_ref(), max_rows).await
+            }?;
+
+            match resp {
+                Response::Query(results) => {
+                    portal.start(results).await;
+                    true
                 }
-                PortalExecutionState::Finished => {
-                    // no data
-                    client.send(PgWireBackendMessage::NoData(NoData)).await?;
+                Response::EmptyQuery => {
+                    client
+                        .feed(PgWireBackendMessage::EmptyQueryResponse(EmptyQueryResponse))
+                        .await?;
+                    false
+                }
+                Response::Execution(tag) => {
+                    send_execution_response(client, tag).await?;
+                    false
+                }
+                Response::TransactionStart(tag) => {
+                    send_execution_response(client, tag).await?;
+                    transaction_status = transaction_status.to_in_transaction_state();
+                    false
+                }
+                Response::TransactionEnd(tag) => {
+                    send_execution_response(client, tag).await?;
+                    transaction_status = transaction_status.to_idle_state();
+                    false
+                }
+                Response::Error(err) => {
+                    client
+                        .send(PgWireBackendMessage::ErrorResponse((*err).into()))
+                        .await?;
+                    transaction_status = transaction_status.to_error_state();
+                    false
+                }
+                Response::CopyIn(result) => {
+                    client.set_state(PgWireConnectionState::CopyInProgress(true));
+                    copy::send_copy_in_response(client, result).await?;
+                    false
+                }
+                Response::CopyOut(result) => {
+                    copy::send_copy_out_response(client, result).await?;
+                    false
+                }
+                Response::CopyBoth(result) => {
+                    client.set_state(PgWireConnectionState::CopyInProgress(true));
+                    copy::send_copy_both_response(client, result).await?;
+                    false
                 }
             }
-
-            if !matches!(client.state(), PgWireConnectionState::CopyInProgress(_)) {
-                client.set_state(super::PgWireConnectionState::ReadyForQuery);
-                client.set_transaction_status(transaction_status);
-            };
-
-            if portal_name == DEFAULT_NAME {
-                client.portal_store().rm_portal(portal_name);
-            }
-
-            Ok(())
         } else {
-            Err(PgWireError::PortalNotFound(portal_name.to_owned()))
+            // Suspended or Finished — fetch remaining rows
+            true
+        };
+
+        // Fetch rows from the portal and send to client
+        if needs_fetch {
+            let fetch_result = portal.fetch(max_rows).await?;
+            let row_count = fetch_result.rows.len();
+            for row in fetch_result.rows {
+                client.feed(PgWireBackendMessage::DataRow(row)).await?;
+            }
+            if fetch_result.suspended {
+                client
+                    .send(PgWireBackendMessage::PortalSuspended(PortalSuspended))
+                    .await?;
+            } else {
+                let tag = Tag::new(&fetch_result.command_tag).with_rows(row_count);
+                client
+                    .send(PgWireBackendMessage::CommandComplete(tag.into()))
+                    .await?;
+            }
         }
+
+        if !matches!(client.state(), PgWireConnectionState::CopyInProgress(_)) {
+            client.set_state(super::PgWireConnectionState::ReadyForQuery);
+            client.set_transaction_status(transaction_status);
+        };
+
+        if portal_name == DEFAULT_NAME {
+            client.portal_store().rm_portal(portal_name);
+        }
+
+        Ok(())
     }
 
     /// Called when client sends `describe` command.

--- a/src/api/query.rs
+++ b/src/api/query.rs
@@ -439,6 +439,7 @@ pub trait ExtendedQueryHandler: Send + Sync {
     {
         // cleanup all portals
         client.portal_store().rm_portal(DEFAULT_NAME);
+        client.portal_store().rm_statement(DEFAULT_NAME);
 
         client
             .send(PgWireBackendMessage::ReadyForQuery(ReadyForQuery::new(

--- a/src/api/query.rs
+++ b/src/api/query.rs
@@ -437,9 +437,7 @@ pub trait ExtendedQueryHandler: Send + Sync {
         C::Error: Debug,
         PgWireError: From<<C as Sink<PgWireBackendMessage>>::Error>,
     {
-        // cleanup all portals
         client.portal_store().rm_portal(DEFAULT_NAME);
-        client.portal_store().rm_statement(DEFAULT_NAME);
 
         client
             .send(PgWireBackendMessage::ReadyForQuery(ReadyForQuery::new(

--- a/src/api/query.rs
+++ b/src/api/query.rs
@@ -305,6 +305,10 @@ pub trait ExtendedQueryHandler: Send + Sync {
                 Response::TransactionEnd(tag) => {
                     send_execution_response(client, tag).await?;
                     transaction_status = transaction_status.to_idle_state();
+
+                    // remove unnamed portal when transaction ends
+                    client.portal_store().rm_portal(DEFAULT_NAME);
+
                     false
                 }
                 Response::Error(err) => {
@@ -357,10 +361,6 @@ pub trait ExtendedQueryHandler: Send + Sync {
             client.set_state(super::PgWireConnectionState::ReadyForQuery);
             client.set_transaction_status(transaction_status);
         };
-
-        if portal_name == DEFAULT_NAME {
-            client.portal_store().rm_portal(portal_name);
-        }
 
         Ok(())
     }

--- a/src/error.rs
+++ b/src/error.rs
@@ -39,6 +39,8 @@ pub enum PgWireError {
     IoError(#[from] std::io::Error),
     #[error("Portal not found for name: {0}")]
     PortalNotFound(String),
+    #[error("Cannot fetch portal in its Initial state, call start() first")]
+    PortalNotStarted,
     #[error("Statement not found for name: {0}")]
     StatementNotFound(String),
     #[error("Parameter index out of bound: {0}")]
@@ -354,6 +356,9 @@ impl From<PgWireError> for ErrorInfo {
             }
             PgWireError::PortalNotFound(_) => {
                 ErrorInfo::new("ERROR".to_owned(), "26000".to_owned(), error.to_string())
+            }
+            PgWireError::PortalNotStarted => {
+                ErrorInfo::new("ERROR".to_owned(), "XX000".to_owned(), error.to_string())
             }
             PgWireError::StatementNotFound(_) => {
                 ErrorInfo::new("ERROR".to_owned(), "26000".to_owned(), error.to_string())


### PR DESCRIPTION
The idea is to provide a unified API to use portal for both extended query and cursor.

We will reuse the state machine in portal. A new `start` is required for initialize query response for portal, to make it fetch-able.

We also included an example for using cursor in `SimpleQueryHandler`.
