### PR TITLE
Fix copy protocol messages

### DIFF
--- a/src/error.rs
+++ b/src/error.rs
@@ -173,6 +173,9 @@ impl ErrorInfo {
         let mut fields = Vec::with_capacity(18);
 
         fields.push((b'S', self.severity));
+        if let Some(value) = self.severity_nonlocalized {
+            fields.push((b'V', value));
+        }
         fields.push((b'C', self.code));
         fields.push((b'M', self.message));
         if let Some(value) = self.detail {
@@ -201,9 +204,6 @@ impl ErrorInfo {
         }
         if let Some(value) = self.routine {
             fields.push((b'R', value));
-        }
-        if let Some(value) = self.severity_nonlocalized {
-            fields.push((b'V', value));
         }
         if let Some(value) = self.schema {
             fields.push((b's', value));

--- a/src/messages/copy.rs
+++ b/src/messages/copy.rs
@@ -79,7 +79,7 @@ pub struct CopyFail {
 impl Message for CopyFail {
     #[inline]
     fn message_type() -> Option<u8> {
-        Some(MESSAGE_TYPE_BYTE_COPY_DONE)
+        Some(MESSAGE_TYPE_BYTE_COPY_FAIL)
     }
 
     fn message_length(&self) -> usize {


### PR DESCRIPTION
- fix copy fail message type misprint
- change ErrorInfo fields order to same that pg18 have
   this allows to have message bytes comparison without parsing 