### PR TITLE
feat(api): carry type size and modifier in RowDescription

### DIFF
--- a/src/api/results.rs
+++ b/src/api/results.rs
@@ -875,9 +875,15 @@ mod test {
     fn field_info_type_size_and_modifier_reach_the_field_description() {
         // numeric(18, 4) packs as ((18 << 16) | 4) + 4.
         let typmod = ((18 << 16) | 4) + 4;
-        let fi = FieldInfo::new("amount".into(), None, None, Type::NUMERIC, FieldFormat::Text)
-            .with_type_size(-1)
-            .with_type_modifier(typmod);
+        let fi = FieldInfo::new(
+            "amount".into(),
+            None,
+            None,
+            Type::NUMERIC,
+            FieldFormat::Text,
+        )
+        .with_type_size(-1)
+        .with_type_modifier(typmod);
         let fd = FieldDescription::from(&fi);
         assert_eq!(fd.type_size, -1);
         assert_eq!(fd.type_modifier, typmod);

--- a/src/api/results.rs
+++ b/src/api/results.rs
@@ -153,6 +153,21 @@ pub struct FieldInfo {
     format: FieldFormat,
     #[new(value = "DEFAULT_FORMAT_OPTIONS.with(|opts| Arc::clone(&*opts))")]
     format_options: Arc<FormatOptions>,
+    /// `pg_type.typlen`: the type's fixed byte width, or a negative value for a
+    /// variable-width type. Defaults to 0 ("unspecified"); set it with
+    /// [`FieldInfo::with_type_size`] to describe the value bytes precisely.
+    #[new(value = "0")]
+    type_size: i16,
+    /// `pg_attribute.atttypmod`: the type-specific modifier, such as the
+    /// precision and scale packed into a `numeric(p, s)` or the declared length
+    /// of a `varchar(n)`.
+    ///
+    /// Defaults to `-1`, PostgreSQL's encoding for "no modifier". This matters:
+    /// clients derive display scale from it, and a `0` here is not "unset" but a
+    /// valid-looking modifier that decodes to a nonsense scale — a `numeric`
+    /// then renders with a long tail of spurious zeros in JDBC-based clients.
+    #[new(value = "-1")]
+    type_modifier: i32,
 }
 
 impl FieldInfo {
@@ -191,6 +206,28 @@ impl FieldInfo {
         self.format_options = format_options;
         self
     }
+
+    /// Get the type size (`pg_type.typlen`).
+    pub fn type_size(&self) -> i16 {
+        self.type_size
+    }
+
+    /// Set the type size (`pg_type.typlen`).
+    pub fn with_type_size(mut self, type_size: i16) -> Self {
+        self.type_size = type_size;
+        self
+    }
+
+    /// Get the type modifier (`pg_attribute.atttypmod`).
+    pub fn type_modifier(&self) -> i32 {
+        self.type_modifier
+    }
+
+    /// Set the type modifier (`pg_attribute.atttypmod`); `-1` means none.
+    pub fn with_type_modifier(mut self, type_modifier: i32) -> Self {
+        self.type_modifier = type_modifier;
+        self
+    }
 }
 
 impl From<&FieldInfo> for FieldDescription {
@@ -200,9 +237,8 @@ impl From<&FieldInfo> for FieldDescription {
             fi.table_id.unwrap_or(0),  // table_id
             fi.column_id.unwrap_or(0), // column_id
             fi.datatype.oid(),         // type_id
-            // TODO: type size and modifier
-            0,
-            0,
+            fi.type_size,              // type_size
+            fi.type_modifier,          // type_modifier
             fi.format.value(),
         )
     }
@@ -217,6 +253,8 @@ impl From<FieldDescription> for FieldInfo {
             Type::from_oid(value.type_id).unwrap_or(Type::UNKNOWN),
             FieldFormat::from(value.format_code),
         )
+        .with_type_size(value.type_size)
+        .with_type_modifier(value.type_modifier)
     }
 }
 
