### PR TITLE
feat: client transaction status tracking

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,11 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Added
 
+- Client API: transaction status tracking. `ClientInfo::transaction_status`
+  reports the status carried by the last `ReadyForQuery` message (idle, in
+  transaction, or in a failed transaction), updated automatically on every
+  code path: startup, simple and extended query, and the error-recovery
+  drains.
 - Client API: protocol version negotiation. `Config::protocol_version`
   selects the version to advertise in the startup message, defaulting to 3.0.
   Following libpq, a test version `3.9999` is available to request the newest

--- a/src/api/client/auth.rs
+++ b/src/api/client/auth.rs
@@ -52,6 +52,7 @@ pub trait StartupHandler: Send {
                 self.on_backend_key(client, backend_key_data).await?;
             }
             PgWireBackendMessage::ReadyForQuery(ready) => {
+                client.set_transaction_status(ready.status);
                 let server_information = self.on_ready_for_query(client, ready).await?;
                 return Ok(ReadyState::Ready(server_information));
             }

--- a/src/api/client/mod.rs
+++ b/src/api/client/mod.rs
@@ -9,6 +9,7 @@ use std::collections::BTreeMap;
 pub use config::Config;
 
 use crate::messages::ProtocolVersion;
+use crate::messages::response::TransactionStatus;
 use crate::messages::startup::SecretKey;
 
 /// A trait for fetching necessary information from Client
@@ -53,7 +54,22 @@ pub trait ClientInfo {
     /// this automatically.
     fn set_protocol_version(&mut self, version: ProtocolVersion);
 
-    // TODO: transaction state
+    /// Returns the current transaction status, as last reported by the
+    /// server in a `ReadyForQuery` message.
+    ///
+    /// The status starts as [`TransactionStatus::Idle`] after startup and
+    /// is updated automatically whenever a `ReadyForQuery` message is
+    /// consumed, on every code path: startup, simple query, extended query,
+    /// and the error-recovery drains.
+    fn transaction_status(&self) -> TransactionStatus;
+
+    /// Updates the tracked transaction status.
+    ///
+    /// This is called automatically by the default message dispatch when a
+    /// `ReadyForQuery` message arrives. Handlers that override the default
+    /// `on_message` implementations and consume `ReadyForQuery` themselves
+    /// should call this so the tracked status stays in sync.
+    fn set_transaction_status(&mut self, status: TransactionStatus);
 }
 
 /// Carries server provided information for current connection

--- a/src/api/client/query.rs
+++ b/src/api/client/query.rs
@@ -86,6 +86,7 @@ pub trait SimpleQueryHandler: Send {
                 self.on_parameter_status(client, parameter_status).await?;
             }
             PgWireBackendMessage::ReadyForQuery(ready_for_query) => {
+                client.set_transaction_status(ready_for_query.status);
                 let response = self.on_ready_for_query(client, ready_for_query).await?;
                 return Ok(ReadyState::Ready(response));
             }
