### PR TITLE
fix(server): close connection on client Terminate

### DIFF
--- a/src/tokio/server.rs
+++ b/src/tokio/server.rs
@@ -567,6 +567,13 @@ macro_rules! process_socket_messages {
             };
 
             if let Some(Ok(msg)) = msg {
+                // A Terminate ('X') means the client is disconnecting: the backend
+                // must close the connection. Some clients (asyncpg) send Terminate
+                // and then block waiting for the server to drop the socket, so
+                // ignoring it deadlocks the client's close(); break to drop `socket`.
+                if matches!(msg, PgWireFrontendMessage::Terminate(_)) {
+                    break;
+                }
                 let is_extended_query = match socket.state() {
                     PgWireConnectionState::CopyInProgress(is_extended_query) => is_extended_query,
                     _ => msg.is_extended_query(),


### PR DESCRIPTION
# Intro

The frontend message loop matched Terminate ('X') with a catch-all `_ => {}`, so the backend never dropped the socket. 

A client that closes gracefully by sending Terminate and then waiting for the server to close the connection (e.g. asyncpg's Connection.close()) would block forever.

Break out of the read loop on Terminate so the framed socket is dropped and the TCP connection closes, as the protocol requires.
