### PR TITLE
perf: coalesce query response into a single socket write (feed instead of send)

### DIFF
--- a/src/api/query.rs
+++ b/src/api/query.rs
@@ -573,10 +573,15 @@ where
 
     // Simple query has row_schema in query response. For extended query,
     // row_schema is returned as response of `Describe`.
+    //
+    // Use `feed` rather than `send` so the whole response coalesces into the one
+    // terminal flush the connection loop already performs (`send_ready_for_query`
+    // for simple queries, `on_sync`/`on_flush` for extended). With TCP_NODELAY on,
+    // each `send` flush is its own `sendto`/segment.
     if send_describe {
         let row_desc = into_row_description(&row_schema);
         client
-            .send(PgWireBackendMessage::RowDescription(row_desc))
+            .feed(PgWireBackendMessage::RowDescription(row_desc))
             .await?;
     }
 
@@ -589,7 +594,7 @@ where
 
     let tag = Tag::new(&command_tag).with_rows(rows);
     client
-        .send(PgWireBackendMessage::CommandComplete(tag.into()))
+        .feed(PgWireBackendMessage::CommandComplete(tag.into()))
         .await?;
 
     Ok(())
@@ -661,8 +666,10 @@ where
     C::Error: Debug,
     PgWireError: From<<C as Sink<PgWireBackendMessage>>::Error>,
 {
+    // Use `feed` rather than `send` so the CommandComplete coalesces with the
+    // trailing ReadyForQuery into one socket write (see `send_query_response`).
     client
-        .send(PgWireBackendMessage::CommandComplete(tag.into()))
+        .feed(PgWireBackendMessage::CommandComplete(tag.into()))
         .await?;
 
     Ok(())


### PR DESCRIPTION
### Summary

`send_query_response` and `send_execution_response` call `.send()` (feed + flush) for the intermediate `RowDescription` and `CommandComplete` messages. With `TCP_NODELAY` enabled (the common setup, and what the examples use), each `.send()` flush becomes its own `sendto` syscall and its own TCP segment. A single-row `SELECT` therefore costs three `sendto`s:

1. `RowDescription`
2. `DataRow` + `CommandComplete` (the `DataRow` is already `feed`-buffered)
3. `ReadyForQuery`

This PR changes those three `.send()` calls to `.feed()`, so the whole response coalesces into the one terminal flush the connection loop already performs:

- **simple query** → `send_ready_for_query` (a `.send()` on `ReadyForQuery`, which flushes) — including the error path via `process_error`
- **extended query** → `on_sync` / `on_flush` (both call `client.flush()`)

No message is left unsent, message ordering is unchanged, and no protocol semantics change — only the number of socket writes/segments drops (3 → 1 for a single-row `SELECT`).

`send_partial_query_response` (the portal-suspend / `max_rows` path) is intentionally left on `.send()`, since an `Execute` with `max_rows` can be followed by more `Execute`s before a `Sync`.

### Measured impact

Embedding this in a Postgres-wire server (sysbench over TCP loopback, `TCP_NODELAY` on):

| Metric | Before | After |
|---|---|---|
| `sendto` per query | 3 | **1** |
| `SELECT 1` round-trip latency | 0.029 ms | **0.020 ms** |
| `oltp_point_select` throughput | — | **+36%** |

### The change

Three `.send()` → `.feed()` in `src/api/query.rs` (`send_query_response`: `RowDescription` + `CommandComplete`; `send_execution_response`: `CommandComplete`), plus short explanatory comments. `cargo fmt` clean; `cargo check` clean.