@@ -426,7 +427,10 @@ where
     async fn drain_to_ready(&mut self) {
         while let Some(message_result) = self.client.next().await {
             match message_result {
-                Ok(PgWireBackendMessage::ReadyForQuery(_)) => break,
+                Ok(PgWireBackendMessage::ReadyForQuery(ready)) => {
+                    self.client.set_transaction_status(ready.status);
+                    break;
+                }
                 Ok(PgWireBackendMessage::ParameterStatus(parameter_status)) => {
                     self.client
                         .set_server_parameter(parameter_status.name, parameter_status.value);
@@ -449,7 +453,10 @@ where
         while let Some(message_result) = self.client.next().await {
             let message = message_result?;
             match message {
-                PgWireBackendMessage::ReadyForQuery(_) => return Ok(()),
+                PgWireBackendMessage::ReadyForQuery(ready) => {
+                    self.client.set_transaction_status(ready.status);
+                    return Ok(());
+                }
                 PgWireBackendMessage::ParameterStatus(parameter_status) => {
                     self.client
                         .set_server_parameter(parameter_status.name, parameter_status.value);
@@ -502,7 +509,8 @@ where
                     let _ = self.handler.on_row_description(row_desc).await?;
                 }
                 PgWireBackendMessage::NoData(_) => {}
-                PgWireBackendMessage::ReadyForQuery(_) => {
+                PgWireBackendMessage::ReadyForQuery(ready) => {
+                    self.client.set_transaction_status(ready.status);
                     return Ok(response);
                 }
                 PgWireBackendMessage::ErrorResponse(error) => {
@@ -680,7 +688,8 @@ where
                         done = true;
                     }
                 }
-                PgWireBackendMessage::ReadyForQuery(_) => {
+                PgWireBackendMessage::ReadyForQuery(ready) => {
+                    self.client.set_transaction_status(ready.status);
                     done = true;
                 }
                 PgWireBackendMessage::ErrorResponse(error) => {
@@ -721,7 +730,8 @@ where
             let message = message_result?;
             match message {
                 PgWireBackendMessage::CloseComplete(_) => {}
-                PgWireBackendMessage::ReadyForQuery(_) => {
+                PgWireBackendMessage::ReadyForQuery(ready) => {
+                    self.client.set_transaction_status(ready.status);
                     return Ok(());
                 }
                 PgWireBackendMessage::ErrorResponse(error) => {
@@ -785,7 +795,8 @@ where
                     self.client
                         .set_server_parameter(parameter_status.name, parameter_status.value);
                 }
-                PgWireBackendMessage::ReadyForQuery(_) => {
+                PgWireBackendMessage::ReadyForQuery(ready) => {
+                    self.client.set_transaction_status(ready.status);
                     return Ok(rows);
                 }
                 _ => {

--- a/src/tokio/client.rs
+++ b/src/tokio/client.rs
@@ -26,6 +26,7 @@ use crate::api::client::query::{ExtendedQueryClient, ExtendedQueryHandler, Simpl
 use crate::api::client::{ClientInfo, Config, ReadyState, ServerInformation};
 use crate::error::{PgWireClientError, PgWireClientResult, PgWireError};
 use crate::messages::cancel::CancelRequest;
+use crate::messages::response::TransactionStatus;
 use crate::messages::startup::SecretKey;
 use crate::messages::{
     DecodeContext, PgWireBackendMessage, PgWireFrontendMessage, ProtocolVersion,
@@ -80,6 +81,9 @@ pub struct PgWireClient {
     socket: Framed<ClientSocket, PgWireMessageClientCodec>,
     config: Arc<Config>,
     server_information: ServerInformation,
+    /// Transaction status as last reported by the server in a
+    /// `ReadyForQuery` message.
+    transaction_status: TransactionStatus,
     /// TLS connector retained so [`PgWireClient::cancel`] can open a second
     /// secured connection to the same server.
     #[cfg(any(feature = "_ring", feature = "_aws-lc-rs"))]
@@ -113,6 +117,14 @@ impl ClientInfo for PgWireClient {
 
     fn set_protocol_version(&mut self, version: ProtocolVersion) {
         self.socket.codec_mut().decode_context.protocol_version = version;
+    }
+
+    fn transaction_status(&self) -> TransactionStatus {
+        self.transaction_status
+    }
+
+    fn set_transaction_status(&mut self, status: TransactionStatus) {
+        self.transaction_status = status;
     }
 }
 
@@ -159,6 +171,7 @@ impl PgWireClient {
             socket,
             config: config.clone(),
             server_information: ServerInformation::default(),
+            transaction_status: TransactionStatus::Idle,
             #[cfg(any(feature = "_ring", feature = "_aws-lc-rs"))]
             tls_connector: tls_connector_for_cancel,
         };
@@ -257,7 +270,10 @@ impl PgWireClient {
                     // last message of a simple query
                     while let Some(message_result) = self.next().await {
                         match message_result? {
-                            PgWireBackendMessage::ReadyForQuery(_) => break,
+                            PgWireBackendMessage::ReadyForQuery(ready) => {
+                                self.set_transaction_status(ready.status);
+                                break;
+                            }
                             PgWireBackendMessage::ParameterStatus(parameter_status) => {
                                 self.set_server_parameter(
                                     parameter_status.name,
@@ -503,6 +519,7 @@ fn get_addr(config: &Config) -> Result<PgSocketAddr, PgWireClientError> {
 mod tests {
     use std::sync::Arc;
 
+    use async_trait::async_trait;
     use tokio::net::TcpListener;
 
     use super::PgWireClient;
@@ -510,7 +527,14 @@ mod tests {
     use crate::api::client::ClientInfo;
     use crate::api::client::auth::DefaultStartupHandler;
     use crate::api::client::config::Config;
+    use crate::api::client::query::DefaultSimpleQueryHandler;
+    use crate::api::query::SimpleQueryHandler as ServerSimpleQueryHandler;
+    use crate::api::results::{Response, Tag};
+    use crate::api::store::PortalStore;
+    use crate::api::{ClientInfo as ServerClientInfo, ClientPortalStore};
+    use crate::error::{ErrorInfo, PgWireResult};
     use crate::messages::ProtocolVersion;
+    use crate::messages::response::TransactionStatus;
     use crate::messages::startup::SecretKey;
     use crate::tokio::server::process_socket;
 
@@ -518,13 +542,48 @@ mod tests {
 
     impl PgWireServerHandlers for TestHandlers {}
 
-    async fn spawn_test_server() -> u16 {
+    /// Simple-query handler that models transaction control statements the
+    /// way a real backend does, for exercising client-side status tracking.
+    struct TxHandlers;
+
+    impl PgWireServerHandlers for TxHandlers {
+        fn simple_query_handler(&self) -> Arc<impl ServerSimpleQueryHandler> {
+            Arc::new(TxSimpleQueryHandler)
+        }
+    }
+
+    struct TxSimpleQueryHandler;
+
+    #[async_trait]
+    impl ServerSimpleQueryHandler for TxSimpleQueryHandler {
+        async fn do_query<C>(&self, _client: &mut C, query: &str) -> PgWireResult<Vec<Response>>
+        where
+            C: ServerClientInfo + ClientPortalStore + Unpin + Send + Sync,
+            C::PortalStore: PortalStore,
+        {
+            match query.trim().to_uppercase().as_str() {
+                "BEGIN" => Ok(vec![Response::TransactionStart(Tag::new("BEGIN"))]),
+                "COMMIT" | "ROLLBACK" => Ok(vec![Response::TransactionEnd(Tag::new("COMMIT"))]),
+                "FAIL" => Ok(vec![Response::Error(Box::new(ErrorInfo::new(
+                    "ERROR".to_owned(),
+                    "XX000".to_owned(),
+                    "boom".to_owned(),
+                )))]),
+                _ => Ok(vec![Response::Execution(Tag::new("OK"))]),
+            }
+        }
+    }
+
+    async fn spawn_test_server<H>(handlers: Arc<H>) -> u16
+    where
+        H: PgWireServerHandlers + Send + Sync,
+    {
         let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
         let port = listener.local_addr().unwrap().port();
         tokio::spawn(async move {
             loop {
                 let (socket, _) = listener.accept().await.unwrap();
-                let handlers = Arc::new(TestHandlers);
+                let handlers = handlers.clone();
                 tokio::spawn(async move {
                     let _ = process_socket(socket, None, handlers).await;
                 });
@@ -535,7 +594,7 @@ mod tests {
 
     #[tokio::test]
     async fn client_negotiates_3_9999_down_to_3_2() {
-        let port = spawn_test_server().await;
+        let port = spawn_test_server(Arc::new(TestHandlers)).await;
 
         let mut config = Config::new();
         config.host("127.0.0.1");
@@ -556,7 +615,7 @@ mod tests {
 
     #[tokio::test]
     async fn client_default_3_0_keeps_i32_secret_key() {
-        let port = spawn_test_server().await;
+        let port = spawn_test_server(Arc::new(TestHandlers)).await;
 
         let mut config = Config::new();
         config.host("127.0.0.1");
@@ -570,5 +629,51 @@ mod tests {
         assert_eq!(client.protocol_version(), ProtocolVersion::PROTOCOL3_0);
         // A protocol 3.0 cancel key is decoded as a 4-byte i32, not as bytes.
         assert!(matches!(client.secret_key(), SecretKey::I32(_)));
+    }
+
+    #[tokio::test]
+    async fn client_tracks_transaction_status() {
+        let port = spawn_test_server(Arc::new(TxHandlers)).await;
+
+        let mut config = Config::new();
+        config.host("127.0.0.1");
+        config.port(port);
+        config.user("pgwire");
+
+        let mut client = PgWireClient::connect(Arc::new(config), DefaultStartupHandler::new(), None)
+            .await
+            .unwrap();
+
+        // a fresh connection is idle
+        assert_eq!(client.transaction_status(), TransactionStatus::Idle);
+
+        client
+            .simple_query(DefaultSimpleQueryHandler::new(), "BEGIN")
+            .await
+            .unwrap();
+        assert_eq!(client.transaction_status(), TransactionStatus::Transaction);
+
+        // statements inside the transaction keep the status
+        client
+            .simple_query(DefaultSimpleQueryHandler::new(), "SELECT 1")
+            .await
+            .unwrap();
+        assert_eq!(client.transaction_status(), TransactionStatus::Transaction);
+
+        // a failed statement puts the connection into the failed-transaction
+        // state; the error is returned but the connection stays usable
+        assert!(
+            client
+                .simple_query(DefaultSimpleQueryHandler::new(), "FAIL")
+                .await
+                .is_err()
+        );
+        assert_eq!(client.transaction_status(), TransactionStatus::Error);
+
+        client
+            .simple_query(DefaultSimpleQueryHandler::new(), "ROLLBACK")
+            .await
+            .unwrap();
+        assert_eq!(client.transaction_status(), TransactionStatus::Idle);
     }
 }

--- a/src/tokio/client.rs
+++ b/src/tokio/client.rs
@@ -640,9 +640,10 @@ mod tests {
         config.port(port);
         config.user("pgwire");
 
-        let mut client = PgWireClient::connect(Arc::new(config), DefaultStartupHandler::new(), None)
-            .await
-            .unwrap();
+        let mut client =
+            PgWireClient::connect(Arc::new(config), DefaultStartupHandler::new(), None)
+                .await
+                .unwrap();
 
         // a fresh connection is idle
         assert_eq!(client.transaction_status(), TransactionStatus::Idle);

--- a/tests-integration/client-api/tests/transaction.rs
+++ b/tests-integration/client-api/tests/transaction.rs
@@ -1,0 +1,104 @@
+//! Transaction status tracking integration tests against a real PostgreSQL:
+//! the status carried by `ReadyForQuery` must be reflected in
+//! `PgWireClient::transaction_status()` across simple query, extended query
+//! and error paths.
+
+mod common;
+
+use common::connect;
+use pgwire::api::client::ClientInfo;
+use pgwire::api::client::query::{DefaultExtendedQueryHandler, DefaultSimpleQueryHandler};
+use pgwire::messages::response::TransactionStatus;
+
+#[tokio::test]
+async fn simple_query_tracks_transaction_status() {
+    let mut client = connect().await;
+
+    // a fresh connection is idle
+    assert_eq!(client.transaction_status(), TransactionStatus::Idle);
+
+    client
+        .simple_query(DefaultSimpleQueryHandler::new(), "BEGIN")
+        .await
+        .expect("BEGIN failed");
+    assert_eq!(client.transaction_status(), TransactionStatus::Transaction);
+
+    // statements inside the transaction keep the status
+    client
+        .simple_query(DefaultSimpleQueryHandler::new(), "SELECT 1")
+        .await
+        .expect("SELECT in transaction failed");
+    assert_eq!(client.transaction_status(), TransactionStatus::Transaction);
+
+    client
+        .simple_query(DefaultSimpleQueryHandler::new(), "COMMIT")
+        .await
+        .expect("COMMIT failed");
+    assert_eq!(client.transaction_status(), TransactionStatus::Idle);
+}
+
+#[tokio::test]
+async fn failed_statement_inside_transaction_reports_error_status() {
+    let mut client = connect().await;
+
+    client
+        .simple_query(DefaultSimpleQueryHandler::new(), "BEGIN")
+        .await
+        .expect("BEGIN failed");
+
+    // 1/0 fails inside the transaction; the query returns an error but the
+    // connection survives in the failed-transaction state
+    assert!(
+        client
+            .simple_query(DefaultSimpleQueryHandler::new(), "SELECT 1/0")
+            .await
+            .is_err()
+    );
+    assert_eq!(client.transaction_status(), TransactionStatus::Error);
+
+    // further statements are rejected while in the failed block, and the
+    // status stays Error
+    assert!(
+        client
+            .simple_query(DefaultSimpleQueryHandler::new(), "SELECT 1")
+            .await
+            .is_err()
+    );
+    assert_eq!(client.transaction_status(), TransactionStatus::Error);
+
+    client
+        .simple_query(DefaultSimpleQueryHandler::new(), "ROLLBACK")
+        .await
+        .expect("ROLLBACK failed");
+    assert_eq!(client.transaction_status(), TransactionStatus::Idle);
+}
+
+#[tokio::test]
+async fn extended_query_tracks_transaction_status() {
+    let mut client = connect().await;
+    let mut handler = DefaultExtendedQueryHandler::new();
+
+    {
+        let mut eqc = client.extended_query(&mut handler);
+        eqc.query("BEGIN", &[], vec![])
+            .await
+            .expect("extended BEGIN failed");
+    }
+    assert_eq!(client.transaction_status(), TransactionStatus::Transaction);
+
+    // a failing extended query inside the transaction also lands in the
+    // failed-transaction state
+    {
+        let mut eqc = client.extended_query(&mut handler);
+        assert!(eqc.query("SELECT 1/0", &[], vec![]).await.is_err());
+    }
+    assert_eq!(client.transaction_status(), TransactionStatus::Error);
+
+    {
+        let mut eqc = client.extended_query(&mut handler);
+        eqc.query("ROLLBACK", &[], vec![])
+            .await
+            .expect("extended ROLLBACK failed");
+    }
+    assert_eq!(client.transaction_status(), TransactionStatus::Idle);
+}


### PR DESCRIPTION
ClientInfo::transaction_status reports the status carried by the last ReadyForQuery message, mirroring the server-side ClientInfo.