@@ -823,6 +861,32 @@ pub enum Response {
 mod test {
 
     use super::*;
+
+    #[test]
+    fn field_info_defaults_to_no_type_modifier() {
+        // `0` is not "unset" on the wire — it decodes to a nonsense scale and
+        // makes JDBC clients render numerics with spurious trailing zeros.
+        let fi = FieldInfo::new("c".into(), None, None, Type::NUMERIC, FieldFormat::Text);
+        assert_eq!(fi.type_modifier(), -1);
+        assert_eq!(FieldDescription::from(&fi).type_modifier, -1);
+    }
+
+    #[test]
+    fn field_info_type_size_and_modifier_reach_the_field_description() {
+        // numeric(18, 4) packs as ((18 << 16) | 4) + 4.
+        let typmod = ((18 << 16) | 4) + 4;
+        let fi = FieldInfo::new("amount".into(), None, None, Type::NUMERIC, FieldFormat::Text)
+            .with_type_size(-1)
+            .with_type_modifier(typmod);
+        let fd = FieldDescription::from(&fi);
+        assert_eq!(fd.type_size, -1);
+        assert_eq!(fd.type_modifier, typmod);
+
+        // And they survive the round trip back into a `FieldInfo`.
+        let back = FieldInfo::from(fd);
+        assert_eq!(back.type_size(), -1);
+        assert_eq!(back.type_modifier(), typmod);
+    }
 
     #[test]
     fn test_command_complete() {


### PR DESCRIPTION
## Problem

`From<&FieldInfo> for FieldDescription` hardcodes the type size and modifier, with a TODO:

```rust
fi.datatype.oid(),         // type_id
// TODO: type size and modifier
0,
0,
```

For the **type modifier** this is not just imprecise, it is actively wrong. PostgreSQL sends `-1` when a type has no modifier; `0` is not "unset" but a valid-looking modifier. Clients decode it and derive a display scale from it: pgJDBC computes a numeric's scale as `(typmod - 4) & 0xffff`, so `0` yields a nonsense scale.

The user-visible symptom: an unconstrained `numeric` holding `1` renders in DataGrip (and other JDBC-based clients) as

```
1.00000000000000000000000000000000000000000000000000000000000000000000000...
```

A declared `numeric(18, 4)` is affected too: it cannot advertise its real precision and scale, so clients cannot format it correctly or report it through `ResultSetMetaData`.

Since `FieldInfo` has no field for either value, a server built on pgwire currently has no way to send a correct `RowDescription`, even when it knows the right answer.

## Change

Adds `type_size` and `type_modifier` to `FieldInfo` and passes them through to `FieldDescription`.

**This is source-compatible.** Both are `#[new(value = ...)]` defaulted fields, so `FieldInfo::new` keeps its current five-argument signature and no existing caller breaks. They are set with `with_type_size` / `with_type_modifier`, mirroring the existing `with_format_options` builder.

The one behavior change is deliberate and is the fix itself: **`type_modifier` now defaults to `-1` instead of `0`**, so servers that do not set it emit PostgreSQL's "no modifier" encoding rather than a modifier that decodes to garbage. `type_size` keeps its `0` default.

The reverse `FieldDescription -> FieldInfo` conversion carries both values back, so a round trip no longer discards them.

## Tests

Two unit tests in `src/api/results.rs`:

- the default modifier is `-1`, and reaches `FieldDescription` as `-1`
- an explicit `numeric(18, 4)` modifier and type size reach `FieldDescription` and survive the round trip back into a `FieldInfo`

I verified the change end to end against a real client: with it applied, a server that previously advertised `typmod=0` on every column now advertises `-1` for unconstrained types and the correctly packed `((p << 16) | s) + 4` for declared `numeric(p, s)`, and DataGrip renders the values correctly.

I was not able to run the full suite locally: the `rusqlite` dev-dependency fails to compile on my toolchain (`error[E0658]: use of unstable library feature 'cfg_select'`), which is unrelated to this change. `cargo build` is clean.