### PR TITLE
Reject malformed element counts in message decoders

### DIFF
--- a/src/error.rs
+++ b/src/error.rs
@@ -17,8 +17,8 @@ pub enum PgWireError {
     InvalidMessageType(u8),
     #[error("Invalid message length, expected max {0}, actual: {1}")]
     MessageTooLarge(usize, usize),
-    #[error("Invalid element count {0}, exceeds {1} remaining bytes")]
-    InvalidElementCount(usize, usize),
+    #[error("Invalid element count {0}: {1} bytes required, {2} remaining")]
+    InvalidElementCount(usize, usize, usize),
     #[error("Invalid target type, received {0}")]
     InvalidTargetType(u8),
     #[error("Invalid transaction status, received {0}")]

--- a/src/error.rs
+++ b/src/error.rs
@@ -17,6 +17,8 @@ pub enum PgWireError {
     InvalidMessageType(u8),
     #[error("Invalid message length, expected max {0}, actual: {1}")]
     MessageTooLarge(usize, usize),
+    #[error("Invalid element count {0}, exceeds {1} remaining bytes")]
+    InvalidElementCount(usize, usize),
     #[error("Invalid target type, received {0}")]
     InvalidTargetType(u8),
     #[error("Invalid transaction status, received {0}")]
@@ -325,6 +327,9 @@ impl From<PgWireError> for ErrorInfo {
                 ErrorInfo::new("FATAL".to_owned(), "08P01".to_owned(), error.to_string())
             }
             PgWireError::MessageTooLarge(..) => {
+                ErrorInfo::new("FATAL".to_owned(), "08P01".to_owned(), error.to_string())
+            }
+            PgWireError::InvalidElementCount(..) => {
                 ErrorInfo::new("FATAL".to_owned(), "08P01".to_owned(), error.to_string())
             }
             PgWireError::InvalidTransactionStatus(_) => {

--- a/src/messages/codec.rs
+++ b/src/messages/codec.rs
@@ -58,6 +58,19 @@ pub(crate) fn get_length(buf: &BytesMut, offset: usize) -> Option<usize> {
     }
 }
 
+/// Validate an on-wire element count before it is used to pre-allocate a
+/// collection. Counts are unsigned; a value larger than the bytes left in the
+/// buffer cannot describe a real message (each element takes at least one byte),
+/// so it is rejected instead of driving an oversized `Vec::with_capacity`.
+pub(crate) fn read_count(count: usize, buf: &BytesMut) -> PgWireResult<usize> {
+    let remaining = buf.remaining();
+    if count > remaining {
+        Err(PgWireError::InvalidElementCount(count, remaining))
+    } else {
+        Ok(count)
+    }
+}
+
 /// Check if message_length matches and move the cursor to right position then
 /// call the `decode_fn` for the body
 pub(crate) fn decode_packet<T, F>(

--- a/src/messages/codec.rs
+++ b/src/messages/codec.rs
@@ -59,13 +59,13 @@ pub(crate) fn get_length(buf: &BytesMut, offset: usize) -> Option<usize> {
 }
 
 /// Validate an on-wire element count before it is used to pre-allocate a
-/// collection. Counts are unsigned; a value larger than the bytes left in the
-/// buffer cannot describe a real message (each element takes at least one byte),
-/// so it is rejected instead of driving an oversized `Vec::with_capacity`.
-pub(crate) fn ensure_count(count: usize, buf: &BytesMut) -> PgWireResult<()> {
+/// collection. Counts are unsigned; `count` elements of `elem_size` bytes each
+/// must fit in the remaining buffer, or the message cannot be real.
+pub(crate) fn ensure_count(count: usize, elem_size: usize, buf: &BytesMut) -> PgWireResult<()> {
     let remaining = buf.remaining();
-    if count > remaining {
-        Err(PgWireError::InvalidElementCount(count, remaining))
+    let needed = count.saturating_mul(elem_size);
+    if needed > remaining {
+        Err(PgWireError::InvalidElementCount(count, needed, remaining))
     } else {
         Ok(())
     }

--- a/src/messages/codec.rs
+++ b/src/messages/codec.rs
@@ -62,12 +62,12 @@ pub(crate) fn get_length(buf: &BytesMut, offset: usize) -> Option<usize> {
 /// collection. Counts are unsigned; a value larger than the bytes left in the
 /// buffer cannot describe a real message (each element takes at least one byte),
 /// so it is rejected instead of driving an oversized `Vec::with_capacity`.
-pub(crate) fn read_count(count: usize, buf: &BytesMut) -> PgWireResult<usize> {
+pub(crate) fn ensure_count(count: usize, buf: &BytesMut) -> PgWireResult<()> {
     let remaining = buf.remaining();
     if count > remaining {
         Err(PgWireError::InvalidElementCount(count, remaining))
     } else {
-        Ok(count)
+        Ok(())
     }
 }
 

--- a/src/messages/copy.rs
+++ b/src/messages/copy.rs
@@ -184,14 +184,14 @@ impl Message for CopyOutResponse {
 
     fn decode_body(buf: &mut BytesMut, _len: usize, _ctx: &DecodeContext) -> PgWireResult<Self> {
         let format = buf.get_i8();
-        let columns = buf.get_u16();
+        let columns = buf.get_i16();
         codec::ensure_count(columns as usize, 2, buf)?;
         let mut column_formats = Vec::with_capacity(columns as usize);
         for _ in 0..columns {
             column_formats.push(buf.get_i16());
         }
 
-        Ok(Self::new(format, columns as i16, column_formats))
+        Ok(Self::new(format, columns, column_formats))
     }
 }
 
@@ -233,13 +233,13 @@ impl Message for CopyBothResponse {
 
     fn decode_body(buf: &mut BytesMut, _len: usize, _ctx: &DecodeContext) -> PgWireResult<Self> {
         let format = buf.get_i8();
-        let columns = buf.get_u16();
+        let columns = buf.get_i16();
         codec::ensure_count(columns as usize, 2, buf)?;
         let mut column_formats = Vec::with_capacity(columns as usize);
         for _ in 0..columns {
             column_formats.push(buf.get_i16());
         }
 
-        Ok(Self::new(format, columns as i16, column_formats))
+        Ok(Self::new(format, columns, column_formats))
     }
 }

--- a/src/messages/copy.rs
+++ b/src/messages/copy.rs
@@ -135,8 +135,9 @@ impl Message for CopyInResponse {
 
     fn decode_body(buf: &mut BytesMut, _len: usize, _ctx: &DecodeContext) -> PgWireResult<Self> {
         let format = buf.get_i8();
-        let columns = codec::read_count(buf.get_u16() as usize, buf)?;
-        let mut column_formats = Vec::with_capacity(columns);
+        let columns = buf.get_u16();
+        codec::ensure_count(columns as usize, buf)?;
+        let mut column_formats = Vec::with_capacity(columns as usize);
         for _ in 0..columns {
             column_formats.push(buf.get_i16());
         }
@@ -183,8 +184,9 @@ impl Message for CopyOutResponse {
 
     fn decode_body(buf: &mut BytesMut, _len: usize, _ctx: &DecodeContext) -> PgWireResult<Self> {
         let format = buf.get_i8();
-        let columns = codec::read_count(buf.get_u16() as usize, buf)?;
-        let mut column_formats = Vec::with_capacity(columns);
+        let columns = buf.get_u16();
+        codec::ensure_count(columns as usize, buf)?;
+        let mut column_formats = Vec::with_capacity(columns as usize);
         for _ in 0..columns {
             column_formats.push(buf.get_i16());
         }
@@ -231,8 +233,9 @@ impl Message for CopyBothResponse {
 
     fn decode_body(buf: &mut BytesMut, _len: usize, _ctx: &DecodeContext) -> PgWireResult<Self> {
         let format = buf.get_i8();
-        let columns = codec::read_count(buf.get_u16() as usize, buf)?;
-        let mut column_formats = Vec::with_capacity(columns);
+        let columns = buf.get_u16();
+        codec::ensure_count(columns as usize, buf)?;
+        let mut column_formats = Vec::with_capacity(columns as usize);
         for _ in 0..columns {
             column_formats.push(buf.get_i16());
         }

--- a/src/messages/copy.rs
+++ b/src/messages/copy.rs
@@ -135,13 +135,13 @@ impl Message for CopyInResponse {
 
     fn decode_body(buf: &mut BytesMut, _len: usize, _ctx: &DecodeContext) -> PgWireResult<Self> {
         let format = buf.get_i8();
-        let columns = buf.get_i16();
-        let mut column_formats = Vec::with_capacity(columns as usize);
+        let columns = codec::read_count(buf.get_u16() as usize, buf)?;
+        let mut column_formats = Vec::with_capacity(columns);
         for _ in 0..columns {
             column_formats.push(buf.get_i16());
         }
 
-        Ok(Self::new(format, columns, column_formats))
+        Ok(Self::new(format, columns as i16, column_formats))
     }
 }
 
@@ -183,13 +183,13 @@ impl Message for CopyOutResponse {
 
     fn decode_body(buf: &mut BytesMut, _len: usize, _ctx: &DecodeContext) -> PgWireResult<Self> {
         let format = buf.get_i8();
-        let columns = buf.get_i16();
-        let mut column_formats = Vec::with_capacity(columns as usize);
+        let columns = codec::read_count(buf.get_u16() as usize, buf)?;
+        let mut column_formats = Vec::with_capacity(columns);
         for _ in 0..columns {
             column_formats.push(buf.get_i16());
         }
 
-        Ok(Self::new(format, columns, column_formats))
+        Ok(Self::new(format, columns as i16, column_formats))
     }
 }
 
@@ -231,12 +231,12 @@ impl Message for CopyBothResponse {
 
     fn decode_body(buf: &mut BytesMut, _len: usize, _ctx: &DecodeContext) -> PgWireResult<Self> {
         let format = buf.get_i8();
-        let columns = buf.get_i16();
-        let mut column_formats = Vec::with_capacity(columns as usize);
+        let columns = codec::read_count(buf.get_u16() as usize, buf)?;
+        let mut column_formats = Vec::with_capacity(columns);
         for _ in 0..columns {
             column_formats.push(buf.get_i16());
         }
 
-        Ok(Self::new(format, columns, column_formats))
+        Ok(Self::new(format, columns as i16, column_formats))
     }
 }

--- a/src/messages/copy.rs
+++ b/src/messages/copy.rs
@@ -135,14 +135,14 @@ impl Message for CopyInResponse {
 
     fn decode_body(buf: &mut BytesMut, _len: usize, _ctx: &DecodeContext) -> PgWireResult<Self> {
         let format = buf.get_i8();
-        let columns = buf.get_u16();
-        codec::ensure_count(columns as usize, buf)?;
+        let columns = buf.get_i16();
+        codec::ensure_count(columns as usize, 2, buf)?;
         let mut column_formats = Vec::with_capacity(columns as usize);
         for _ in 0..columns {
             column_formats.push(buf.get_i16());
         }
 
-        Ok(Self::new(format, columns as i16, column_formats))
+        Ok(Self::new(format, columns, column_formats))
     }
 }
 
@@ -185,7 +185,7 @@ impl Message for CopyOutResponse {
     fn decode_body(buf: &mut BytesMut, _len: usize, _ctx: &DecodeContext) -> PgWireResult<Self> {
         let format = buf.get_i8();
         let columns = buf.get_u16();
-        codec::ensure_count(columns as usize, buf)?;
+        codec::ensure_count(columns as usize, 2, buf)?;
         let mut column_formats = Vec::with_capacity(columns as usize);
         for _ in 0..columns {
             column_formats.push(buf.get_i16());
@@ -234,7 +234,7 @@ impl Message for CopyBothResponse {
     fn decode_body(buf: &mut BytesMut, _len: usize, _ctx: &DecodeContext) -> PgWireResult<Self> {
         let format = buf.get_i8();
         let columns = buf.get_u16();
-        codec::ensure_count(columns as usize, buf)?;
+        codec::ensure_count(columns as usize, 2, buf)?;
         let mut column_formats = Vec::with_capacity(columns as usize);
         for _ in 0..columns {
             column_formats.push(buf.get_i16());

--- a/src/messages/data.rs
+++ b/src/messages/data.rs
@@ -75,8 +75,8 @@ impl Message for RowDescription {
     }
 
     fn decode_body(buf: &mut BytesMut, _: usize, _ctx: &DecodeContext) -> PgWireResult<Self> {
-        let fields_len = buf.get_i16();
-        let mut fields = Vec::with_capacity(fields_len as usize);
+        let fields_len = codec::read_count(buf.get_u16() as usize, buf)?;
+        let mut fields = Vec::with_capacity(fields_len);
 
         for _ in 0..fields_len {
             let field = FieldDescription {

--- a/src/messages/data.rs
+++ b/src/messages/data.rs
@@ -75,7 +75,7 @@ impl Message for RowDescription {
     }
 
     fn decode_body(buf: &mut BytesMut, _: usize, _ctx: &DecodeContext) -> PgWireResult<Self> {
-        let fields_len = buf.get_u16();
+        let fields_len = buf.get_i16();
         // Each field: C-string name (>= 1 byte) + 18 fixed bytes.
         codec::ensure_count(fields_len as usize, 19, buf)?;
         let mut fields = Vec::with_capacity(fields_len as usize);

--- a/src/messages/data.rs
+++ b/src/messages/data.rs
@@ -76,7 +76,8 @@ impl Message for RowDescription {
 
     fn decode_body(buf: &mut BytesMut, _: usize, _ctx: &DecodeContext) -> PgWireResult<Self> {
         let fields_len = buf.get_u16();
-        codec::ensure_count(fields_len as usize, buf)?;
+        // Each field: C-string name (>= 1 byte) + 18 fixed bytes.
+        codec::ensure_count(fields_len as usize, 19, buf)?;
         let mut fields = Vec::with_capacity(fields_len as usize);
 
         for _ in 0..fields_len {

--- a/src/messages/data.rs
+++ b/src/messages/data.rs
@@ -75,8 +75,9 @@ impl Message for RowDescription {
     }
 
     fn decode_body(buf: &mut BytesMut, _: usize, _ctx: &DecodeContext) -> PgWireResult<Self> {
-        let fields_len = codec::read_count(buf.get_u16() as usize, buf)?;
-        let mut fields = Vec::with_capacity(fields_len);
+        let fields_len = buf.get_u16();
+        codec::ensure_count(fields_len as usize, buf)?;
+        let mut fields = Vec::with_capacity(fields_len as usize);
 
         for _ in 0..fields_len {
             let field = FieldDescription {

--- a/src/messages/extendedquery.rs
+++ b/src/messages/extendedquery.rs
@@ -281,7 +281,7 @@ impl Message for Bind {
         }
 
         let result_column_format_code_len = buf.get_u16();
-        codec::ensure_count(result_column_format_code_len as usize, buf)?;
+        codec::ensure_count(result_column_format_code_len as usize, 2, buf)?;
         let mut result_column_format_codes =
             Vec::with_capacity(result_column_format_code_len as usize);
         for _ in 0..result_column_format_code_len {

--- a/src/messages/extendedquery.rs
+++ b/src/messages/extendedquery.rs
@@ -280,9 +280,8 @@ impl Message for Bind {
             }
         }
 
-        let result_column_format_code_len = buf.get_i16();
-        let mut result_column_format_codes =
-            Vec::with_capacity(result_column_format_code_len as usize);
+        let result_column_format_code_len = codec::read_count(buf.get_u16() as usize, buf)?;
+        let mut result_column_format_codes = Vec::with_capacity(result_column_format_code_len);
         for _ in 0..result_column_format_code_len {
             result_column_format_codes.push(buf.get_i16());
         }

--- a/src/messages/extendedquery.rs
+++ b/src/messages/extendedquery.rs
@@ -280,8 +280,10 @@ impl Message for Bind {
             }
         }
 
-        let result_column_format_code_len = codec::read_count(buf.get_u16() as usize, buf)?;
-        let mut result_column_format_codes = Vec::with_capacity(result_column_format_code_len);
+        let result_column_format_code_len = buf.get_u16();
+        codec::ensure_count(result_column_format_code_len as usize, buf)?;
+        let mut result_column_format_codes =
+            Vec::with_capacity(result_column_format_code_len as usize);
         for _ in 0..result_column_format_code_len {
             result_column_format_codes.push(buf.get_i16());
         }

--- a/src/messages/mod.rs
+++ b/src/messages/mod.rs
@@ -1029,4 +1029,49 @@ mod test {
         assert_eq!(196608i32, i32::from(ProtocolVersion::PROTOCOL3_0));
         assert_eq!(196610i32, i32::from(ProtocolVersion::PROTOCOL3_2));
     }
+
+    // A count read as signed (0xffff -> -1 -> usize::MAX) must become a decode
+    // error, not a `capacity overflow` panic. Completes #192 for the decoders it
+    // did not reach.
+    #[test]
+    fn test_element_count_capacity_overflow_rejected() {
+        let ctx = DecodeContext::new(ProtocolVersion::PROTOCOL3_0);
+
+        // Backend messages decoded by the client/proxy from an untrusted server.
+        for bytes in [
+            &b"T\0\0\0\x06\xff\xff"[..],                 // RowDescription
+            &b"G\0\0\0\x07\0\xff\xff"[..],               // CopyInResponse
+            &b"H\0\0\0\x07\0\xff\xff"[..],               // CopyOutResponse
+            &b"W\0\0\0\x07\0\xff\xff"[..],               // CopyBothResponse
+            &b"v\0\0\0\x0c\0\0\0\0\xff\xff\xff\xff"[..], // NegotiateProtocolVersion
+        ] {
+            let mut buf = BytesMut::from(bytes);
+            assert!(super::PgWireBackendMessage::decode(&mut buf, &ctx).is_err());
+        }
+
+        // Bind decoded by the server from an untrusted client. #192 widened the
+        // first two of Bind's three counts; this covers the third.
+        let mut fctx = DecodeContext::new(ProtocolVersion::PROTOCOL3_0);
+        fctx.awaiting_frontend_ssl = false;
+        fctx.awaiting_frontend_startup = false;
+        let mut buf = BytesMut::from(&b"B\0\0\0\x0c\0\0\0\0\0\0\xff\xff"[..]);
+        assert!(super::PgWireFrontendMessage::decode(&mut buf, &fctx).is_err());
+    }
+
+    #[test]
+    fn test_valid_element_count_still_decodes() {
+        let ctx = DecodeContext::new(ProtocolVersion::PROTOCOL3_0);
+
+        // Zero count decodes to an empty collection.
+        let mut buf = BytesMut::from(&b"T\0\0\0\x06\0\0"[..]);
+        let row = RowDescription::decode(&mut buf, &ctx).unwrap().unwrap();
+        assert!(row.fields.is_empty());
+
+        // A well-formed positive count round-trips.
+        let row = RowDescription::new(vec![
+            FieldDescription::new("id".to_owned(), 0, 0, 23, 4, -1, 0),
+            FieldDescription::new("name".to_owned(), 0, 0, 25, -1, -1, 0),
+        ]);
+        roundtrip!(row, RowDescription, &ctx);
+    }
 }

--- a/src/messages/mod.rs
+++ b/src/messages/mod.rs
@@ -1056,6 +1056,12 @@ mod test {
         fctx.awaiting_frontend_startup = false;
         let mut buf = BytesMut::from(&b"B\0\0\0\x0c\0\0\0\0\0\0\xff\xff"[..]);
         assert!(super::PgWireFrontendMessage::decode(&mut buf, &fctx).is_err());
+
+        // Bind with 5 result format codes but only 6 bytes left: the codes are
+        // Int16s, so the element-aware bound must reject (5 * 2 > 6) instead of
+        // passing a byte-count check and panicking on the truncated read.
+        let mut buf = BytesMut::from(&b"B\0\0\0\x0e\0\0\0\0\0\0\0\x05\0\0\0\0\0\0"[..]);
+        assert!(super::PgWireFrontendMessage::decode(&mut buf, &fctx).is_err());
     }
 
     #[test]

--- a/src/messages/startup.rs
+++ b/src/messages/startup.rs
@@ -820,7 +820,7 @@ impl Message for NegotiateProtocolVersion {
         _ctx: &DecodeContext,
     ) -> PgWireResult<Self> {
         let version = buf.get_i32();
-        let option_count = buf.get_u32();
+        let option_count = buf.get_i32();
         codec::ensure_count(option_count as usize, 1, buf)?;
         let mut options = Vec::with_capacity(option_count as usize);
 

--- a/src/messages/startup.rs
+++ b/src/messages/startup.rs
@@ -821,7 +821,7 @@ impl Message for NegotiateProtocolVersion {
     ) -> PgWireResult<Self> {
         let version = buf.get_i32();
         let option_count = buf.get_u32();
-        codec::ensure_count(option_count as usize, buf)?;
+        codec::ensure_count(option_count as usize, 1, buf)?;
         let mut options = Vec::with_capacity(option_count as usize);
 
         for _ in 0..option_count {

--- a/src/messages/startup.rs
+++ b/src/messages/startup.rs
@@ -820,8 +820,9 @@ impl Message for NegotiateProtocolVersion {
         _ctx: &DecodeContext,
     ) -> PgWireResult<Self> {
         let version = buf.get_i32();
-        let option_count = codec::read_count(buf.get_u32() as usize, buf)?;
-        let mut options = Vec::with_capacity(option_count);
+        let option_count = buf.get_u32();
+        codec::ensure_count(option_count as usize, buf)?;
+        let mut options = Vec::with_capacity(option_count as usize);
 
         for _ in 0..option_count {
             options.push(codec::get_cstring(buf).unwrap_or_else(|| "".to_owned()))

--- a/src/messages/startup.rs
+++ b/src/messages/startup.rs
@@ -820,8 +820,8 @@ impl Message for NegotiateProtocolVersion {
         _ctx: &DecodeContext,
     ) -> PgWireResult<Self> {
         let version = buf.get_i32();
-        let option_count = buf.get_i32();
-        let mut options = Vec::with_capacity(option_count as usize);
+        let option_count = codec::read_count(buf.get_u32() as usize, buf)?;
+        let mut options = Vec::with_capacity(option_count);
 
         for _ in 0..option_count {
             options.push(codec::get_cstring(buf).unwrap_or_else(|| "".to_owned()))


### PR DESCRIPTION
Several message decoders read a repeated-element count as a signed `i16`/`i32` and hand it to `Vec::with_capacity` before reading any element. A negative count (`0xffff` as `i16` = -1) sign-extends to `usize::MAX` and panics with `capacity overflow`, so a ~7-byte crafted message crashes whoever decodes it — the shipped client/proxy on a backend message, or the server on `Bind`.

Repro (debug and release):
`PgWireBackendMessage::decode(&mut BytesMut::from(&b"T\0\0\0\x06\xff\xff"[..]), &ctx)` → `capacity overflow`.

#192 fixed this for `Parse`, `Bind` and `ParameterDescription` by widening the count to `u16` but stopped short of the siblings that share the shape. This completes it for the six missed: `RowDescription`, `CopyInResponse`/`CopyOutResponse`/`CopyBothResponse`, `NegotiateProtocolVersion` (re-introduced in #281), and `Bind`'s `result_column_format_codes` (#192 widened the other two counts in that same function, not this third).

The counts are read unsigned and routed through one shared `codec::read_count` that rejects a count larger than the remaining bytes, turning a malformed message into a decode `Err`. A single helper also keeps the pattern from silently reappearing as it did in #281; and reading unsigned alone isn't enough for the `i32` option count, where `u32::MAX` still forces a huge allocation, so the bound is applied uniformly. The four counts #192 already widened are left untouched.

Tests exercise all six sites through the public `decode` API, plus zero-count and well-formed positive-count controls.